### PR TITLE
add ability to list all groups

### DIFF
--- a/docs/api.swagger.yaml
+++ b/docs/api.swagger.yaml
@@ -1376,8 +1376,8 @@ paths:
   /warden/groups:
     get:
       description: >-
-        The subject making the request needs to be assigned to a policy
-        containing:
+        The subject making the request, if member is specified, needs to be
+        assigned to a policy containing:
 
 
         ```
@@ -1385,6 +1385,23 @@ paths:
         {
 
         "resources": ["rn:hydra:warden:groups:<member>"],
+
+        "actions": ["get"],
+
+        "effect": "allow"
+
+        }
+
+        ```
+
+        If member is not specified, the subject making the request needs to be
+        assigned to a policy containing:
+
+        ```
+
+        {
+
+        "resources": ["rn:hydra:warden:groups"],
 
         "actions": ["get"],
 
@@ -1403,8 +1420,8 @@ paths:
       tags:
         - warden
         - groups
-      summary: Find group IDs by member
-      operationId: findGroupsByMember
+      summary: Find group IDs
+      operationId: findGroups
       security:
         - oauth2:
             - hydra.groups
@@ -1415,9 +1432,21 @@ paths:
           description: The id of the member to look up.
           name: member
           in: query
+        - type: integer
+          format: int64
+          x-go-name: Offset
+          description: The offset from where to start looking if member isn't specified.
+          name: offset
+          in: query
+        - type: integer
+          format: int64
+          x-go-name: Limit
+          description: The maximum amount of policies returned if member isn't specified.
+          name: limit
+          in: query
       responses:
         '200':
-          $ref: '#/responses/findGroupsByMemberResponse'
+          $ref: '#/responses/findGroupsResponse'
         '401':
           $ref: '#/responses/genericError'
         '403':
@@ -2721,7 +2750,7 @@ responses:
     headers:
       description:
         type: string
-  findGroupsByMemberResponse:
+  findGroupsResponse:
     description: A list of groups the member is belonging to
     schema:
       type: array

--- a/docs/api.swagger.yaml
+++ b/docs/api.swagger.yaml
@@ -1376,26 +1376,9 @@ paths:
   /warden/groups:
     get:
       description: >-
-        The subject making the request, if member is specified, needs to be
-        assigned to a policy containing:
+        The subject making the request needs to be assigned to a policy
+        containing:
 
-
-        ```
-
-        {
-
-        "resources": ["rn:hydra:warden:groups:<member>"],
-
-        "actions": ["get"],
-
-        "effect": "allow"
-
-        }
-
-        ```
-
-        If member is not specified, the subject making the request needs to be
-        assigned to a policy containing:
 
         ```
 
@@ -1420,8 +1403,8 @@ paths:
       tags:
         - warden
         - groups
-      summary: Find group IDs
-      operationId: findGroups
+      summary: List group IDs
+      operationId: listGroups
       security:
         - oauth2:
             - hydra.groups
@@ -1446,7 +1429,7 @@ paths:
           in: query
       responses:
         '200':
-          $ref: '#/responses/findGroupsResponse'
+          $ref: '#/responses/listGroupsResponse'
         '401':
           $ref: '#/responses/genericError'
         '403':
@@ -2750,7 +2733,7 @@ responses:
     headers:
       description:
         type: string
-  findGroupsResponse:
+  listGroupsResponse:
     description: A list of groups the member is belonging to
     schema:
       type: array

--- a/warden/group/doc.go
+++ b/warden/group/doc.go
@@ -2,14 +2,14 @@
 package group
 
 // A list of groups the member is belonging to
