### PR TITLE
oauth2: Requires firewall check for introspecting access tokens

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,8 +231,8 @@
 [[projects]]
   name = "github.com/ory/fosite"
   packages = [".","compose","handler/oauth2","handler/openid","storage","token/hmac","token/jwt"]
-  revision = "83136a3ed5ed99b3a525f0ad87d693eadf273e8a"
-  version = "v0.13.1"
+  revision = "8d35b668079db8642ede3b1d345d74692926515f"
+  version = "v0.14.1"
 
 [[projects]]
   name = "github.com/ory/graceful"
@@ -435,6 +435,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "686483967cc06c41b139bcfa515d4c5bbf226da7a489c09664bc75441951bb2a"
+  inputs-digest = "a5af1928bdfc4abe289c26c8b2c8c5b9ef016fff070b1167b31e29eda4d065ac"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,7 +75,7 @@
 
 [[constraint]]
   name = "github.com/ory/fosite"
-  version = "0.13.1"
+  version = "0.14.1"
 
 [[constraint]]
   name = "github.com/ory/graceful"

--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -147,6 +147,8 @@ func newOAuth2Handler(c *config.Config, router *httprouter.Router, cm oauth2.Con
 		CookieStore:         sessions.NewCookieStore(c.GetCookieSecret()),
 		Issuer:              c.Issuer,
 		L:                   c.GetLogger(),
+		W:                   c.Context().Warden,
+		ResourcePrefix:      c.AccessControlResourcePrefix,
 	}
 
 	handler.SetRoutes(router)

--- a/compose/firewall.go
+++ b/compose/firewall.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ory/fosite"
 	foauth2 "github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/storage"
 	"github.com/ory/hydra/firewall"
 	. "github.com/ory/hydra/oauth2"
 	"github.com/ory/hydra/pkg"
