### PR TITLE
health: disable TLS restriction for health check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -128,6 +128,10 @@ func (c *Config) DoesRequestSatisfyTermination(r *http.Request) error {
 		return errors.New("TLS termination is not enabled")
 	}
 
+	if r.URL.Path == "/health" {
+		return nil
+	}
+
 	ranges := strings.Split(c.AllowTLSTermination, ",")
 	if err := matchesRange(r, ranges); err != nil {
 		return err

--- a/health/doc.go
+++ b/health/doc.go
@@ -1,8 +1,11 @@
 package health
 
 // A list of clients.
-// swagger:response clientsList
+// swagger:response healthStatus
 type swaggerListClientsResult struct {
 	// in: body
-	Body struct{}
+	Body struct{
+		// Status always contains "ok"
+		Status string `json:"status"`
+	}
 }

--- a/health/handler.go
+++ b/health/handler.go
@@ -24,16 +24,20 @@ func (h *Handler) SetRoutes(r *httprouter.Router) {
 //
 // Check health status of instance
 //
+// This endpoint does not require the `X-Forwarded-Proto` header when TLS termination is set.
+//
 //     Responses:
-//       204: emptyResponse
+//       200: healthStatus
 //       500: genericError
 func (h *Handler) Health(rw http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	rw.Write([]byte("ok"))
+	rw.Write([]byte(`{"status": "ok"}`))
 }
 
 // swagger:route GET /health/stats health getStatistics
 //
 // Show instance statistics
+//
+// This endpoint returns information on the instance's health. It is currently not documented.
 //
 // The subject making the request needs to be assigned to a policy containing:
 //
@@ -57,7 +61,7 @@ func (h *Handler) Health(rw http.ResponseWriter, r *http.Request, _ httprouter.P
 //       oauth2: hydra.health
 //
 //     Responses:
-//       200: clientsList
+//       200: emptyResponse
 //       401: genericError
 //       403: genericError
 //       500: genericError


### PR DESCRIPTION
Removes TLS restriction on health endpoint when termination is set - closes #586