-// swagger:response findGroupsResponse
-type swaggerFindGroupsResponse struct {
+// swagger:response listGroupsResponse
+type swaggerListGroupsResponse struct {
 	// in: body
 	Body []string
 }
 
-// swagger:parameters findGroups
-type swaggerFindGroupsParameters struct {
+// swagger:parameters listGroups
+type swaggerListGroupsParameters struct {
 	// The id of the member to look up.
 	// in: query
 	Member int `json:"member"`

--- a/warden/group/doc.go
+++ b/warden/group/doc.go
@@ -2,17 +2,25 @@
 package group
 
 // A list of groups the member is belonging to
-// swagger:response findGroupsByMemberResponse
-type swaggerFindGroupsByMemberResponse struct {
+// swagger:response findGroupsResponse
+type swaggerFindGroupsResponse struct {
 	// in: body
 	Body []string
 }
 
-// swagger:parameters findGroupsByMember
-type swaggerFindGroupsByMemberParameters struct {
+// swagger:parameters findGroups
+type swaggerFindGroupsParameters struct {
 	// The id of the member to look up.
 	// in: query
 	Member int `json:"member"`
+
+	// The offset from where to start looking if member isn't specified.
+	// in: query
+	Offset int `json:"offset"`
+
+	// The maximum amount of policies returned if member isn't specified.
+	// in: query
+	Limit int `json:"limit"`
 }
 
 // swagger:parameters getGroup deleteGroup

--- a/warden/group/manager.go
+++ b/warden/group/manager.go
@@ -19,5 +19,6 @@ type Manager interface {
 	AddGroupMembers(group string, members []string) error
 	RemoveGroupMembers(group string, members []string) error
 
+	ListGroups(limit, offset int64) ([]string, error)
 	FindGroupNames(subject string) ([]string, error)
 }

--- a/warden/group/manager_http.go
+++ b/warden/group/manager_http.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -18,6 +19,8 @@ type HTTPManager struct {
 	FakeTLSTermination bool
 	Dry                bool
 }
+
+var _ Manager = (*HTTPManager)(nil)
 
 func (m *HTTPManager) CreateGroup(g *Group) error {
 	var r = pkg.NewSuperAgent(m.Endpoint.String())
@@ -89,6 +92,19 @@ func (m *HTTPManager) RemoveGroupMembers(group string, members []string) error {
 	}
 
 	return nil
+}
+
+func (m *HTTPManager) ListGroups(limit, offset int64) ([]string, error) {
+	var g []string
+	var r = pkg.NewSuperAgent(m.Endpoint.String() + fmt.Sprintf("?limit=%d&offset=%d", limit, offset))
+	r.Client = m.Client
+	r.Dry = m.Dry
+	r.FakeTLSTermination = m.FakeTLSTermination
+	if err := r.Get(&g); err != nil {
+		return nil, err
+	}
+
+	return g, nil
 }
 
 func (m *HTTPManager) FindGroupNames(subject string) ([]string, error) {

--- a/warden/group/manager_memory.go
+++ b/warden/group/manager_memory.go
@@ -88,11 +88,12 @@ func (m *MemoryManager) ListGroups(limit, offset int64) ([]string, error) {
 		offset = 0
 	}
 
+	res := []string{}
+
 	if offset >= int64(len(m.Groups)) {
-		return nil, nil
+		return res, nil
 	}
 
-	var res []string
 	for _, g := range m.Groups {
 		res = append(res, g.ID)
 	}
@@ -113,7 +114,7 @@ func (m *MemoryManager) FindGroupNames(subject string) ([]string, error) {
 		m.Groups = map[string]Group{}
 	}
 
-	var res []string
+	res := []string{}
 	for _, g := range m.Groups {
 		for _, s := range g.Members {
 			if s == subject {

--- a/warden/group/manager_memory.go
+++ b/warden/group/manager_memory.go
@@ -80,12 +80,12 @@ func (m *MemoryManager) RemoveGroupMembers(group string, subjects []string) erro
 }
 
 func (m *MemoryManager) ListGroups(limit, offset int64) ([]string, error) {
-	if limit < 0 {
-		return nil, errors.New("limit can't be less than 0")
+	if limit <= 0 {
+		limit = 500
 	}
 
 	if offset < 0 {
-		return nil, errors.New("offset can't be less than 0")
+		offset = 0
 	}
 
 	if offset >= int64(len(m.Groups)) {
@@ -100,10 +100,6 @@ func (m *MemoryManager) ListGroups(limit, offset int64) ([]string, error) {
 	sort.Strings(res)
 
 	res = res[offset:]
-
-	if limit == 0 {
-		limit = 500
-	}
 
 	if limit < int64(len(res)) {
 		res = res[:limit]

--- a/warden/group/manager_sql.go
+++ b/warden/group/manager_sql.go
@@ -126,19 +126,15 @@ func (m *SQLManager) RemoveGroupMembers(group string, subjects []string) error {
 }
 
 func (m *SQLManager) ListGroups(limit, offset int64) ([]string, error) {
-	if limit < 0 {
-		return nil, errors.New("limit can't be less than 0")
+	if limit <= 0 {
+		limit = 500
 	}
 
 	if offset < 0 {
-		return nil, errors.New("offset can't be less than 0")
+		offset = 0
 	}
 
 	var q []string
-
-	if limit == 0 {
-		limit = 500
-	}
 
 	if err := m.DB.Select(&q, m.DB.Rebind("SELECT id from hydra_warden_group ORDER BY id LIMIT ? OFFSET ?"), limit, offset); err != nil {
 		return nil, errors.WithStack(err)

--- a/warden/group/manager_sql.go
+++ b/warden/group/manager_sql.go
@@ -134,7 +134,7 @@ func (m *SQLManager) ListGroups(limit, offset int64) ([]string, error) {
 		offset = 0
 	}
 
-	var q []string
+	q := []string{}
 
 	if err := m.DB.Select(&q, m.DB.Rebind("SELECT id from hydra_warden_group ORDER BY id LIMIT ? OFFSET ?"), limit, offset); err != nil {
 		return nil, errors.WithStack(err)
@@ -144,7 +144,7 @@ func (m *SQLManager) ListGroups(limit, offset int64) ([]string, error) {
 }
 
 func (m *SQLManager) FindGroupNames(subject string) ([]string, error) {
-	var q []string
+	q := []string{}
 	if err := m.DB.Select(&q, m.DB.Rebind("SELECT group_id from hydra_warden_group_member WHERE member = ? GROUP BY group_id"), subject); err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/warden/group/manager_test.go
+++ b/warden/group/manager_test.go
@@ -85,6 +85,8 @@ func connectToPG() {
 }
 
 func TestManagers(t *testing.T) {
+	t.Parallel()
+
 	for k, m := range clientManagers {
 		t.Run(fmt.Sprintf("case=%s", k), TestHelperManagers(m))
 	}

--- a/warden/group/manager_test_helper.go
+++ b/warden/group/manager_test_helper.go
@@ -12,18 +12,22 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		ds, err := m.ListGroups(0, 0)
 		assert.NoError(t, err)
 		assert.Empty(t, ds)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(-1, 0)
 		assert.NoError(t, err)
-		assert.Nil(t, ds)
+		assert.Empty(t, ds)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(0, -1)
 		assert.NoError(t, err)
-		assert.Nil(t, ds)
+		assert.Empty(t, ds)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(-1, -1)
 		assert.NoError(t, err)
-		assert.Nil(t, ds)
+		assert.Empty(t, ds)
+		assert.NotNil(t, ds)
 
 		_, err = m.GetGroup("4321")
 		assert.NotNil(t, err)
@@ -36,10 +40,12 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		ds, err = m.ListGroups(0, 0)
 		require.NoError(t, err)
 		assert.Len(t, ds, 1)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(0, 1)
 		require.NoError(t, err)
 		assert.Len(t, ds, 0)
+		assert.NotNil(t, ds)
 
 		assert.NoError(t, m.CreateGroup(&Group{
 			ID:      "2",
@@ -48,30 +54,37 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		ds, err = m.ListGroups(0, 0)
 		require.NoError(t, err)
 		assert.Len(t, ds, 2)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(0, 1)
 		require.NoError(t, err)
 		assert.Len(t, ds, 1)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(0, 2)
 		require.NoError(t, err)
 		assert.Len(t, ds, 0)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(1, 0)
 		require.NoError(t, err)
 		assert.Len(t, ds, 1)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(2, 0)
 		require.NoError(t, err)
 		assert.Len(t, ds, 2)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(1, 1)
 		require.NoError(t, err)
 		assert.Len(t, ds, 1)
+		assert.NotNil(t, ds)
 
 		ds, err = m.ListGroups(0, 2)
 		require.NoError(t, err)
 		assert.Len(t, ds, 0)
+		assert.NotNil(t, ds)
 
 		assert.NoError(t, m.CreateGroup(&Group{
 			ID:      "3",
@@ -80,6 +93,7 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		ds, err = m.ListGroups(0, 0)
 		require.NoError(t, err)
 		assert.Len(t, ds, 3)
+		assert.NotNil(t, ds)
 
 		d, err := m.GetGroup("1")
 		require.NoError(t, err)
@@ -89,17 +103,20 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		ds, err = m.FindGroupNames("foo")
 		require.NoError(t, err)
 		assert.Len(t, ds, 2)
+		assert.NotNil(t, ds)
 
 		assert.NoError(t, m.AddGroupMembers("1", []string{"baz"}))
 
 		ds, err = m.FindGroupNames("baz")
 		require.NoError(t, err)
 		assert.Len(t, ds, 1)
+		assert.NotNil(t, ds)
 
 		assert.NoError(t, m.RemoveGroupMembers("1", []string{"baz"}))
 		ds, err = m.FindGroupNames("baz")
 		require.NoError(t, err)
 		assert.Len(t, ds, 0)
+		assert.NotNil(t, ds)
 
 		assert.NoError(t, m.DeleteGroup("1"))
 		_, err = m.GetGroup("1")
@@ -108,6 +125,6 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		ds, err = m.ListGroups(0, 0)
 		require.NoError(t, err)
 		assert.Len(t, ds, 2)
-
+		assert.NotNil(t, ds)
 	}
 }

--- a/warden/group/manager_test_helper.go
+++ b/warden/group/manager_test_helper.go
@@ -9,7 +9,23 @@ import (
 
 func TestHelperManagers(m Manager) func(t *testing.T) {
 	return func(t *testing.T) {
-		_, err := m.GetGroup("4321")
+		ds, err := m.ListGroups(0, 0)
+		assert.NoError(t, err)
+		assert.Empty(t, ds)
+
+		ds, err = m.ListGroups(-1, 0)
+		assert.Error(t, err)
+		assert.Nil(t, ds)
+
+		ds, err = m.ListGroups(0, -1)
+		assert.Error(t, err)
+		assert.Nil(t, ds)
+
+		ds, err = m.ListGroups(-1, -1)
+		assert.Error(t, err)
+		assert.Nil(t, ds)
+
+		_, err = m.GetGroup("4321")
 		assert.NotNil(t, err)
 
 		c := &Group{
@@ -17,17 +33,60 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 			Members: []string{"bar", "foo"},
 		}
 		assert.NoError(t, m.CreateGroup(c))
+		ds, err = m.ListGroups(0, 0)
+		require.NoError(t, err)
+		assert.Len(t, ds, 1)
+
+		ds, err = m.ListGroups(0, 1)
+		require.NoError(t, err)
+		assert.Len(t, ds, 0)
+
 		assert.NoError(t, m.CreateGroup(&Group{
 			ID:      "2",
 			Members: []string{"foo"},
 		}))
+		ds, err = m.ListGroups(0, 0)
+		require.NoError(t, err)
+		assert.Len(t, ds, 2)
+
+		ds, err = m.ListGroups(0, 1)
+		require.NoError(t, err)
+		assert.Len(t, ds, 1)
+
+		ds, err = m.ListGroups(0, 2)
+		require.NoError(t, err)
+		assert.Len(t, ds, 0)
+
+		ds, err = m.ListGroups(1, 0)
+		require.NoError(t, err)
+		assert.Len(t, ds, 1)
+
+		ds, err = m.ListGroups(2, 0)
+		require.NoError(t, err)
+		assert.Len(t, ds, 2)
+
+		ds, err = m.ListGroups(1, 1)
+		require.NoError(t, err)
+		assert.Len(t, ds, 1)
+
+		ds, err = m.ListGroups(0, 2)
+		require.NoError(t, err)
+		assert.Len(t, ds, 0)
+
+		assert.NoError(t, m.CreateGroup(&Group{
+			ID:      "3",
+			Members: []string{"bar"},
+		}))
+		ds, err = m.ListGroups(0, 0)
+		require.NoError(t, err)
+		assert.Len(t, ds, 3)
 
 		d, err := m.GetGroup("1")
 		require.NoError(t, err)
 		assert.EqualValues(t, c.Members, d.Members)
 		assert.EqualValues(t, c.ID, d.ID)
 
-		ds, err := m.FindGroupNames("foo")
+		ds, err = m.FindGroupNames("foo")
 		require.NoError(t, err)
 		assert.Len(t, ds, 2)
 
@@ -45,5 +104,10 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		assert.NoError(t, m.DeleteGroup("1"))
 		_, err = m.GetGroup("1")
 		require.NotNil(t, err)
+
+		ds, err = m.ListGroups(0, 0)
+		require.NoError(t, err)
+		assert.Len(t, ds, 2)
+
 	}
 }

--- a/warden/group/manager_test_helper.go
+++ b/warden/group/manager_test_helper.go
@@ -14,15 +14,15 @@ func TestHelperManagers(m Manager) func(t *testing.T) {
 		assert.Empty(t, ds)
 
 		ds, err = m.ListGroups(-1, 0)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 		assert.Nil(t, ds)
 
 		ds, err = m.ListGroups(0, -1)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 		assert.Nil(t, ds)
 
 		ds, err = m.ListGroups(-1, -1)
-		assert.Error(t, err)
+		assert.NoError(t, err)
 		assert.Nil(t, ds)
 
 		_, err = m.GetGroup("4321")


### PR DESCRIPTION
This is to satisfy #594 

I'm not sure if the `api.swagger.yaml` file is complete/correct since the `gen-swagger.sh` script produces the uncommitted `api.swagger.json` file.

The API is also a little strange as the `GET /warden/groups` endpoint already existed and previously required a `member` param (and `GET /warden/groups/<id>` refers to the group id, not the member id).

Now `GET /warden/groups` _OPTIONALLY_ uses the `member` param. If it exists, the behavior is the same as before so there are no API regressions.

However, if `member` does not exist, then it is assumed that the user wants to list all groups. In this case, the required policy resource changes (from `rn:hydra:warden:groups:<member>` to `rn:hydra:warden:groups`). Additionally, the `limit` and `offset` parameters are used if they exist. `limit` defaults to `500` if not specified (the same as `GET /policies`).