### PR TITLE
fix go-jose imports

### DIFF
--- a/cmd/server/helper_cert.go
+++ b/cmd/server/helper_cert.go
@@ -84,8 +84,8 @@ func getOrCreateTLSCertificate(cmd *cobra.Command, c *config.Config) tls.Certifi
 
 		private := jwk.First(keys.Key("private"))
 		private.Certificates = []*x509.Certificate{cert}
-		keys = &jose.JsonWebKeySet{
-			Keys: []jose.JsonWebKey{
+		keys = &jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{
 				*private,
 				*jwk.First(keys.Key("public")),
 			},

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 116f662b157744514f2af5dfa680474afcd6df0e7255904a48a3f56df6766483
-updated: 2017-09-15T12:04:13.6327978+02:00
+hash: aad3297c5199dfa86e0a27733ac9dfd1acfa14d009391af687ba303749850702
+updated: 2017-10-09T14:11:26.683738-06:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 4918b99a7cb949bb295f3c7bbaf24b577d806e35
@@ -85,7 +85,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jehiah/go-strftime
-  version: 2efbe75097a505e2789f7e39cb9da067b5be8e3e
+  version: 834e15c05a45371503440cc195bbd05c9a0968d9
 - name: github.com/jmoiron/sqlx
   version: d9bd385d68c068f1fabb5057e3dedcbcbb039d0f
   subpackages:
@@ -158,12 +158,12 @@ imports:
   version: bdb0aeca8a993b292b85c9ec17b5ce0ff81848c8
 - name: github.com/segmentio/backo-go
   version: 204274ad699c0983a70203a566887f17a717fef4
+- name: github.com/sirupsen/logrus
+  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/Sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
   repo: https://github.com/sirupsen/logrus.git
   vcs: git
-- name: github.com/sirupsen/logrus
-  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
   version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -51,10 +51,6 @@ import:
 - package: github.com/rubenv/sql-migrate
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
-- package: github.com/square/go-jose
-  version: ~1.1.0
-  subpackages:
-  - json
 - package: github.com/stretchr/testify
   version: 1.1.4
   subpackages:

--- a/jwk/cast.go
+++ b/jwk/cast.go
@@ -7,7 +7,7 @@ import (
 	"github.com/square/go-jose"
 )
 
-func MustRSAPublic(key *jose.JsonWebKey) *rsa.PublicKey {
+func MustRSAPublic(key *jose.JSONWebKey) *rsa.PublicKey {
 	res, err := ToRSAPublic(key)
 	if err != nil {
 		panic(err.Error())
@@ -16,7 +16,7 @@ func MustRSAPublic(key *jose.JsonWebKey) *rsa.PublicKey {
 
 }
 
-func ToRSAPublic(key *jose.JsonWebKey) (*rsa.PublicKey, error) {
+func ToRSAPublic(key *jose.JSONWebKey) (*rsa.PublicKey, error) {
 	res, ok := key.Key.(*rsa.PublicKey)
 	if !ok {
 		return res, errors.New("Could not convert key to RSA Private Key.")
@@ -24,7 +24,7 @@ func ToRSAPublic(key *jose.JsonWebKey) (*rsa.PublicKey, error) {
 	return res, nil
 }
 
-func MustRSAPrivate(key *jose.JsonWebKey) *rsa.PrivateKey {
+func MustRSAPrivate(key *jose.JSONWebKey) *rsa.PrivateKey {
 	res, err := ToRSAPrivate(key)
 	if err != nil {
 		panic(err.Error())
@@ -32,7 +32,7 @@ func MustRSAPrivate(key *jose.JsonWebKey) *rsa.PrivateKey {
 	return res
 }
 
-func ToRSAPrivate(key *jose.JsonWebKey) (*rsa.PrivateKey, error) {
+func ToRSAPrivate(key *jose.JSONWebKey) (*rsa.PrivateKey, error) {
 	res, ok := key.Key.(*rsa.PrivateKey)
 	if !ok {
 		return res, errors.New("Could not convert key to RSA Private Key.")

--- a/jwk/generator.go
+++ b/jwk/generator.go
@@ -3,5 +3,5 @@ package jwk
 import "github.com/square/go-jose"
 
 type KeyGenerator interface {
-	Generate(id string) (*jose.JsonWebKeySet, error)
+	Generate(id string) (*jose.JSONWebKeySet, error)
 }

--- a/jwk/generator_ecdsa256.go
+++ b/jwk/generator_ecdsa256.go
@@ -12,14 +12,14 @@ import (
 
 type ECDSA256Generator struct{}
 
-func (g *ECDSA256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *ECDSA256Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, errors.Errorf("Could not generate key because %s", err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          key,
 				KeyID:        ider("private", id),

--- a/jwk/generator_ecdsa521.go
+++ b/jwk/generator_ecdsa521.go
@@ -12,14 +12,14 @@ import (
 
 type ECDSA521Generator struct{}
 
-func (g *ECDSA521Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *ECDSA521Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
 		return nil, errors.Errorf("Could not generate key because %s", err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          key,
 				KeyID:        ider("private", id),

--- a/jwk/generator_hs256.go
+++ b/jwk/generator_hs256.go
@@ -12,7 +12,7 @@ type HS256Generator struct {
 	Length int
 }
 
-func (g *HS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *HS256Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	if g.Length < 12 {
 		g.Length = 12
 	}
@@ -26,8 +26,8 @@ func (g *HS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.Errorf("Could not generate key because %s", err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          []byte(string(key)),
 				KeyID:        id,

--- a/jwk/generator_rs256.go
+++ b/jwk/generator_rs256.go
@@ -14,7 +14,7 @@ type RS256Generator struct {
 	KeyLength int
 }
 
-func (g *RS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *RS256Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	if g.KeyLength < 4096 {
 		g.KeyLength = 4096
 	}
@@ -28,8 +28,8 @@ func (g *RS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
 
 	// jose does not support this...
 	key.Precomputed = rsa.PrecomputedValues{}
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          key,
 				KeyID:        ider("private", id),

--- a/jwk/generator_test.go
+++ b/jwk/generator_test.go
@@ -11,23 +11,23 @@ import (
 func TestGenerator(t *testing.T) {
 	for _, c := range []struct {
 		g     KeyGenerator
-		check func(*jose.JsonWebKeySet)
+		check func(*jose.JSONWebKeySet)
 	}{
 		{
 			g: &RS256Generator{},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 2)
 			},
 		},
 		{
 			g: &ECDSA521Generator{},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 2)
 			},
 		},
 		{
 			g: &ECDSA256Generator{},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 2)
 			},
 		},
@@ -35,7 +35,7 @@ func TestGenerator(t *testing.T) {
 			g: &HS256Generator{
 				Length: 32,
 			},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 1)
 			},
 		},

--- a/jwk/handler.go
+++ b/jwk/handler.go
@@ -341,7 +341,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, ps httprouter.P
 func (h *Handler) UpdateKeySet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var ctx = context.Background()
 	var requests joseWebKeySetRequest
-	var keySet = new(jose.JsonWebKeySet)
+	var keySet = new(jose.JSONWebKeySet)
 	var set = ps.ByName("set")
 
 	if _, err := h.W.TokenAllowed(ctx, h.W.TokenFromRequest(r), &firewall.TokenAccessRequest{
@@ -358,7 +358,7 @@ func (h *Handler) UpdateKeySet(w http.ResponseWriter, r *http.Request, ps httpro
 	}
 
 	for _, request := range requests.Keys {
-		key := &jose.JsonWebKey{}
+		key := &jose.JSONWebKey{}
 		if err := key.UnmarshalJSON(request); err != nil {
 			h.H.WriteError(w, r, errors.WithStack(err))
 		}
@@ -407,7 +407,7 @@ func (h *Handler) UpdateKeySet(w http.ResponseWriter, r *http.Request, ps httpro
 //       500: genericError
 func (h *Handler) UpdateKey(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var ctx = context.Background()
-	var key jose.JsonWebKey
+	var key jose.JSONWebKey
 	var set = ps.ByName("set")
 
 	if err := json.NewDecoder(r.Body).Decode(&key); err != nil {

--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var testServer *httptest.Server
-var IDKS *jose.JsonWebKeySet
+var IDKS *jose.JSONWebKeySet
 
 func init() {
 	localWarden, _ := compose.NewMockFirewall(
@@ -57,7 +57,7 @@ func TestHandlerWellKnown(t *testing.T) {
 	require.NoError(t, err, "problem in http request")
 	defer res.Body.Close()
 
-	var known jose.JsonWebKeySet
+	var known jose.JSONWebKeySet
 	err = json.NewDecoder(res.Body).Decode(&known)
 	require.NoError(t, err, "problem in decoding response")
 

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/square/go-jose"
 )
 
-func First(keys []jose.JsonWebKey) *jose.JsonWebKey {
+func First(keys []jose.JSONWebKey) *jose.JSONWebKey {
 	if len(keys) == 0 {
 		return nil
 	}

--- a/jwk/manager.go
+++ b/jwk/manager.go
@@ -3,13 +3,13 @@ package jwk
 import "github.com/square/go-jose"
 
 type Manager interface {
-	AddKey(set string, key *jose.JsonWebKey) error
+	AddKey(set string, key *jose.JSONWebKey) error
 
-	AddKeySet(set string, keys *jose.JsonWebKeySet) error
+	AddKeySet(set string, keys *jose.JSONWebKeySet) error
 
-	GetKey(set, kid string) (*jose.JsonWebKeySet, error)
+	GetKey(set, kid string) (*jose.JSONWebKeySet, error)
 
-	GetKeySet(set string) (*jose.JsonWebKeySet, error)
+	GetKeySet(set string) (*jose.JSONWebKeySet, error)
 
 	DeleteKey(set, kid string) error
 

--- a/jwk/manager_http.go
+++ b/jwk/manager_http.go
@@ -15,10 +15,10 @@ type HTTPManager struct {
 	FakeTLSTermination bool
 }
 
-func (m *HTTPManager) CreateKeys(set, algorithm string) (*jose.JsonWebKeySet, error) {
+func (m *HTTPManager) CreateKeys(set, algorithm string) (*jose.JSONWebKeySet, error) {
 	var c = struct {
 		Algorithm string            `json:"alg"`
-		Keys      []jose.JsonWebKey `json:"keys"`
+		Keys      []jose.JSONWebKey `json:"keys"`
 	}{
 		Algorithm: algorithm,
 	}
@@ -31,12 +31,12 @@ func (m *HTTPManager) CreateKeys(set, algorithm string) (*jose.JsonWebKeySet, er
 		return nil, err
 	}
 
-	return &jose.JsonWebKeySet{
+	return &jose.JSONWebKeySet{
 		Keys: c.Keys,
 	}, nil
 }
 
-func (m *HTTPManager) AddKey(set string, key *jose.JsonWebKey) error {
+func (m *HTTPManager) AddKey(set string, key *jose.JSONWebKey) error {
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set, key.KeyID).String())
 	r.Client = m.Client
 	r.Dry = m.Dry
@@ -44,7 +44,7 @@ func (m *HTTPManager) AddKey(set string, key *jose.JsonWebKey) error {
 	return r.Update(key)
 }
 
-func (m *HTTPManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
+func (m *HTTPManager) AddKeySet(set string, keys *jose.JSONWebKeySet) error {
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set).String())
 	r.Client = m.Client
 	r.Dry = m.Dry
@@ -52,8 +52,8 @@ func (m *HTTPManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
 	return r.Update(keys)
 }
 
-func (m *HTTPManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
-	var c jose.JsonWebKeySet
+func (m *HTTPManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
+	var c jose.JSONWebKeySet
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set, kid).String())
 	r.Client = m.Client
 	r.Dry = m.Dry
@@ -65,8 +65,8 @@ func (m *HTTPManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
 	return &c, nil
 }
 
-func (m *HTTPManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
-	var c jose.JsonWebKeySet
+func (m *HTTPManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
+	var c jose.JSONWebKeySet
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set).String())
 	r.Client = m.Client
 	r.Dry = m.Dry

--- a/jwk/manager_memory.go
+++ b/jwk/manager_memory.go
@@ -9,30 +9,30 @@ import (
 )
 
 type MemoryManager struct {
-	Keys map[string]*jose.JsonWebKeySet
+	Keys map[string]*jose.JSONWebKeySet
 	sync.RWMutex
 }
 
-func (m *MemoryManager) AddKey(set string, key *jose.JsonWebKey) error {
+func (m *MemoryManager) AddKey(set string, key *jose.JSONWebKey) error {
 	m.Lock()
 	defer m.Unlock()
 
 	m.alloc()
 	if m.Keys[set] == nil {
-		m.Keys[set] = &jose.JsonWebKeySet{Keys: []jose.JsonWebKey{}}
+		m.Keys[set] = &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{}}
 	}
 	m.Keys[set].Keys = append(m.Keys[set].Keys, *key)
 	return nil
 }
 
-func (m *MemoryManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
+func (m *MemoryManager) AddKeySet(set string, keys *jose.JSONWebKeySet) error {
 	for _, key := range keys.Keys {
 		m.AddKey(set, &key)
 	}
 	return nil
 }
 
-func (m *MemoryManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
+func (m *MemoryManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -47,12 +47,12 @@ func (m *MemoryManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
 	}
 
-	return &jose.JsonWebKeySet{
+	return &jose.JSONWebKeySet{
 		Keys: result,
 	}, nil
 }
 
-func (m *MemoryManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
+func (m *MemoryManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -72,7 +72,7 @@ func (m *MemoryManager) DeleteKey(set, kid string) error {
 	}
 
 	m.Lock()
-	var results []jose.JsonWebKey
+	var results []jose.JSONWebKey
 	for _, key := range keys.Keys {
 		if key.KeyID != kid {
 			results = append(results)
@@ -94,6 +94,6 @@ func (m *MemoryManager) DeleteKeySet(set string) error {
 
 func (m *MemoryManager) alloc() {
 	if m.Keys == nil {
-		m.Keys = make(map[string]*jose.JsonWebKeySet)
+		m.Keys = make(map[string]*jose.JSONWebKeySet)
 	}
 }

--- a/jwk/manager_sql.go
+++ b/jwk/manager_sql.go
@@ -52,7 +52,7 @@ func (s *SQLManager) CreateSchemas() (int, error) {
 	return n, nil
 }
 
-func (m *SQLManager) AddKey(set string, key *jose.JsonWebKey) error {
+func (m *SQLManager) AddKey(set string, key *jose.JSONWebKey) error {
 	out, err := json.Marshal(key)
 	if err != nil {
 		return errors.WithStack(err)
@@ -74,7 +74,7 @@ func (m *SQLManager) AddKey(set string, key *jose.JsonWebKey) error {
 	return nil
 }
 
-func (m *SQLManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
+func (m *SQLManager) AddKeySet(set string, keys *jose.JSONWebKeySet) error {
 	tx, err := m.DB.Beginx()
 	if err != nil {
 		return errors.WithStack(err)
@@ -119,7 +119,7 @@ func (m *SQLManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
 	return nil
 }
 
-func (m *SQLManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
+func (m *SQLManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
 	var d sqlData
 	if err := m.DB.Get(&d, m.DB.Rebind("SELECT * FROM hydra_jwk WHERE sid=? AND kid=?"), set, kid); err == sql.ErrNoRows {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
@@ -132,17 +132,17 @@ func (m *SQLManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	var c jose.JsonWebKey
+	var c jose.JSONWebKey
 	if err := json.Unmarshal(key, &c); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{c},
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{c},
 	}, nil
 }
 
-func (m *SQLManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
+func (m *SQLManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
 	var ds []sqlData
 	if err := m.DB.Select(&ds, m.DB.Rebind("SELECT * FROM hydra_jwk WHERE sid=?"), set); err == sql.ErrNoRows {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
@@ -154,14 +154,14 @@ func (m *SQLManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
 	}
 
-	keys := &jose.JsonWebKeySet{Keys: []jose.JsonWebKey{}}
+	keys := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{}}
 	for _, d := range ds {
 		key, err := m.Cipher.Decrypt(d.Key)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 
-		var c jose.JsonWebKey
+		var c jose.JSONWebKey
 		if err := json.Unmarshal(key, &c); err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/jwk/manager_test_helpers.go
+++ b/jwk/manager_test_helpers.go
@@ -19,7 +19,7 @@ func RandomBytes(n int) ([]byte, error) {
 	return bytes, nil
 }
 
-func TestHelperManagerKey(m Manager, keys *jose.JsonWebKeySet) func(t *testing.T) {
+func TestHelperManagerKey(m Manager, keys *jose.JSONWebKeySet) func(t *testing.T) {
 	pub := keys.Key("public")
 	priv := keys.Key("private")
 
@@ -53,7 +53,7 @@ func TestHelperManagerKey(m Manager, keys *jose.JsonWebKeySet) func(t *testing.T
 	}
 }
 
-func TestHelperManagerKeySet(m Manager, keys *jose.JsonWebKeySet) func(t *testing.T) {
+func TestHelperManagerKeySet(m Manager, keys *jose.JSONWebKeySet) func(t *testing.T) {
 	return func(t *testing.T) {
 		_, err := m.GetKeySet("foo")
 		pkg.AssertError(t, true, err)

--- a/sdk/consent_test.go
+++ b/sdk/consent_test.go
@@ -16,14 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func genKey() *jose.JsonWebKeySet {
+func genKey() *jose.JSONWebKeySet {
 	g := &jwk.RS256Generator{}
 	k, _ := g.Generate("")
 	return k
 }
 
 func TestConsentHelper(t *testing.T) {
-	km := &jwk.MemoryManager{Keys: map[string]*jose.JsonWebKeySet{}}
+	km := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 	km.AddKeySet(oauth2.ConsentChallengeKey, genKey())
 	km.AddKeySet(oauth2.ConsentEndpointKey, genKey())
 


### PR DESCRIPTION
This is a patch against v0.9.13, but there was no branch based on that at present, so I apologize for requesting this against master.

When using the hydra sdk in other go packages, there is a problem with the go-jose import that makes it impossible, unless the other package uses glide, to resolve the vendor issues such that hydra still builds and tests successfully while the package that imports it builds and tests successfully. This is because it uses the `github.com/square/go-jose` import while expecting the v1 version of go-jose which is supposed to be imported with `gopkg.in/square/go-jose.v1`.

This patch fixes the imports so that go-jose v2 (which uses the `github.com/square/go-jose` import`) can be used instead and drops the v1 requirement from glide.