### PR TITLE
feat(default root client): enable overwriting redirect uris for the r…

### DIFF
--- a/cmd/host.go
+++ b/cmd/host.go
@@ -65,6 +65,12 @@ CORE CONTROLS
 	and the secret: "FORCE_ROOT_CLIENT_CREDENTIALS=urlencode(id):urlencode(secret)".
 	Example: FORCE_ROOT_CLIENT_CREDENTIALS=admin:h6hy92tK4dQcZ2EaFsGNRtqg
 
+- FORCE_ROOT_CLIENT_REDIRECT_URI: When generating the root client on first start up, it's redirect URI will be set to
+	"http://localhost:4445/callback". This can be overwritten using the "FORCE_ROOT_CLIENT_REDIRECT_URI" environment variable.
+	It comes in handy if you're developing against Hydra locally but behind a proxy like Traefik or Nginx.
+	Multiple URIs can also be set using commas between URIs.
+	Example: FORCE_ROOT_CLIENT_REDIRECT_URI=http://myapp.example/callback,http://localhost:9000/cb
+
 - PORT: The port hydra should listen on.
 	Defaults to PORT=4444
 

--- a/cmd/server/helper_client.go
+++ b/cmd/server/helper_client.go
@@ -59,6 +59,14 @@ func (h *Handler) createRootIfNewInstall(c *config.Config) {
 		}
 	}
 
+	// Overwrite the default redirect uri for the temporary root client.
+	// Comma seperated values are supported. No URL validation is done.
+	redirectURIs := []string{"http://localhost:4445/callback"}
+	forceRedirectURIs := os.Getenv("FORCE_ROOT_CLIENT_REDIRECT_URI")
+	if forceRedirectURIs != "" {
+		redirectURIs := strings.Split(forceRedirectURIs, ",")
+	}
+
 	c.GetLogger().Warn("No clients were found. Creating a temporary root client...")
 	root := &client.Client{
 		ID:            id,
@@ -66,7 +74,7 @@ func (h *Handler) createRootIfNewInstall(c *config.Config) {
 		ResponseTypes: []string{"id_token", "code", "token"},
 		GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 		Scope:         "hydra.* openid offline hydra",
-		RedirectURIs:  []string{"http://localhost:4445/callback"},
+		RedirectURIs:  redirectURIs,
 		Secret:        secret,
 	}
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -86,6 +86,7 @@ $ docker run -d \
   -e ISSUER=https://localhost:9000/ \
   -e CONSENT_URL=http://localhost:9020/consent \
   -e FORCE_ROOT_CLIENT_CREDENTIALS=admin:demo-password \
+  -e FORCE_ROOT_CLIENT_REDIRECT_URI=http://myapp.example/callback` \
   oryd/hydra:v0.10.0
 
 # And check if it's running:
@@ -109,6 +110,9 @@ app in the following sections **(required)**.
 * `-e FORCE_ROOT_CLIENT_CREDENTIALS=admin:demo-password` sets the credentials of the root account. Use the root
 account to manage your ORY Hydra instance. If this is not set, ORY Hydra will auto-generate a client and display
 the credentials in the logs **(optional)**.
+* `-e FORCE_ROOT_CLIENT_REDIRECT_URI=http://myapp.example/callback` sets the redirect URI of the root account.
+If you want to set multiple URLs you can separate them using commas.
+If this is not set, it will default to `http://localhost:4445/callback`. **(optional)**.
 
 To confirm that the instance is running properly, [open the health check](https://localhost:9000/health/status). If asked,
 accept the self signed certificate in your browser. You should simply see `ok`.
@@ -137,7 +141,8 @@ Note this down, otherwise you won't be able to restart Hydra.
 using a self-signed certificate, which is why we need to run all commands using --skip-tls-verify.
 3. If the OAuth 2.0 Client database table is empty, a new root client with random credentials is created. Root clients
 have access to all APIs, OAuth 2.0 flows and are allowed to do everything. If the `FORCE_ROOT_CLIENT_CREDENTIALS` environment.
-is set, those credentials will be used instead.
+is set, those credentials will be used instead. Additionally by using `FORCE_ROOT_CLIENT_REDIRECT_URI` the redirect URI can be set.
+Multiple URIs can be set by separating them with commas.
 
 ORY Hydra can be managed using the Hydra Command Line Interface (CLI), which is using ORY Hydra's REST APIs. To
 see the available commands, run:

--- a/docs/install.md
+++ b/docs/install.md
@@ -86,7 +86,7 @@ $ docker run -d \
   -e ISSUER=https://localhost:9000/ \
   -e CONSENT_URL=http://localhost:9020/consent \
   -e FORCE_ROOT_CLIENT_CREDENTIALS=admin:demo-password \
-  -e FORCE_ROOT_CLIENT_REDIRECT_URI=http://myapp.example/callback` \
+  -e FORCE_ROOT_CLIENT_REDIRECT_URI=http://myapp.example/callback \
   oryd/hydra:v0.10.0
 
 # And check if it's running:


### PR DESCRIPTION
…oot client

Just like `FORCE_ROOT_CLIENT_CREDENTIALS`, `FORCE_ROOT_CLIENT_REDIRECT_URI` will set the redirect uris for the root client.

closes #699 
