### PR TITLE
docs: updated hydra version in the tutorial to v0.10.0-alpha.8 and consent app to v0.10.0-alpha.9

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -46,11 +46,11 @@ $ export SYSTEM_SECRET=this_needs_to_be_the_same_always_and_also_very_$3cuR3-._
 $ export DATABASE_URL=postgres://hydra:secret@postgres:5432/hydra?sslmode=disable
 
 # Before starting, let's pull the latest ORY Hydra tag from docker.
-$ docker pull oryd/hydra:v0.9.12
+$ docker pull oryd/hydra:v0.10.0-alpha.8
 
 # This command will show you all the environment variables that you can set. Read this carefully.
 # It is the equivalent to `hydra help host`.
-$ docker run -it --entrypoint hydra oryd/hydra:v0.9.12 help host
+$ docker run -it --entrypoint hydra oryd/hydra:v0.10.0-alpha.8 help host
 
 Starts all HTTP/2 APIs and connects to a database backend.
 [...]
@@ -58,7 +58,7 @@ Starts all HTTP/2 APIs and connects to a database backend.
 # ORY Hydra does not do magic, it requires concious decisions, for example, when running SQL migrations, which is required
 # when installing a new version of ORY Hydra, or upgrading an existing installation.
 # It is the equivalent to `hydra migrate sql postgres://hydra:secret@postgres:5432/hydra?sslmode=disable`
-$ docker run --link ory-hydra-example--postgres:postgres -it --entrypoint hydra oryd/hydra:v0.9.12 migrate sql $DATABASE_URL
+$ docker run --link ory-hydra-example--postgres:postgres -it --entrypoint hydra oryd/hydra:v0.10.0-alpha.8 migrate sql $DATABASE_URL
 
 Applying `ladon` SQL migrations...
 Applied 3 `ladon` SQL migrations.
@@ -134,7 +134,7 @@ ORY Hydra can be managed using the Hydra Command Line Interface (CLI), which is 
 see the available commands, run:
 
 ```
-$ docker run -it --entrypoint hydra oryd/hydra:v0.9.12 help
+$ docker run -it --entrypoint hydra oryd/hydra:v0.10.0-alpha.8 help
 Hydra is a cloud native high throughput OAuth2 and OpenID Connect provider
 
 Usage:
@@ -205,7 +205,7 @@ Next we need to connect to ORY Hydra and set up OAuth 2.0 Clients and access con
 ```
 # We run a shell with ORY Hydra installed. We also expose port 4445 which we will use later to perform
 # the authorize code flow. Also, we connect this container to our ORY Hydra instance.
-$ docker run -p 9010:4445 --link ory-hydra-example--hydra:hydra -it --entrypoint "/bin/sh" oryd/hydra:v0.9.12
+$ docker run -p 9010:4445 --link ory-hydra-example--hydra:hydra -it --entrypoint "/bin/sh" oryd/hydra:v0.10.0-alpha.8
 
 # Let's connect to the ORY Hydra cluster
 $ hydra connect
@@ -249,7 +249,7 @@ $ hydra clients create --skip-tls-verify \
   --name "Consent App Client" \
   --grant-types client_credentials \
   --response-types token \
-  --allowed-scopes hydra.consent*
+  --allowed-scopes hydra.consent
 ```
 
 Let's dive into the arguments:
@@ -302,7 +302,7 @@ $ docker run -d \
   -e HYDRA_CLIENT_SECRET=consent-secret \
   -e HYDRA_URL=https://hydra:4444 \
   -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  oryd/hydra-consent-app-express:v0.10.0-alpha.7
+  oryd/hydra-consent-app-express:v0.10.0-alpha.9
 
 # Let's check if it's running ok:
 $ docker logs ory-hydra-example--consent
@@ -317,7 +317,7 @@ from the ORY Hydra docker container (`CONSENT_URL=http://localhost:9020/consent`
 * `NODE_TLS_REJECT_UNAUTHORIZED=0` disables TLS verification, because we are using self-signed certificates.
 
 Now close this shell and return to the one which is connected to the ORY Hydra bash container
-(`docker run -p 9010:4445 --link ory-hydra-example--hydra:hydra -it --entrypoint "/bin/sh" oryd/hydra:v0.9.12`).
+(`docker run -p 9010:4445 --link ory-hydra-example--hydra:hydra -it --entrypoint "/bin/sh" oryd/hydra:v0.10.0-alpha.8`).
 
 ## Perform OAuth 2.0 Flow
 

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -14,7 +14,7 @@ the user's account is limited to the "scope" of the authorization granted (e.g. 
 2. **Authorization Server (Hydra)** verifies the identity of the user and issues access tokens to the *client application*.
 3. **Client** is the *application* that wants to access the user's account. Before it may do so, it must be authorized
 by the user.
-4. **Identity Provider** contains a log in user interface and a database of all your users. To integrate Hydra,
+4. **Identity Provider** contains a login user interface and a database of all your users. To integrate Hydra,
 you must modify the Identity Provider. It mus be able to generate consent tokens and ask for the user's consent.
 5. **User Agent** is usually the resource owner's browser.
 6. **Consent App** is an app (e.g. NodeJS) that is able to receive consent challenges and create consent tokens.
@@ -24,12 +24,12 @@ if he consents to allowing the client access to his resources.
 
 Examples:
 1. Peter wants to give MyPhotoBook access to his Dropbox. Peter is the resource owner.
-2. The Authorization Server (Hydra) is responsible for managing the access request fom MyPhotoBook. Hydra handles
+2. The Authorization Server (Hydra) is responsible for managing the access request for MyPhotoBook. Hydra handles
 the communication between the resource owner, the consent endpoint and the client. Hydra is the authorization server.
 In this case, Dropbox would be the one who uses Hydra.
 3. MyPhotoBook is the client and was issued an id and a password by Hydra. MyPhotoBook uses these credentials
 to talk with Hydra.
-4. Dropbox has a database and a frontend that allow their users to log in, using their username and password.
+4. Dropbox has a database and a frontend that allow their users to login, using their username and password.
 This is what an Identity Provider does.
 5. The User Agent is Peter's FireFox.
 6. The Consent App is a frontend app that asks the user if he is willing to give MyPhotoBook access to his pictures stored
@@ -43,7 +43,7 @@ first.
 
 Hydra uses the [JSON Web Key Manager](./jwk.md) to retrieve the
 key pair `hydra.openid.id-token` for signing ID tokens. You can use that endpoint to retrieve the public key for verification,
-has Hydra is not supporting OpenID Connect Discovery yet.
+as Hydra does not supporting OpenID Connect Discovery yet.
 
 ### OAuth 2.0 Clients
 

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -42,8 +42,8 @@ If you are new to OpenID Connect, please read the [Introduction to OAuth 2.0 and
 first. 
 
 Hydra uses the [JSON Web Key Manager](./jwk.md) to retrieve the
-key pair `hydra.openid.id-token` for signing ID tokens. You can use that endpoint to retrieve the public key for verification,
-as Hydra does not supporting OpenID Connect Discovery yet.
+key pair `hydra.openid.id-token` for signing ID tokens. You can use that endpoint to retrieve the public key for verification.
+Additionally, Hydra supports OpenID Connect Discovery.
 
 ### OAuth 2.0 Clients
 


### PR DESCRIPTION
this PR updated the installation docs to reflect the latest hydra version at the time and the consent app.

also it fixes a mistake in assigning the consent scope.

I have ran through the installation with this update and was able to reach the end without any issues.