### PR TITLE
Support ES256 JWK Algo

### DIFF
--- a/cmd/keys_create.go
+++ b/cmd/keys_create.go
@@ -27,6 +27,6 @@ var keysCreateCmd = &cobra.Command{
 
 func init() {
 	keysCmd.AddCommand(keysCreateCmd)
-	keysCreateCmd.Flags().StringP("alg", "a", "", "REQUIRED name that identifies the algorithm intended for use with the key. Supports: RS256, ES521, HS256")
+	keysCreateCmd.Flags().StringP("alg", "a", "", "REQUIRED name that identifies the algorithm intended for use with the key. Supports: RS256, ES256, ES521, HS256")
 
 }

--- a/docs/api.swagger.yaml
+++ b/docs/api.swagger.yaml
@@ -2113,7 +2113,7 @@ definitions:
       alg:
         description: >-
           The algorithm to be used for creating the key. Supports "RS256",
-          "ES521" and "HS256"
+          "ES256", "ES521" and "HS256"
         type: string
         x-go-name: Algorithm
       kid:

--- a/jwk/handler.go
+++ b/jwk/handler.go
@@ -28,6 +28,7 @@ func (h *Handler) GetGenerators() map[string]KeyGenerator {
 	if h.Generators == nil || len(h.Generators) == 0 {
 		h.Generators = map[string]KeyGenerator{
 			"RS256": &RS256Generator{},
+			"ES256": &ECDSA256Generator{},
 			"ES521": &ECDSA521Generator{},
 			"HS256": &HS256Generator{
 				Length: 32,
@@ -52,7 +53,7 @@ func (h *Handler) SetRoutes(r *httprouter.Router) {
 }
 
 type createRequest struct {
-	// The algorithm to be used for creating the key. Supports "RS256", "ES521" and "HS256"
+	// The algorithm to be used for creating the key. Supports "RS256", "ES256", "ES521" and "HS256"
 	// required: true
 	// in: body
 	Algorithm string `json:"alg"`

--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -38,7 +38,7 @@ func init() {
 		},
 	)
 	router := httprouter.New()
-	IDKS, _ = testGenerator.Generate("")
+	IDKS, _ = testGenerators["RS256"].Generate("")
 
 	h := Handler{
 		Manager: &MemoryManager{},

--- a/jwk/manager_test_helpers.go
+++ b/jwk/manager_test_helpers.go
@@ -19,57 +19,57 @@ func RandomBytes(n int) ([]byte, error) {
 	return bytes, nil
 }
 
-func TestHelperManagerKey(m Manager, keys *jose.JSONWebKeySet) func(t *testing.T) {
+func TestHelperManagerKey(m Manager, name string, keys *jose.JSONWebKeySet) func(t *testing.T) {
 	pub := keys.Key("public")
 	priv := keys.Key("private")
 
 	return func(t *testing.T) {
-		_, err := m.GetKey("faz", "baz")
+		_, err := m.GetKey(name+"faz", "baz")
 		assert.NotNil(t, err)
 
-		err = m.AddKey("faz", First(priv))
+		err = m.AddKey(name+"faz", First(priv))
 		assert.Nil(t, err)
 
-		got, err := m.GetKey("faz", "private")
-		assert.Nil(t, err)
-		assert.Equal(t, priv, got.Keys)
-
-		err = m.AddKey("faz", First(pub))
-		assert.Nil(t, err)
-
-		got, err = m.GetKey("faz", "private")
+		got, err := m.GetKey(name+"faz", "private")
 		assert.Nil(t, err)
 		assert.Equal(t, priv, got.Keys)
 
-		got, err = m.GetKey("faz", "public")
+		err = m.AddKey(name+"faz", First(pub))
+		assert.Nil(t, err)
+
+		got, err = m.GetKey(name+"faz", "private")
+		assert.Nil(t, err)
+		assert.Equal(t, priv, got.Keys)
+
+		got, err = m.GetKey(name+"faz", "public")
 		assert.Nil(t, err)
 		assert.Equal(t, pub, got.Keys)
 
-		err = m.DeleteKey("faz", "public")
+		err = m.DeleteKey(name+"faz", "public")
 		assert.Nil(t, err)
 
-		_, err = m.GetKey("faz", "public")
+		_, err = m.GetKey(name+"faz", "public")
 		assert.NotNil(t, err)
 	}
 }
 
-func TestHelperManagerKeySet(m Manager, keys *jose.JSONWebKeySet) func(t *testing.T) {
+func TestHelperManagerKeySet(m Manager, name string, keys *jose.JSONWebKeySet) func(t *testing.T) {
 	return func(t *testing.T) {
-		_, err := m.GetKeySet("foo")
+		_, err := m.GetKeySet(name + "foo")
 		pkg.AssertError(t, true, err)
 
-		err = m.AddKeySet("bar", keys)
+		err = m.AddKeySet(name+"bar", keys)
 		assert.Nil(t, err)
 
-		got, err := m.GetKeySet("bar")
+		got, err := m.GetKeySet(name + "bar")
 		assert.Nil(t, err)
 		assert.Equal(t, keys.Key("public"), got.Key("public"))
 		assert.Equal(t, keys.Key("private"), got.Key("private"))
 
-		err = m.DeleteKeySet("bar")
+		err = m.DeleteKeySet(name + "bar")
 		assert.Nil(t, err)
 
-		_, err = m.GetKeySet("bar")
+		_, err = m.GetKeySet(name + "bar")
 		assert.NotNil(t, err)
 	}
 }


### PR DESCRIPTION
I think this is all that's necessary to support #627 

It looks like support for ES256 is available (`jwk/generator_ecdsa256.go`), but that the JWK handler doesn't support it (https://github.com/ory/hydra/blob/master/jwk/handler.go#L27-L38).

Go's P-256 is implementation is constant-time (which prevents certain types of attacks) while its P-384 and P-521 are not (https://github.com/gtank/cryptopasta).