### PR TITLE
Support dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
   - go install github.com/ory/hydra
   - glide update
   - go install github.com/ory/hydra
+  - dep ensure
+  - go install github.com/ory/hydra
 
 script:
   - touch ./coverage.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - sudo apt-get install curl
 
 install:
-  - go get github.com/mattn/goveralls golang.org/x/tools/cmd/cover github.com/Masterminds/glide github.com/mitchellh/gox
+  - go get github.com/mattn/goveralls golang.org/x/tools/cmd/cover github.com/Masterminds/glide github.com/mitchellh/gox github.com/golang/dep/cmd/dep
   - git clone https://github.com/docker-library/official-images.git ~/official-images
   - glide install
   - go install github.com/ory/hydra

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,71 @@
+[[constraint]]
+  name = "github.com/dgrijalva/jwt-go"
+  version = "3.0.0"
+
+[[constraint]]
+  name = "github.com/go-sql-driver/mysql"
+  version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/gorilla/context"
+  version = "1.1.0"
+
+[[constraint]]
+  name = "github.com/gorilla/sessions"
+  version = "1.1.0"
+
+[[constraint]]
+  name = "github.com/imdario/mergo"
+  version = "0.2.2"
+
+[[constraint]]
+  name = "github.com/julienschmidt/httprouter"
+  version = "1.1.0"
+
+[[constraint]]
+  name = "github.com/oleiade/reflections"
+  version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/ory/fosite"
+  version = "0.10.0"
+
+[[constraint]]
+  name = "github.com/ory/graceful"
+  version = "0.1.0"
+
+[[constraint]]
+  name = "github.com/ory/herodot"
+  version = "0.1.1"
+
+[[constraint]]
+  name = "github.com/ory/ladon"
+  version = "0.8.2"
+
+[[constraint]]
+  name = "github.com/pborman/uuid"
+  version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "0.8.0"
+
+[[constraint]]
+  name = "github.com/pkg/profile"
+  version = "1.2.1"
+
+[[constraint]]
+  name = "github.com/square/go-jose"
+  version = "2.1.3"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.1.4"
+
+[[constraint]]
+  name = "github.com/toqueteos/webbrowser"
+  version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/urfave/negroni"
+  version = "0.2.0"

--- a/cmd/server/helper_cert.go
+++ b/cmd/server/helper_cert.go
@@ -84,8 +84,8 @@ func getOrCreateTLSCertificate(cmd *cobra.Command, c *config.Config) tls.Certifi
 
 		private := jwk.First(keys.Key("private"))
 		private.Certificates = []*x509.Certificate{cert}
