### PR TITLE
travis: move deploy scripts to its own file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ script:
   - goveralls -service=travis-ci -coverprofile=coverage.txt
 
 before_deploy:
-  - gox -ldflags "-X github.com/ory/hydra/cmd.Version=`git describe --tags` -X github.com/ory/hydra/cmd.BuildTime=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/hydra/cmd.GitHash=`git rev-parse HEAD`" -output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}"
-  - npm version -f --no-git-tag-version $(git describe --tag)
+  - ./scripts/run-deploy.sh
 
 deploy:
   - provider: npm

--- a/scripts/run-deploy.sh
+++ b/scripts/run-deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $(cat package.json | grep $(git describe --tag)) ]]; then
+  echo "Seems like deploy script ran already."
+  exit 0;
+else
+  echo "Running deploy script..."
+fi
+
+gox -ldflags "-X github.com/ory/hydra/cmd.Version=`git describe --tags` -X github.com/ory/hydra/cmd.BuildTime=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/hydra/cmd.GitHash=`git rev-parse HEAD`" -output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}"
+npm version -f --no-git-tag-version $(git describe --tag)


### PR DESCRIPTION
This is required because before_deploy is ran twice if multiple providers exist, see https://github.com/travis-ci/travis-ci/issues/2570