### PR TITLE
sdk: Resolves composer license complaint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "api"
   ],
   "homepage": "https://github.com/ory/hydra",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "authors": [],
   "require": {
     "php": ">=5.4",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "api"
   ],
   "homepage": "https://github.com/ory/hydra",
-  "license": "Apache 2.0",
+  "license": "Apache License 2.0",
   "authors": [],
   "require": {
     "php": ">=5.4",


### PR DESCRIPTION
Composer complained because an unknown license was used "Apache 2.0" instead of "Apache License 2.0". This patch resolves that.