### PR TITLE
docs: fix bash command and version used in tutorial

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -76,7 +76,7 @@ $ docker run -d \
   -e ISSUER=https://localhost:9000/ \
   -e CONSENT_URL=http://localhost:9020/consent \
   -e FORCE_ROOT_CLIENT_CREDENTIALS=admin:demo-password \
-  oryd/hydra:v0.10.0-alpha.1
+  oryd/hydra:v0.10.0-alpha.8
 
 # And check if it's running:
 $ docker logs ory-hydra-example--hydra

--- a/docs/install.md
+++ b/docs/install.md
@@ -76,7 +76,7 @@ $ docker run -d \
   -e ISSUER=https://localhost:9000/ \
   -e CONSENT_URL=http://localhost:9020/consent \
   -e FORCE_ROOT_CLIENT_CREDENTIALS=admin:demo-password \
-  oryd/hydra:v0.10.0-alpha1
+  oryd/hydra:v0.10.0-alpha.1
 
 # And check if it's running:
 $ docker logs ory-hydra-example--hydra
@@ -275,7 +275,7 @@ $ hydra policies create --skip-tls-verify \
   --description "Allow consent-app to manage OAuth2 consent requests." \
   --allow \
   --id consent-app-policy \
-  --resources rn:hydra:oauth2:consent:requests:<.*> \
+  --resources "rn:hydra:oauth2:consent:requests:<.*>" \
   --subjects consent-app
 
 Created policy consent-app-policy.
@@ -286,7 +286,7 @@ Let's take a look at the arguments:
 * `--actions get,accept,reject` we need to be able to get, accept and reject consent requests.
 * `--allow` sets the policy effect to `allow`. Omit to set this for `deny`.
 * `--id consent-app-policy` a unique identifier.
-* `--resources rn:hydra:oauth2:consent:requests:<.*> ` we need to be able to access the consent request resource.
+* `--resources "rn:hydra:oauth2:consent:requests:<.*>" ` we need to be able to access the consent request resource.
 * `--subjects consent-app` the subject ("user") of this policy is our consent app.
 
 Awesome! Next we will run the [ORY Hydra Consent App Example (NodeJS)](https://github.com/ory/hydra-consent-app-express).


### PR DESCRIPTION
bash command that contain regex needs to be quoated, version doesn't exists

Before creating your pull request, make sure that you have
[signed the DOC](https://github.com/ory/hydra/blob/master/CONTRIBUTING.md#developers-certificate-of-origin). You can ammend your
signature to the current commit using `git commit --amend -s`.

Please create PRs only for bugs, or features that have been discussed with the maintainers, either at the
[ORY Community](https://community.ory.am/) or join the [ORY Chat](https://gitter.im/ory-am/hydra).