@@ -31,9 +32,13 @@ import (
 )
 
 func NewMockFirewall(issuer string, subject string, scopes fosite.Arguments, p ...ladon.Policy) (firewall.Firewall, *http.Client) {
+	return NewMockFirewallWithStore(issuer, subject, scopes, pkg.FositeStore(), p...)
+}
+
+func NewMockFirewallWithStore(issuer string, subject string, scopes fosite.Arguments, storage *storage.MemoryStore, p ...ladon.Policy) (firewall.Firewall, *http.Client) {
 	tokens := pkg.Tokens(1)
 
-	fositeStore := pkg.FositeStore()
+	fositeStore := storage
 	ps := map[string]ladon.Policy{}
 
 	for _, x := range p {

--- a/compose/firewall.go
+++ b/compose/firewall.go
@@ -46,6 +46,8 @@ func NewMockFirewall(issuer string, subject string, scopes fosite.Arguments, p .
 	fositeStore.CreateAccessTokenSession(nil, tokens[0][0], ar)
 
 	conf := &oauth2.Config{Scopes: scopes, Endpoint: oauth2.Endpoint{}}
+	l := logrus.New()
+	l.Level = logrus.DebugLevel
 
 	return &warden.LocalWarden{
 			Warden: ladonWarden,
@@ -63,7 +65,7 @@ func NewMockFirewall(issuer string, subject string, scopes fosite.Arguments, p .
 			Issuer:              issuer,
 			AccessTokenLifespan: time.Hour,
 			Groups:              group.NewMemoryManager(),
-			L:                   logrus.New(),
+			L:                   l,
 		}, conf.Client(oauth2.NoContext, &oauth2.Token{
 			AccessToken: tokens[0][1],
 			Expiry:      time.Now().Add(time.Hour),

--- a/docs/api.swagger.json
+++ b/docs/api.swagger.json
@@ -1014,7 +1014,7 @@
     },
     "/oauth2/introspect": {
       "post": {
-        "description": "The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token\nis neither expired nor revoked. If a token is active, additional information on the token will be included. You can\nset additional data for a token by setting `accessTokenExtra` during the consent flow.",
+        "description": "The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token\nis neither expired nor revoked. If a token is active, additional information on the token will be included. You can\nset additional data for a token by setting `accessTokenExtra` during the consent flow.\n\n```\n{\n\"resources\": [\"rn:hydra:oauth2:tokens\"],\n\"actions\": [\"introspect\"],\n\"effect\": \"allow\"\n}\n```",
         "consumes": [
           "application/x-www-form-urlencoded"
         ],
@@ -1035,7 +1035,9 @@
             "basic": []
           },
           {
-            "oauth2": []
+            "oauth2": [
+              "hydra.introspect"
+            ]
           }
         ],
         "parameters": [
@@ -1847,8 +1849,6 @@
         },
         "expiresAt": {
           "description": "ExpiresAt is the time where the access request will expire.",
-          "type": "string",
-          "format": "date-time",
           "x-go-name": "ExpiresAt"
         },
         "id": {
@@ -1895,8 +1895,6 @@
         },
         "expiresAt": {
           "description": "ExpiresAt is the expiry timestamp.",
-          "type": "string",
-          "format": "date-time",
           "x-go-name": "ExpiresAt"
         },
         "grantedScopes": {
@@ -1909,8 +1907,6 @@
         },
         "issuedAt": {
           "description": "IssuedAt is the token creation time stamp.",
-          "type": "string",
-          "format": "date-time",
           "x-go-name": "IssuedAt"
         },
         "issuer": {
@@ -1934,17 +1930,26 @@
     "Handler": {
       "type": "object",
       "properties": {
+        "Generators": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/KeyGenerator"
+          }
+        },
         "H": {
           "$ref": "#/definitions/Writer"
         },
         "Manager": {
           "$ref": "#/definitions/Manager"
         },
+        "ResourcePrefix": {
+          "type": "string"
+        },
         "W": {
           "$ref": "#/definitions/Firewall"
         }
       },
-      "x-go-package": "github.com/ory/hydra/warden/group"
+      "x-go-package": "github.com/ory/hydra/jwk"
     },
     "KeyGenerator": {
       "type": "object",

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/julienschmidt/httprouter"
-	pkg2 "github.com/ory/common/pkg"
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/firewall"
 	"github.com/ory/hydra/pkg"
@@ -225,7 +224,7 @@ func (h *Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request, _ ht
 			return
 		}
 	} else {
-		h.H.WriteError(w, r, errors.WithStack(pkg2.ErrUnauthorized))
+		h.H.WriteError(w, r, errors.WithStack(fosite.ErrRequestUnauthorized))
 		return
 	}
 

--- a/oauth2/handler_struct.go
+++ b/oauth2/handler_struct.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/ory/fosite"
 	"github.com/ory/herodot"
+	"github.com/ory/hydra/firewall"
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,4 +42,20 @@ type Handler struct {
 	ScopeStrategy fosite.ScopeStrategy
 
 	Issuer string
+
+	W firewall.Firewall
+
+	ResourcePrefix string
+}
+
+func (h *Handler) PrefixResource(resource string) string {
+	if h.ResourcePrefix == "" {
+		h.ResourcePrefix = "rn:hydra"
+	}
+
+	if h.ResourcePrefix[len(h.ResourcePrefix)-1] == ':' {
+		h.ResourcePrefix = h.ResourcePrefix[:len(h.ResourcePrefix)-1]
+	}
+
+	return h.ResourcePrefix + ":" + resource
 }

--- a/sdk/go/hydra/swagger/consent_request.go
+++ b/sdk/go/hydra/swagger/consent_request.go
@@ -10,17 +10,10 @@
 
 package swagger
 
-import (
-	"time"
-)
-
 type ConsentRequest struct {
 
 	// ClientID is the client id that initiated the OAuth2 request.
 	ClientId string `json:"clientId,omitempty"`
-
-	// ExpiresAt is the time where the access request will expire.
-	ExpiresAt time.Time `json:"expiresAt,omitempty"`
 
 	// ID is the id of this consent request.
 	Id string `json:"id,omitempty"`

--- a/sdk/go/hydra/swagger/context.go
+++ b/sdk/go/hydra/swagger/context.go
@@ -10,10 +10,6 @@
 
 package swagger
 
-import (
-	"time"
-)
-
 // Context contains an access token's session data
 type Context struct {
 
@@ -23,14 +19,8 @@ type Context struct {
 	// ClientID is id of the client the token was issued for..
 	ClientId string `json:"clientId,omitempty"`
 
-	// ExpiresAt is the expiry timestamp.
-	ExpiresAt time.Time `json:"expiresAt,omitempty"`
-
 	// GrantedScopes is a list of scopes that the subject authorized when asked for consent.
 	GrantedScopes []string `json:"grantedScopes,omitempty"`
-
-	// IssuedAt is the token creation time stamp.
-	IssuedAt time.Time `json:"issuedAt,omitempty"`
 
 	// Issuer is the id of the issuer, typically an hydra instance.
 	Issuer string `json:"issuer,omitempty"`

--- a/sdk/go/hydra/swagger/docs/ConsentRequest.md
+++ b/sdk/go/hydra/swagger/docs/ConsentRequest.md
@@ -4,7 +4,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClientId** | **string** | ClientID is the client id that initiated the OAuth2 request. | [optional] [default to null]
-**ExpiresAt** | [**time.Time**](time.Time.md) | ExpiresAt is the time where the access request will expire. | [optional] [default to null]
 **Id** | **string** | ID is the id of this consent request. | [optional] [default to null]
 **RedirectUrl** | **string** | Redirect URL is the URL where the user agent should be redirected to after the consent has been accepted or rejected. | [optional] [default to null]
 **RequestedScopes** | **[]string** | RequestedScopes represents a list of scopes that have been requested by the OAuth2 request initiator. | [optional] [default to null]

--- a/sdk/go/hydra/swagger/docs/Context.md
+++ b/sdk/go/hydra/swagger/docs/Context.md
@@ -5,9 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **AccessTokenExtra** | [**map[string]interface{}**](interface{}.md) | Extra represents arbitrary session data. | [optional] [default to null]
 **ClientId** | **string** | ClientID is id of the client the token was issued for.. | [optional] [default to null]
-**ExpiresAt** | [**time.Time**](time.Time.md) | ExpiresAt is the expiry timestamp. | [optional] [default to null]
 **GrantedScopes** | **[]string** | GrantedScopes is a list of scopes that the subject authorized when asked for consent. | [optional] [default to null]
-**IssuedAt** | [**time.Time**](time.Time.md) | IssuedAt is the token creation time stamp. | [optional] [default to null]
 **Issuer** | **string** | Issuer is the id of the issuer, typically an hydra instance. | [optional] [default to null]
 **Subject** | **string** | Subject is the identity that authorized issuing the token, for example a user or an OAuth2 app. This is usually a uuid but you can choose a urn or some other id too. | [optional] [default to null]
 

--- a/sdk/go/hydra/swagger/docs/Handler.md
+++ b/sdk/go/hydra/swagger/docs/Handler.md
@@ -3,8 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Generators** | [**map[string]KeyGenerator**](KeyGenerator.md) |  | [optional] [default to null]
 **H** | [**Writer**](Writer.md) |  | [optional] [default to null]
 **Manager** | [**Manager**](Manager.md) |  | [optional] [default to null]
+**ResourcePrefix** | **string** |  | [optional] [default to null]
 **W** | [**Firewall**](Firewall.md) |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/sdk/go/hydra/swagger/docs/OAuth2Api.md
+++ b/sdk/go/hydra/swagger/docs/OAuth2Api.md
@@ -197,7 +197,7 @@ No authorization required
 
 Introspect OAuth2 tokens
 
-The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting `accessTokenExtra` during the consent flow.
+The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting `accessTokenExtra` during the consent flow.  ``` { \"resources\": [\"rn:hydra:oauth2:tokens\"], \"actions\": [\"introspect\"], \"effect\": \"allow\" } ```
 
 
 ### Parameters

--- a/sdk/go/hydra/swagger/handler.go
+++ b/sdk/go/hydra/swagger/handler.go
@@ -11,9 +11,13 @@
 package swagger
 
 type Handler struct {
+	Generators map[string]KeyGenerator `json:"Generators,omitempty"`
+
 	H Writer `json:"H,omitempty"`
 
 	Manager Manager `json:"Manager,omitempty"`
+
+	ResourcePrefix string `json:"ResourcePrefix,omitempty"`
 
 	W Firewall `json:"W,omitempty"`
 }

--- a/sdk/go/hydra/swagger/o_auth2_api.go
+++ b/sdk/go/hydra/swagger/o_auth2_api.go
@@ -428,7 +428,7 @@ func (a OAuth2Api) GetWellKnown() (*WellKnown, *APIResponse, error) {
 
 /**
  * Introspect OAuth2 tokens
- * The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting &#x60;accessTokenExtra&#x60; during the consent flow.
+ * The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting &#x60;accessTokenExtra&#x60; during the consent flow.  &#x60;&#x60;&#x60; { \&quot;resources\&quot;: [\&quot;rn:hydra:oauth2:tokens\&quot;], \&quot;actions\&quot;: [\&quot;introspect\&quot;], \&quot;effect\&quot;: \&quot;allow\&quot; } &#x60;&#x60;&#x60;
  *
  * @param token The string value of the token. For access tokens, this is the \&quot;access_token\&quot; value returned from the token endpoint defined in OAuth 2.0 [RFC6749], Section 5.1. This endpoint DOES NOT accept refresh tokens for validation.
  * @param scope An optional, space separated list of required scopes. If the access token was not granted one of the scopes, the result of active will be false.

--- a/sdk/js/swagger/docs/ConsentRequest.md
+++ b/sdk/js/swagger/docs/ConsentRequest.md
@@ -4,7 +4,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **clientId** | **String** | ClientID is the client id that initiated the OAuth2 request. | [optional] 
-**expiresAt** | **Date** | ExpiresAt is the time where the access request will expire. | [optional] 
 **id** | **String** | ID is the id of this consent request. | [optional] 
 **redirectUrl** | **String** | Redirect URL is the URL where the user agent should be redirected to after the consent has been accepted or rejected. | [optional] 
 **requestedScopes** | **[String]** | RequestedScopes represents a list of scopes that have been requested by the OAuth2 request initiator. | [optional] 

--- a/sdk/js/swagger/docs/Context.md
+++ b/sdk/js/swagger/docs/Context.md
@@ -5,9 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **accessTokenExtra** | **{String: Object}** | Extra represents arbitrary session data. | [optional] 
 **clientId** | **String** | ClientID is id of the client the token was issued for.. | [optional] 
-**expiresAt** | **Date** | ExpiresAt is the expiry timestamp. | [optional] 
 **grantedScopes** | **[String]** | GrantedScopes is a list of scopes that the subject authorized when asked for consent. | [optional] 
-**issuedAt** | **Date** | IssuedAt is the token creation time stamp. | [optional] 
 **issuer** | **String** | Issuer is the id of the issuer, typically an hydra instance. | [optional] 
 **subject** | **String** | Subject is the identity that authorized issuing the token, for example a user or an OAuth2 app. This is usually a uuid but you can choose a urn or some other id too. | [optional] 
 

--- a/sdk/js/swagger/docs/Handler.md
+++ b/sdk/js/swagger/docs/Handler.md
@@ -3,8 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**generators** | [**{String: KeyGenerator}**](KeyGenerator.md) |  | [optional] 
 **H** | [**Writer**](Writer.md) |  | [optional] 
 **manager** | [**Manager**](Manager.md) |  | [optional] 
+**resourcePrefix** | **String** |  | [optional] 
 **W** | [**Firewall**](Firewall.md) |  | [optional] 
 
 

--- a/sdk/js/swagger/docs/OAuth2Api.md
+++ b/sdk/js/swagger/docs/OAuth2Api.md
@@ -324,7 +324,7 @@ No authorization required
 
 Introspect OAuth2 tokens
 
-The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting &#x60;accessTokenExtra&#x60; during the consent flow.
+The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting &#x60;accessTokenExtra&#x60; during the consent flow.  &#x60;&#x60;&#x60; { \&quot;resources\&quot;: [\&quot;rn:hydra:oauth2:tokens\&quot;], \&quot;actions\&quot;: [\&quot;introspect\&quot;], \&quot;effect\&quot;: \&quot;allow\&quot; } &#x60;&#x60;&#x60;
 
 ### Example
 ```javascript

--- a/sdk/js/swagger/src/api/OAuth2Api.js
+++ b/sdk/js/swagger/src/api/OAuth2Api.js
@@ -419,7 +419,7 @@
 
     /**
      * Introspect OAuth2 tokens
-     * The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting &#x60;accessTokenExtra&#x60; during the consent flow.
+     * The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting &#x60;accessTokenExtra&#x60; during the consent flow.  &#x60;&#x60;&#x60; { \&quot;resources\&quot;: [\&quot;rn:hydra:oauth2:tokens\&quot;], \&quot;actions\&quot;: [\&quot;introspect\&quot;], \&quot;effect\&quot;: \&quot;allow\&quot; } &#x60;&#x60;&#x60;
      * @param {String} token The string value of the token. For access tokens, this is the \&quot;access_token\&quot; value returned from the token endpoint defined in OAuth 2.0 [RFC6749], Section 5.1. This endpoint DOES NOT accept refresh tokens for validation.
      * @param {Object} opts Optional parameters
      * @param {String} opts.scope An optional, space separated list of required scopes. If the access token was not granted one of the scopes, the result of active will be false.

--- a/sdk/js/swagger/src/model/ConsentRequest.js
+++ b/sdk/js/swagger/src/model/ConsentRequest.js
@@ -62,9 +62,6 @@
       if (data.hasOwnProperty('clientId')) {
         obj['clientId'] = ApiClient.convertToType(data['clientId'], 'String')
       }
-      if (data.hasOwnProperty('expiresAt')) {
-        obj['expiresAt'] = ApiClient.convertToType(data['expiresAt'], 'Date')
-      }
       if (data.hasOwnProperty('id')) {
         obj['id'] = ApiClient.convertToType(data['id'], 'String')
       }
@@ -89,11 +86,6 @@
    * @member {String} clientId
    */
   exports.prototype['clientId'] = undefined
-  /**
-   * ExpiresAt is the time where the access request will expire.
-   * @member {Date} expiresAt
-   */
-  exports.prototype['expiresAt'] = undefined
   /**
    * ID is the id of this consent request.
    * @member {String} id

--- a/sdk/js/swagger/src/model/Context.js
+++ b/sdk/js/swagger/src/model/Context.js
@@ -69,16 +69,10 @@
       if (data.hasOwnProperty('clientId')) {
         obj['clientId'] = ApiClient.convertToType(data['clientId'], 'String')
       }
-      if (data.hasOwnProperty('expiresAt')) {
-        obj['expiresAt'] = ApiClient.convertToType(data['expiresAt'], 'Date')
-      }
       if (data.hasOwnProperty('grantedScopes')) {
         obj['grantedScopes'] = ApiClient.convertToType(data['grantedScopes'], [
           'String'
         ])
-      }
-      if (data.hasOwnProperty('issuedAt')) {
-        obj['issuedAt'] = ApiClient.convertToType(data['issuedAt'], 'Date')
       }
       if (data.hasOwnProperty('issuer')) {
         obj['issuer'] = ApiClient.convertToType(data['issuer'], 'String')
@@ -101,20 +95,10 @@
    */
   exports.prototype['clientId'] = undefined
   /**
-   * ExpiresAt is the expiry timestamp.
-   * @member {Date} expiresAt
-   */
-  exports.prototype['expiresAt'] = undefined
-  /**
    * GrantedScopes is a list of scopes that the subject authorized when asked for consent.
    * @member {Array.<String>} grantedScopes
    */
   exports.prototype['grantedScopes'] = undefined
-  /**
-   * IssuedAt is the token creation time stamp.
-   * @member {Date} issuedAt
-   */
-  exports.prototype['issuedAt'] = undefined
   /**
    * Issuer is the id of the issuer, typically an hydra instance.
    * @member {String} issuer

--- a/sdk/js/swagger/src/model/Handler.js
+++ b/sdk/js/swagger/src/model/Handler.js
@@ -18,7 +18,13 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(
-      ['ApiClient', 'model/Firewall', 'model/Manager', 'model/Writer'],
+      [
+        'ApiClient',
+        'model/Firewall',
+        'model/KeyGenerator',
+        'model/Manager',
+        'model/Writer'
+      ],
       factory
     )
   } else if (typeof module === 'object' && module.exports) {
@@ -26,6 +32,7 @@
     module.exports = factory(
       require('../ApiClient'),
       require('./Firewall'),
+      require('./KeyGenerator'),
       require('./Manager'),
       require('./Writer')
     )
@@ -37,11 +44,12 @@
     root.HydraOAuth2OpenIdConnectServer.Handler = factory(
       root.HydraOAuth2OpenIdConnectServer.ApiClient,
       root.HydraOAuth2OpenIdConnectServer.Firewall,
+      root.HydraOAuth2OpenIdConnectServer.KeyGenerator,
       root.HydraOAuth2OpenIdConnectServer.Manager,
       root.HydraOAuth2OpenIdConnectServer.Writer
     )
   }
-})(this, function(ApiClient, Firewall, Manager, Writer) {
+})(this, function(ApiClient, Firewall, KeyGenerator, Manager, Writer) {
   'use strict'
 
   /**
@@ -70,11 +78,22 @@
     if (data) {
       obj = obj || new exports()
 
+      if (data.hasOwnProperty('Generators')) {
+        obj['Generators'] = ApiClient.convertToType(data['Generators'], {
+          String: KeyGenerator
+        })
+      }
       if (data.hasOwnProperty('H')) {
         obj['H'] = Writer.constructFromObject(data['H'])
       }
       if (data.hasOwnProperty('Manager')) {
         obj['Manager'] = Manager.constructFromObject(data['Manager'])
+      }
+      if (data.hasOwnProperty('ResourcePrefix')) {
+        obj['ResourcePrefix'] = ApiClient.convertToType(
+          data['ResourcePrefix'],
+          'String'
+        )
       }
       if (data.hasOwnProperty('W')) {
         obj['W'] = Firewall.constructFromObject(data['W'])
@@ -84,6 +103,10 @@
   }
 
   /**
+   * @member {Object.<String, module:model/KeyGenerator>} Generators
+   */
+  exports.prototype['Generators'] = undefined
+  /**
    * @member {module:model/Writer} H
    */
   exports.prototype['H'] = undefined
@@ -91,6 +114,10 @@
    * @member {module:model/Manager} Manager
    */
   exports.prototype['Manager'] = undefined
+  /**
+   * @member {String} ResourcePrefix
+   */
+  exports.prototype['ResourcePrefix'] = undefined
   /**
    * @member {module:model/Firewall} W
    */


### PR DESCRIPTION
From now on, requests introspecting tokens require the client making the request (as identified by the Authorization header) to be allowed to access that endpoint. If an OAuth 2.0 token is given, the scope `hydra.introspect` is required additonally to a policy granting access to `rn:hydra:oauth2:tokens` with action `introspect`.