### PR TITLE
oauth2: resource owner password credentials proposal #214

### DIFF
--- a/cmd/cli/handler_warden.go
+++ b/cmd/cli/handler_warden.go
@@ -26,7 +26,7 @@ func newWardenHandler(c *config.Config) *WardenHandler {
 func (h *WardenHandler) IsAuthorized(cmd *cobra.Command, args []string) {
 	h.M.Dry, _ = cmd.Flags().GetBool("dry")
 	h.M.Client = h.Config.OAuth2Client(cmd)
-	h.M.Endpoint = h.Config.Resolve("/connections")
+	h.M.Endpoint = h.Config.Resolve(oauth2.IntrospectPath)
 
 	if len(args) != 1 {
 		fmt.Print(cmd.UsageString())

--- a/oauth2/oauht2_resource_owner_password_credentials_flow.go
+++ b/oauth2/oauht2_resource_owner_password_credentials_flow.go
@@ -1,0 +1,1 @@
+package oauth2


### PR DESCRIPTION
## Proposal

The idea is to make the OAuth 2.0 resource owner password credentials proposal a part of Hydra. This is currently not possible because Hydra does not have access to the user database. There are two obvious solutions available:
### :a: HTTP API

We could specify an HTTP API that Hydra calls in order to authenticate users. The identity provider would have to implement that API. A request could look like:

```
POST /oauth2_login
username=foo&password=bar

{
  "valid": true
}
```
### :b: Consent flow

Instead of making an HTTP request, we could redirect the user agent to the consent endpoint and pass a consent challenge that contains the username/password. The consent endpoint would validate the user data and generate the consent response automatically and redirect the user agent back to hydra, which in turn issues the access token.
## Todo
- [ ] remove unsupported note from documentations
- [ ] add documentation how this flow works

Vote 👍 if you like :a: and ❤️ if you like :b:.