-		keys = &jose.JsonWebKeySet{
-			Keys: []jose.JsonWebKey{
+		keys = &jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{
 				*private,
 				*jwk.First(keys.Key("public")),
 			},

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 116f662b157744514f2af5dfa680474afcd6df0e7255904a48a3f56df6766483
-updated: 2017-09-15T12:04:13.6327978+02:00
+hash: aad3297c5199dfa86e0a27733ac9dfd1acfa14d009391af687ba303749850702
+updated: 2017-10-09T14:11:26.683738-06:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 4918b99a7cb949bb295f3c7bbaf24b577d806e35
@@ -85,7 +85,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jehiah/go-strftime
-  version: 2efbe75097a505e2789f7e39cb9da067b5be8e3e
+  version: 834e15c05a45371503440cc195bbd05c9a0968d9
 - name: github.com/jmoiron/sqlx
   version: d9bd385d68c068f1fabb5057e3dedcbcbb039d0f
   subpackages:
@@ -158,12 +158,12 @@ imports:
   version: bdb0aeca8a993b292b85c9ec17b5ce0ff81848c8
 - name: github.com/segmentio/backo-go
   version: 204274ad699c0983a70203a566887f17a717fef4
+- name: github.com/sirupsen/logrus
+  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/Sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
   repo: https://github.com/sirupsen/logrus.git
   vcs: git
-- name: github.com/sirupsen/logrus
-  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
   version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: aad3297c5199dfa86e0a27733ac9dfd1acfa14d009391af687ba303749850702
-updated: 2017-10-09T14:11:26.683738-06:00
+hash: 4f5430a29f1bb6f18cc5a1d401f62b5f4f6ebda2eb461f04b4084be1f975109d
+updated: 2017-10-10T21:36:28.006157-06:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 4918b99a7cb949bb295f3c7bbaf24b577d806e35
 - name: github.com/Azure/go-ansiterm
-  version: 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
+  version: d6e3b3328b783f23731bc4d058875b0371ff8109
   subpackages:
   - winterm
 - name: github.com/cenk/backoff
@@ -52,11 +52,11 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/fsouza/go-dockerclient
-  version: 98edf3edfae6a6500fecc69d2bcccf1302544004
+  version: d2a6d0596004cc01062a2a068540b817f911e6dc
 - name: github.com/go-sql-driver/mysql
   version: a0583e0143b1624142adab07e0e97fe106d99561
 - name: github.com/golang/protobuf
-  version: 11b8df160996e00fd4b55cbaafb3d84ec6d50fa8
+  version: 130e6b02ab059e7b717a096f397c5b60111cae74
   subpackages:
   - proto
 - name: github.com/gorilla/context
@@ -70,7 +70,7 @@ imports:
   subpackages:
   - simplelru
 - name: github.com/hashicorp/hcl
-  version: 68e816d1c783414e79bc65b3994d9ab6b0a722ab
+  version: 42e33e2d55a0ff1d6263f738896ea8c13571a8d0
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -93,7 +93,7 @@ imports:
 - name: github.com/julienschmidt/httprouter
   version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
 - name: github.com/lib/pq
-  version: e42267488fe361b9dc034be7a6bffef5b195bceb
+  version: 30d59eaf01528a141f560f34f0208e0ec5218e75
   subpackages:
   - oid
 - name: github.com/magiconair/properties
@@ -105,20 +105,20 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/mohae/deepcopy
-  version: 491d3605edfb866af34a48075bd4355ac1bf46ca
+  version: c48cc78d482608239f6c4c92a4abd87eb8761c90
 - name: github.com/moul/http2curl
-  version: 4e24498b31dba4683efb9d35c1c8a91e2eda28c8
+  version: 9ac6cf4d929b2fa8fd2d2e6dec5bb0feb4f4911d
 - name: github.com/Nvveen/Gotty
   version: cd527374f1e5bff4938207604a14f2e38a9cf512
 - name: github.com/oleiade/reflections
   version: 2b6ec3da648e3e834dc41bad8d9ed7f2dc6a9496
 - name: github.com/opencontainers/runc
-  version: 593914b8bd5448a93f7c3e4902a03408b6d5c0ce
+  version: beb8716fcb400d5f555c5d96a0534572d40f0248
   subpackages:
   - libcontainer/system
   - libcontainer/user
 - name: github.com/ory/dockertest
-  version: 4e3eadceb309bdef330865c89b5a06635c09c2f6
+  version: b6cb198a39dfd21edd511aad53bab6e1a247b437
 - name: github.com/ory/fosite
   version: ef8f1757f0c26317fd7dbb46f66fde7516a3b4bb
   subpackages:
@@ -141,7 +141,7 @@ imports:
 - name: github.com/pborman/uuid
   version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/pelletier/go-toml
-  version: 1d6b12b7cb290426e27e6b4e38b89fcda3aeef03
+  version: 2009e44b6f182e34d8ce081ac2767622937ea3d4
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pkg/profile
@@ -158,28 +158,28 @@ imports:
   version: bdb0aeca8a993b292b85c9ec17b5ce0ff81848c8
 - name: github.com/segmentio/backo-go
   version: 204274ad699c0983a70203a566887f17a717fef4
-- name: github.com/sirupsen/logrus
-  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/Sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
   repo: https://github.com/sirupsen/logrus.git
   vcs: git
+- name: github.com/sirupsen/logrus
+  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
-  version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
+  version: e67d870304c4bca21331b02f414f970df13aa694
   subpackages:
   - mem
 - name: github.com/spf13/cast
   version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
 - name: github.com/spf13/cobra
-  version: b78744579491c1ceeaaa3b40205e56b0591b93a3
+  version: 4d6af280c76ff7d266434f2dba207c4b75dfc076
 - name: github.com/spf13/jwalterweatherman
   version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
 - name: github.com/spf13/pflag
-  version: 7aff26db30c1be810f9de5038ec5ef96ac41fd7c
+  version: a9789e855c7696159b7db0db7f440b449edf2b31
 - name: github.com/spf13/viper
-  version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
+  version: d9cca5ef33035202efb1586825bdbb15ff9ec3ba
 - name: github.com/square/go-jose
-  version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
+  version: f8f38de21b4dcd69d0413faf231983f5fd6634b1
   subpackages:
   - json
 - name: github.com/stretchr/testify
@@ -194,33 +194,35 @@ imports:
 - name: github.com/xtgo/uuid
   version: a0b114877d4caeffbd7f87e3757c17fce570fea7
 - name: golang.org/x/crypto
-  version: faadfbdc035307d901e69eea569f5dda451a3ee3
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
   subpackages:
   - bcrypt
   - blowfish
+  - ed25519
+  - ed25519/internal/edwards25519
   - ssh/terminal
 - name: golang.org/x/net
-  version: 859d1a86bb617c0c20d154590c3c5d3fcb670b07
+  version: a04bdaca5b32abe1c069418fb7088ae607de5bd0
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/oauth2
-  version: 13449ad91cb26cb47661c1b080790392170385fd
+  version: bb50c06baba3d0c76f9d125c0719093e315b5b44
   subpackages:
   - clientcredentials
   - internal
 - name: golang.org/x/sys
-  version: 062cd7e4e68206d8bab9b18396626e855c992658
+  version: ebfc5b4631820b793c9010c87fd8fef0f39eb082
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
+  version: 825fc78a2fd6fa0a5447e300189e3219e05e1f25
   subpackages:
   - transform
   - unicode/norm
 - name: google.golang.org/appengine
-  version: d9a072cfa7b9736e44311ef77b3e09d804bfa599
+  version: 07f075729064fd38e1360517947f0f6e03500651
   subpackages:
   - internal
   - internal/base
@@ -231,8 +233,8 @@ imports:
   - urlfetch
 - name: gopkg.in/gorp.v1
   version: c87af80f3cc5036b55b83d77171e156791085e2e
-- name: gopkg.in/square/go-jose.v1
-  version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
+- name: gopkg.in/square/go-jose.v2
+  version: f8f38de21b4dcd69d0413faf231983f5fd6634b1
   subpackages:
   - cipher
   - json

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,9 +3,9 @@ import:
 - package: github.com/sirupsen/logrus
   version: master
 - package: github.com/Sirupsen/logrus
+  version: master
   repo: https://github.com/sirupsen/logrus.git
   vcs: git
-  version: master
 - package: github.com/dgrijalva/jwt-go
   version: 3.0.0
 - package: github.com/go-sql-driver/mysql
@@ -51,6 +51,8 @@ import:
 - package: github.com/rubenv/sql-migrate
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
+- package: github.com/square/go-jose
+  version: 2.1.3
 - package: github.com/stretchr/testify
   version: 1.1.4
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -51,10 +51,6 @@ import:
 - package: github.com/rubenv/sql-migrate
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
-- package: github.com/square/go-jose
-  version: ~1.1.0
-  subpackages:
-  - json
 - package: github.com/stretchr/testify
   version: 1.1.4
   subpackages:

--- a/jwk/cast.go
+++ b/jwk/cast.go
@@ -7,7 +7,7 @@ import (
 	"github.com/square/go-jose"
 )
 
-func MustRSAPublic(key *jose.JsonWebKey) *rsa.PublicKey {
+func MustRSAPublic(key *jose.JSONWebKey) *rsa.PublicKey {
 	res, err := ToRSAPublic(key)
 	if err != nil {
 		panic(err.Error())
@@ -16,7 +16,7 @@ func MustRSAPublic(key *jose.JsonWebKey) *rsa.PublicKey {
 
 }
 
-func ToRSAPublic(key *jose.JsonWebKey) (*rsa.PublicKey, error) {
+func ToRSAPublic(key *jose.JSONWebKey) (*rsa.PublicKey, error) {
 	res, ok := key.Key.(*rsa.PublicKey)
 	if !ok {
 		return res, errors.New("Could not convert key to RSA Private Key.")
@@ -24,7 +24,7 @@ func ToRSAPublic(key *jose.JsonWebKey) (*rsa.PublicKey, error) {
 	return res, nil
 }
 
-func MustRSAPrivate(key *jose.JsonWebKey) *rsa.PrivateKey {
+func MustRSAPrivate(key *jose.JSONWebKey) *rsa.PrivateKey {
 	res, err := ToRSAPrivate(key)
 	if err != nil {
 		panic(err.Error())
@@ -32,7 +32,7 @@ func MustRSAPrivate(key *jose.JsonWebKey) *rsa.PrivateKey {
 	return res
 }
 
-func ToRSAPrivate(key *jose.JsonWebKey) (*rsa.PrivateKey, error) {
+func ToRSAPrivate(key *jose.JSONWebKey) (*rsa.PrivateKey, error) {
 	res, ok := key.Key.(*rsa.PrivateKey)
 	if !ok {
 		return res, errors.New("Could not convert key to RSA Private Key.")

--- a/jwk/generator.go
+++ b/jwk/generator.go
@@ -3,5 +3,5 @@ package jwk
 import "github.com/square/go-jose"
 
 type KeyGenerator interface {
-	Generate(id string) (*jose.JsonWebKeySet, error)
+	Generate(id string) (*jose.JSONWebKeySet, error)
 }

--- a/jwk/generator_ecdsa256.go
+++ b/jwk/generator_ecdsa256.go
@@ -12,14 +12,14 @@ import (
 
 type ECDSA256Generator struct{}
 
-func (g *ECDSA256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *ECDSA256Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, errors.Errorf("Could not generate key because %s", err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          key,
 				KeyID:        ider("private", id),

--- a/jwk/generator_ecdsa521.go
+++ b/jwk/generator_ecdsa521.go
@@ -12,14 +12,14 @@ import (
 
 type ECDSA521Generator struct{}
 
-func (g *ECDSA521Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *ECDSA521Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
 		return nil, errors.Errorf("Could not generate key because %s", err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          key,
 				KeyID:        ider("private", id),

--- a/jwk/generator_hs256.go
+++ b/jwk/generator_hs256.go
@@ -12,7 +12,7 @@ type HS256Generator struct {
 	Length int
 }
 
-func (g *HS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *HS256Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	if g.Length < 12 {
 		g.Length = 12
 	}
@@ -26,8 +26,8 @@ func (g *HS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.Errorf("Could not generate key because %s", err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          []byte(string(key)),
 				KeyID:        id,

--- a/jwk/generator_rs256.go
+++ b/jwk/generator_rs256.go
@@ -14,7 +14,7 @@ type RS256Generator struct {
 	KeyLength int
 }
 
-func (g *RS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
+func (g *RS256Generator) Generate(id string) (*jose.JSONWebKeySet, error) {
 	if g.KeyLength < 4096 {
 		g.KeyLength = 4096
 	}
@@ -28,8 +28,8 @@ func (g *RS256Generator) Generate(id string) (*jose.JsonWebKeySet, error) {
 
 	// jose does not support this...
 	key.Precomputed = rsa.PrecomputedValues{}
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
 			{
 				Key:          key,
 				KeyID:        ider("private", id),

--- a/jwk/generator_test.go
+++ b/jwk/generator_test.go
@@ -11,23 +11,23 @@ import (
 func TestGenerator(t *testing.T) {
 	for _, c := range []struct {
 		g     KeyGenerator
-		check func(*jose.JsonWebKeySet)
+		check func(*jose.JSONWebKeySet)
 	}{
 		{
 			g: &RS256Generator{},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 2)
 			},
 		},
 		{
 			g: &ECDSA521Generator{},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 2)
 			},
 		},
 		{
 			g: &ECDSA256Generator{},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 2)
 			},
 		},
@@ -35,7 +35,7 @@ func TestGenerator(t *testing.T) {
 			g: &HS256Generator{
 				Length: 32,
 			},
-			check: func(ks *jose.JsonWebKeySet) {
+			check: func(ks *jose.JSONWebKeySet) {
 				assert.Len(t, ks, 1)
 			},
 		},

--- a/jwk/handler.go
+++ b/jwk/handler.go
@@ -341,7 +341,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, ps httprouter.P
 func (h *Handler) UpdateKeySet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var ctx = context.Background()
 	var requests joseWebKeySetRequest
-	var keySet = new(jose.JsonWebKeySet)
+	var keySet = new(jose.JSONWebKeySet)
 	var set = ps.ByName("set")
 
 	if _, err := h.W.TokenAllowed(ctx, h.W.TokenFromRequest(r), &firewall.TokenAccessRequest{
@@ -358,7 +358,7 @@ func (h *Handler) UpdateKeySet(w http.ResponseWriter, r *http.Request, ps httpro
 	}
 
 	for _, request := range requests.Keys {
-		key := &jose.JsonWebKey{}
+		key := &jose.JSONWebKey{}
 		if err := key.UnmarshalJSON(request); err != nil {
 			h.H.WriteError(w, r, errors.WithStack(err))
 		}
@@ -407,7 +407,7 @@ func (h *Handler) UpdateKeySet(w http.ResponseWriter, r *http.Request, ps httpro
 //       500: genericError
 func (h *Handler) UpdateKey(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var ctx = context.Background()
-	var key jose.JsonWebKey
+	var key jose.JSONWebKey
 	var set = ps.ByName("set")
 
 	if err := json.NewDecoder(r.Body).Decode(&key); err != nil {

--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var testServer *httptest.Server
-var IDKS *jose.JsonWebKeySet
+var IDKS *jose.JSONWebKeySet
 
 func init() {
 	localWarden, _ := compose.NewMockFirewall(
@@ -57,7 +57,7 @@ func TestHandlerWellKnown(t *testing.T) {
 	require.NoError(t, err, "problem in http request")
 	defer res.Body.Close()
 
-	var known jose.JsonWebKeySet
+	var known jose.JSONWebKeySet
 	err = json.NewDecoder(res.Body).Decode(&known)
 	require.NoError(t, err, "problem in decoding response")
 

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/square/go-jose"
 )
 
-func First(keys []jose.JsonWebKey) *jose.JsonWebKey {
+func First(keys []jose.JSONWebKey) *jose.JSONWebKey {
 	if len(keys) == 0 {
 		return nil
 	}

--- a/jwk/manager.go
+++ b/jwk/manager.go
@@ -3,13 +3,13 @@ package jwk
 import "github.com/square/go-jose"
 
 type Manager interface {
-	AddKey(set string, key *jose.JsonWebKey) error
+	AddKey(set string, key *jose.JSONWebKey) error
 
-	AddKeySet(set string, keys *jose.JsonWebKeySet) error
+	AddKeySet(set string, keys *jose.JSONWebKeySet) error
 
-	GetKey(set, kid string) (*jose.JsonWebKeySet, error)
+	GetKey(set, kid string) (*jose.JSONWebKeySet, error)
 
-	GetKeySet(set string) (*jose.JsonWebKeySet, error)
+	GetKeySet(set string) (*jose.JSONWebKeySet, error)
 
 	DeleteKey(set, kid string) error
 

--- a/jwk/manager_http.go
+++ b/jwk/manager_http.go
@@ -15,10 +15,10 @@ type HTTPManager struct {
 	FakeTLSTermination bool
 }
 
-func (m *HTTPManager) CreateKeys(set, algorithm string) (*jose.JsonWebKeySet, error) {
+func (m *HTTPManager) CreateKeys(set, algorithm string) (*jose.JSONWebKeySet, error) {
 	var c = struct {
 		Algorithm string            `json:"alg"`
-		Keys      []jose.JsonWebKey `json:"keys"`
+		Keys      []jose.JSONWebKey `json:"keys"`
 	}{
 		Algorithm: algorithm,
 	}
@@ -31,12 +31,12 @@ func (m *HTTPManager) CreateKeys(set, algorithm string) (*jose.JsonWebKeySet, er
 		return nil, err
 	}
 
-	return &jose.JsonWebKeySet{
+	return &jose.JSONWebKeySet{
 		Keys: c.Keys,
 	}, nil
 }
 
-func (m *HTTPManager) AddKey(set string, key *jose.JsonWebKey) error {
+func (m *HTTPManager) AddKey(set string, key *jose.JSONWebKey) error {
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set, key.KeyID).String())
 	r.Client = m.Client
 	r.Dry = m.Dry
@@ -44,7 +44,7 @@ func (m *HTTPManager) AddKey(set string, key *jose.JsonWebKey) error {
 	return r.Update(key)
 }
 
-func (m *HTTPManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
+func (m *HTTPManager) AddKeySet(set string, keys *jose.JSONWebKeySet) error {
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set).String())
 	r.Client = m.Client
 	r.Dry = m.Dry
@@ -52,8 +52,8 @@ func (m *HTTPManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
 	return r.Update(keys)
 }
 
-func (m *HTTPManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
-	var c jose.JsonWebKeySet
+func (m *HTTPManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
+	var c jose.JSONWebKeySet
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set, kid).String())
 	r.Client = m.Client
 	r.Dry = m.Dry
@@ -65,8 +65,8 @@ func (m *HTTPManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
 	return &c, nil
 }
 
-func (m *HTTPManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
-	var c jose.JsonWebKeySet
+func (m *HTTPManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
+	var c jose.JSONWebKeySet
 	var r = pkg.NewSuperAgent(pkg.JoinURL(m.Endpoint, set).String())
 	r.Client = m.Client
 	r.Dry = m.Dry

--- a/jwk/manager_memory.go
+++ b/jwk/manager_memory.go
@@ -9,30 +9,30 @@ import (
 )
 
 type MemoryManager struct {
-	Keys map[string]*jose.JsonWebKeySet
+	Keys map[string]*jose.JSONWebKeySet
 	sync.RWMutex
 }
 
-func (m *MemoryManager) AddKey(set string, key *jose.JsonWebKey) error {
+func (m *MemoryManager) AddKey(set string, key *jose.JSONWebKey) error {
 	m.Lock()
 	defer m.Unlock()
 
 	m.alloc()
 	if m.Keys[set] == nil {
-		m.Keys[set] = &jose.JsonWebKeySet{Keys: []jose.JsonWebKey{}}
+		m.Keys[set] = &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{}}
 	}
 	m.Keys[set].Keys = append(m.Keys[set].Keys, *key)
 	return nil
 }
 
-func (m *MemoryManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
+func (m *MemoryManager) AddKeySet(set string, keys *jose.JSONWebKeySet) error {
 	for _, key := range keys.Keys {
 		m.AddKey(set, &key)
 	}
 	return nil
 }
 
-func (m *MemoryManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
+func (m *MemoryManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -47,12 +47,12 @@ func (m *MemoryManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
 	}
 
-	return &jose.JsonWebKeySet{
+	return &jose.JSONWebKeySet{
 		Keys: result,
 	}, nil
 }
 
-func (m *MemoryManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
+func (m *MemoryManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -72,7 +72,7 @@ func (m *MemoryManager) DeleteKey(set, kid string) error {
 	}
 
 	m.Lock()
-	var results []jose.JsonWebKey
+	var results []jose.JSONWebKey
 	for _, key := range keys.Keys {
 		if key.KeyID != kid {
 			results = append(results)
@@ -94,6 +94,6 @@ func (m *MemoryManager) DeleteKeySet(set string) error {
 
 func (m *MemoryManager) alloc() {
 	if m.Keys == nil {
-		m.Keys = make(map[string]*jose.JsonWebKeySet)
+		m.Keys = make(map[string]*jose.JSONWebKeySet)
 	}
 }

--- a/jwk/manager_sql.go
+++ b/jwk/manager_sql.go
@@ -52,7 +52,7 @@ func (s *SQLManager) CreateSchemas() (int, error) {
 	return n, nil
 }
 
-func (m *SQLManager) AddKey(set string, key *jose.JsonWebKey) error {
+func (m *SQLManager) AddKey(set string, key *jose.JSONWebKey) error {
 	out, err := json.Marshal(key)
 	if err != nil {
 		return errors.WithStack(err)
@@ -74,7 +74,7 @@ func (m *SQLManager) AddKey(set string, key *jose.JsonWebKey) error {
 	return nil
 }
 
-func (m *SQLManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
+func (m *SQLManager) AddKeySet(set string, keys *jose.JSONWebKeySet) error {
 	tx, err := m.DB.Beginx()
 	if err != nil {
 		return errors.WithStack(err)
@@ -119,7 +119,7 @@ func (m *SQLManager) AddKeySet(set string, keys *jose.JsonWebKeySet) error {
 	return nil
 }
 
-func (m *SQLManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
+func (m *SQLManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
 	var d sqlData
 	if err := m.DB.Get(&d, m.DB.Rebind("SELECT * FROM hydra_jwk WHERE sid=? AND kid=?"), set, kid); err == sql.ErrNoRows {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
@@ -132,17 +132,17 @@ func (m *SQLManager) GetKey(set, kid string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	var c jose.JsonWebKey
+	var c jose.JSONWebKey
 	if err := json.Unmarshal(key, &c); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	return &jose.JsonWebKeySet{
-		Keys: []jose.JsonWebKey{c},
+	return &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{c},
 	}, nil
 }
 
-func (m *SQLManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
+func (m *SQLManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
 	var ds []sqlData
 	if err := m.DB.Select(&ds, m.DB.Rebind("SELECT * FROM hydra_jwk WHERE sid=?"), set); err == sql.ErrNoRows {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
@@ -154,14 +154,14 @@ func (m *SQLManager) GetKeySet(set string) (*jose.JsonWebKeySet, error) {
 		return nil, errors.Wrap(pkg.ErrNotFound, "")
 	}
 
-	keys := &jose.JsonWebKeySet{Keys: []jose.JsonWebKey{}}
+	keys := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{}}
 	for _, d := range ds {
 		key, err := m.Cipher.Decrypt(d.Key)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 
-		var c jose.JsonWebKey
+		var c jose.JSONWebKey
 		if err := json.Unmarshal(key, &c); err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/jwk/manager_test_helpers.go
+++ b/jwk/manager_test_helpers.go
@@ -19,7 +19,7 @@ func RandomBytes(n int) ([]byte, error) {
 	return bytes, nil
 }
 
-func TestHelperManagerKey(m Manager, keys *jose.JsonWebKeySet) func(t *testing.T) {
+func TestHelperManagerKey(m Manager, keys *jose.JSONWebKeySet) func(t *testing.T) {
 	pub := keys.Key("public")
 	priv := keys.Key("private")
 
@@ -53,7 +53,7 @@ func TestHelperManagerKey(m Manager, keys *jose.JsonWebKeySet) func(t *testing.T
 	}
 }
 
-func TestHelperManagerKeySet(m Manager, keys *jose.JsonWebKeySet) func(t *testing.T) {
+func TestHelperManagerKeySet(m Manager, keys *jose.JSONWebKeySet) func(t *testing.T) {
 	return func(t *testing.T) {
 		_, err := m.GetKeySet("foo")
 		pkg.AssertError(t, true, err)

--- a/sdk/consent_test.go
+++ b/sdk/consent_test.go
@@ -16,14 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func genKey() *jose.JsonWebKeySet {
+func genKey() *jose.JSONWebKeySet {
 	g := &jwk.RS256Generator{}
 	k, _ := g.Generate("")
 	return k
 }
 
 func TestConsentHelper(t *testing.T) {
-	km := &jwk.MemoryManager{Keys: map[string]*jose.JsonWebKeySet{}}
+	km := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 	km.AddKeySet(oauth2.ConsentChallengeKey, genKey())
 	km.AddKeySet(oauth2.ConsentEndpointKey, genKey())
 


### PR DESCRIPTION
This is a patch against v0.9.13, and requires #605, but there was no branch based on that at present, so I apologize for requesting this against master.

This adds a Gopkg.toml file so that [dep](https://github.com/golang/dep) can be supported. You can continue to use glide if you keep the Gopkg.toml up-to-date too. The reason that this is useful, for packages that use the hydra sdk, is that dep will recursively resolve dependencies using the Gopkg.toml file.

Right now, we have to add overrides for each of hydra's dependencies which is less than ideal.