### PR TITLE
[DOC] Update "Build from source" section to actual state

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -63,15 +63,15 @@ Available Commands:
 
 ### Build from source
 
-If you wish to compile Hydra yourself, you need to install and set up [Go 1.5+](https://golang.org/) and add `$GOPATH/bin`
+If you wish to compile ORY Hydra yourself, you need to install and set up [Go 1.8+](https://golang.org/) and add `$GOPATH/bin`
 to your `$PATH`. To do so, run the following commands in a shell (bash, sh, cmd.exe, ...):
 
 ```
-$ go get github.com/ory-am/hydra
+$ go get -d -u github.com/ory/hydra
 $ go get github.com/Masterminds/glide
-$ cd $GOPATH/src/github.com/ory-am/hydra
+$ cd $GOPATH/src/github.com/ory/hydra
 $ glide install
-$ go install github.com/ory-am/hydra
+$ go install github.com/ory/hydra
 $ hydra
 Hydra is a cloud native high throughput OAuth2 and OpenID Connect provider
 


### PR DESCRIPTION
"Build from source" section in https://ory.gitbooks.io/hydra/content/install.html#installing-hydra is different than https://github.com/ory/hydra/blob/master/README.md