### PR TITLE
client: do not show/send secret when client is public

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -148,7 +148,12 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 		return
 	}
 
-	c.Secret = secret
+	c.Secret = ""
+
+	if !c.Public {
+		c.Secret = secret
+	}
+
 	h.H.WriteCreated(w, r, ClientsHandlerPath+"/"+c.GetID(), &c)
 }
 

--- a/client/sdk_test.go
+++ b/client/sdk_test.go
@@ -71,7 +71,7 @@ func TestClientSDK(t *testing.T) {
 	c := hydra.NewOAuth2ApiWithBasePath(server.URL)
 	c.Configuration.Transport = httpClient.Transport
 
-	t.Run("client is created and updated", func(t *testing.T) {
+	t.Run("case=client is created and updated", func(t *testing.T) {
 		createClient := createTestClient("")
 
 		result, _, err := c.CreateOAuth2Client(createClient)
@@ -107,7 +107,7 @@ func TestClientSDK(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, response.StatusCode)
 	})
 
-	t.Run("public client is transmitted without secret", func(t *testing.T) {
+	t.Run("case=public client is transmitted without secret", func(t *testing.T) {
 		result, _, err := c.CreateOAuth2Client(hydra.OAuth2Client{
 			Public: true,
 		})

--- a/client/sdk_test.go
+++ b/client/sdk_test.go
@@ -71,7 +71,7 @@ func TestClientSDK(t *testing.T) {
 	c := hydra.NewOAuth2ApiWithBasePath(server.URL)
 	c.Configuration.Transport = httpClient.Transport
 
-	t.Run("foo", func(t *testing.T) {
+	t.Run("client is created and updated", func(t *testing.T) {
 		createClient := createTestClient("")
 
 		result, _, err := c.CreateOAuth2Client(createClient)
@@ -105,5 +105,19 @@ func TestClientSDK(t *testing.T) {
 		_, response, err := c.GetOAuth2Client(updateClient.Id)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	})
+
+	t.Run("public client is transmitted without secret", func(t *testing.T) {
+		result, _, err := c.CreateOAuth2Client(hydra.OAuth2Client{
+			Public: true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "", result.ClientSecret)
+
+		result, _, err = c.CreateOAuth2Client(createTestClient(""))
+
+		require.NoError(t, err)
+		assert.NotEqual(t, "", result.ClientSecret)
 	})
 }

--- a/cmd/cli/handler_client.go
+++ b/cmd/cli/handler_client.go
@@ -106,7 +106,12 @@ func (h *ClientHandler) CreateClient(cmd *cobra.Command, args []string) {
 	checkResponse(response, err, http.StatusCreated)
 
 	fmt.Printf("OAuth2 client id: %s\n", result.Id)
-	fmt.Printf("OAuth2 client secret: %s\n", result.ClientSecret)
+
+	if result.ClientSecret == "" {
+		fmt.Println("This client has no secret.")
+	} else {
+		fmt.Printf("OAuth2 client secret: %s\n", result.ClientSecret)
+	}
 }
 
 func (h *ClientHandler) DeleteClient(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Previously a newly created public client had a secret send with the initial response and this secret was displayed in the CLI.
Now it is clear that there is no secret needed for public clients. It is not displayed in the CLI anymore.

closes #737 