### PR TITLE
client: Introduces pagination to client management

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -40,6 +40,18 @@ type swaggerUpdateClientPayload struct {
 	Body Client
 }
 
+// swagger:parameters listOAuth2Clients
+type swaggerListClientsParameter struct {
+
+	// The maximum amount of policies returned.
+	// in: query
+	Limit int `json:"limit"`
+
+	// The offset from where to start looking.
+	// in: query
+	Offset int `json:"offset"`
+}
+
 // A list of clients.
 // swagger:response oAuth2ClientList
 type swaggerListClientsResult struct {

--- a/client/handler.go
+++ b/client/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ory/hydra/firewall"
 	"github.com/ory/hydra/rand/sequence"
 	"github.com/ory/ladon"
+	"github.com/ory/pagination"
 	"github.com/pkg/errors"
 )
 
@@ -290,7 +291,8 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		return
 	}
 
-	c, err := h.Manager.GetClients()
+	limit, offset := pagination.Parse(r, 100, 0, 500)
+	c, err := h.Manager.GetClients(limit, offset)
 	if err != nil {
 		h.H.WriteError(w, r, err)
 		return

--- a/client/manager.go
+++ b/client/manager.go
@@ -33,7 +33,7 @@ type Storage interface {
 
 	DeleteClient(id string) error
 
-	GetClients() (map[string]Client, error)
+	GetClients(limit, offset int) (map[string]Client, error)
 
 	GetConcreteClient(id string) (*Client, error)
 }

--- a/client/manager_memory.go
+++ b/client/manager_memory.go
@@ -21,12 +21,13 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/pkg"
+	"github.com/ory/pagination"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 )
 
 type MemoryManager struct {
-	Clients map[string]Client
+	Clients []Client
 	Hasher  fosite.Hasher
 	sync.RWMutex
 }
@@ -37,7 +38,7 @@ func NewMemoryManager(hasher fosite.Hasher) *MemoryManager {
 	}
 
 	return &MemoryManager{
-		Clients: map[string]Client{},
+		Clients: []Client{},
 		Hasher:  hasher,
 	}
 }
@@ -46,11 +47,13 @@ func (m *MemoryManager) GetConcreteClient(id string) (*Client, error) {
 	m.RLock()
 	defer m.RUnlock()
 
-	c, ok := m.Clients[id]
-	if !ok {
-		return nil, errors.Wrap(pkg.ErrNotFound, "")
+	for _, c := range m.Clients {
+		if c.GetID() == id {
+			return &c, nil
+		}
 	}
-	return &c, nil
+
+	return nil, errors.Wrap(pkg.ErrNotFound, "")
 }
 
 func (m *MemoryManager) GetClient(_ context.Context, id string) (fosite.Client, error) {
@@ -76,7 +79,14 @@ func (m *MemoryManager) UpdateClient(c *Client) error {
 		return errors.WithStack(err)
 	}
 
-	m.Clients[c.GetID()] = *c
+	m.Lock()
+	defer m.Unlock()
+	for k, f := range m.Clients {
+		if f.GetID() == c.ID {
+			m.Clients[k] = *c
+		}
+	}
+
 	return nil
 }
 
@@ -84,19 +94,23 @@ func (m *MemoryManager) Authenticate(id string, secret []byte) (*Client, error) 
 	m.RLock()
 	defer m.RUnlock()
 
-	c, ok := m.Clients[id]
-	if !ok {
-		return nil, errors.Wrap(pkg.ErrNotFound, "")
+	c, err := m.GetConcreteClient(id)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := m.Hasher.Compare(c.GetHashedSecret(), secret); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	return &c, nil
+	return c, nil
 }
 
 func (m *MemoryManager) CreateClient(c *Client) error {
+	if _, err := m.GetConcreteClient(c.ID); err == nil {
+		return errors.Errorf("Client %s already exists", c.ID)
+	}
+
 	m.Lock()
 	defer m.Unlock()
 
@@ -110,7 +124,7 @@ func (m *MemoryManager) CreateClient(c *Client) error {
 	}
 	c.Secret = string(hash)
 
-	m.Clients[c.GetID()] = *c
+	m.Clients = append(m.Clients, *c)
 	return nil
 }
 
@@ -118,15 +132,23 @@ func (m *MemoryManager) DeleteClient(id string) error {
 	m.Lock()
 	defer m.Unlock()
 
-	delete(m.Clients, id)
+	for k, f := range m.Clients {
+		if f.GetID() == id {
+			m.Clients = append(m.Clients[:k], m.Clients[k+1:]...)
+			return nil
+		}
+	}
+
 	return nil
 }
 
-func (m *MemoryManager) GetClients() (clients map[string]Client, err error) {
+func (m *MemoryManager) GetClients(limit, offset int) (clients map[string]Client, err error) {
 	m.RLock()
 	defer m.RUnlock()
 	clients = make(map[string]Client)
-	for _, c := range m.Clients {
+
+	start, end := pagination.Index(limit, offset, len(m.Clients))
+	for _, c := range m.Clients[start:end] {
 		clients[c.ID] = c
 	}
 

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -230,7 +230,7 @@ func (m *SQLManager) GetClients(limit, offset int) (clients map[string]Client, e
 	d := make([]sqlData, 0)
 	clients = make(map[string]Client)
 
-	if err := m.DB.Select(&d, "SELECT * FROM hydra_client ORDER BY id LIMIT ? OFFSET ?", limit, offset); err != nil {
+	if err := m.DB.Select(&d, m.DB.Rebind("SELECT * FROM hydra_client ORDER BY id LIMIT ? OFFSET ?"), limit, offset); err != nil {
 		return nil, errors.WithStack(err)
 	}
 

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -226,11 +226,11 @@ func (m *SQLManager) DeleteClient(id string) error {
 	return nil
 }
 
-func (m *SQLManager) GetClients() (clients map[string]Client, err error) {
-	var d = []sqlData{}
+func (m *SQLManager) GetClients(limit, offset int) (clients map[string]Client, err error) {
+	d := make([]sqlData, 0)
 	clients = make(map[string]Client)
 
-	if err := m.DB.Select(&d, "SELECT * FROM hydra_client"); err != nil {
+	if err := m.DB.Select(&d, "SELECT * FROM hydra_client ORDER BY id LIMIT ? OFFSET ?", limit, offset); err != nil {
 		return nil, errors.WithStack(err)
 	}
 

--- a/client/manager_test.go
+++ b/client/manager_test.go
@@ -29,10 +29,7 @@ import (
 var clientManagers = map[string]Manager{}
 
 func init() {
-	clientManagers["memory"] = &MemoryManager{
-		Clients: map[string]Client{},
-		Hasher:  &fosite.BCrypt{},
-	}
+	clientManagers["memory"] = NewMemoryManager(&fosite.BCrypt{})
 }
 
 func TestMain(m *testing.M) {

--- a/client/manager_test_helpers.go
+++ b/client/manager_test_helpers.go
@@ -88,10 +88,18 @@ func TestHelperCreateGetDeleteClient(k string, m Storage) func(t *testing.T) {
 			compare(t, d, k)
 		}
 
-		ds, err := m.GetClients()
+		ds, err := m.GetClients(100, 0)
 		assert.NoError(t, err)
 		assert.Len(t, ds, 2)
 		assert.NotEqual(t, ds["1234"].ID, ds["2-1234"].ID)
+
+		ds, err = m.GetClients(1, 0)
+		assert.NoError(t, err)
+		assert.Len(t, ds, 1)
+
+		ds, err = m.GetClients(100, 100)
+		assert.NoError(t, err)
+		assert.Len(t, ds, 0)
 
 		err = m.UpdateClient(&Client{
 			ID:                "2-1234",

--- a/client/sdk_test.go
+++ b/client/sdk_test.go
@@ -83,7 +83,7 @@ func TestClientSDK(t *testing.T) {
 		result, _, err = c.GetOAuth2Client(createClient.Id)
 		assert.EqualValues(t, compareClient, *result)
 
-		results, _, err := c.ListOAuth2Clients()
+		results, _, err := c.ListOAuth2Clients(100, 0)
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
 		assert.EqualValues(t, compareClient, results[0])

--- a/cmd/server/handler_client_factory.go
+++ b/cmd/server/handler_client_factory.go
@@ -26,10 +26,7 @@ func newClientManager(c *config.Config) client.Manager {
 
 	switch con := ctx.Connection.(type) {
 	case *config.MemoryConnection:
-		return &client.MemoryManager{
-			Clients: map[string]client.Client{},
-			Hasher:  ctx.Hasher,
-		}
+		return client.NewMemoryManager(ctx.Hasher)
 	case *config.SQLConnection:
 		return &client.SQLManager{
 			DB:     con.GetDatabase(),

--- a/cmd/server/helper_client.go
+++ b/cmd/server/helper_client.go
@@ -29,7 +29,7 @@ import (
 func (h *Handler) createRootIfNewInstall(c *config.Config) {
 	ctx := c.Context()
 
-	clients, err := h.Clients.Manager.GetClients()
+	clients, err := h.Clients.Manager.GetClients(100, 0)
 	pkg.Must(err, "Could not fetch client list: %s", err)
 	if len(clients) != 0 {
 		return

--- a/docs/api.swagger.json
+++ b/docs/api.swagger.json
@@ -127,6 +127,24 @@
         ],
         "summary": "List OAuth 2.0 Clients",
         "operationId": "listOAuth2Clients",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int64",
+            "x-go-name": "Limit",
+            "description": "The maximum amount of policies returned.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "x-go-name": "Offset",
+            "description": "The offset from where to start looking.",
+            "name": "offset",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/oAuth2ClientList"

--- a/oauth2/fosite_store_test.go
+++ b/oauth2/fosite_store_test.go
@@ -31,7 +31,7 @@ import (
 
 var clientManagers = map[string]pkg.FositeStorer{}
 var clientManager = &client.MemoryManager{
-	Clients: map[string]client.Client{"foobar": {ID: "foobar"}},
+	Clients: []client.Client{{ID: "foobar"}},
 	Hasher:  &fosite.BCrypt{},
 }
 

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -38,10 +38,7 @@ import (
 var hasher = &fosite.BCrypt{}
 
 var store = &FositeMemoryStore{
-	Manager: &hc.MemoryManager{
-		Clients: map[string]hc.Client{},
-		Hasher:  hasher,
-	},
+	Manager:        hc.NewMemoryManager(hasher),
 	AuthorizeCodes: make(map[string]fosite.Requester),
 	IDSessions:     make(map[string]fosite.Requester),
 	AccessTokens:   make(map[string]fosite.Requester),
@@ -121,14 +118,14 @@ func init() {
 	c, _ := url.Parse(ts.URL + "/consent")
 	handler.ConsentURL = *c
 
-	store.Manager.(*hc.MemoryManager).Clients["app-client"] = hc.Client{
+	store.Manager.(*hc.MemoryManager).Clients = append(store.Manager.(*hc.MemoryManager).Clients, hc.Client{
 		ID:            "app-client",
 		Secret:        string(h),
 		RedirectURIs:  []string{ts.URL + "/callback"},
 		ResponseTypes: []string{"id_token", "code", "token"},
 		GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 		Scope:         "hydra.* offline openid",
-	}
+	})
 
 	oauthConfig = &oauth2.Config{
 		ClientID:     "app-client",

--- a/sdk/go/hydra/sdk_api.go
+++ b/sdk/go/hydra/sdk_api.go
@@ -149,7 +149,7 @@ type OAuth2API interface {
 	GetOAuth2ConsentRequest(id string) (*swagger.OAuth2ConsentRequest, *swagger.APIResponse, error)
 	GetWellKnown() (*swagger.WellKnown, *swagger.APIResponse, error)
 	IntrospectOAuth2Token(token string, scope string) (*swagger.OAuth2TokenIntrospection, *swagger.APIResponse, error)
-	ListOAuth2Clients() ([]swagger.OAuth2Client, *swagger.APIResponse, error)
+	ListOAuth2Clients(limit int64, offset int64) ([]swagger.OAuth2Client, *swagger.APIResponse, error)
 	RejectOAuth2ConsentRequest(id string, body swagger.ConsentRequestRejection) (*swagger.APIResponse, error)
 	RevokeOAuth2Token(token string) (*swagger.APIResponse, error)
 	UpdateOAuth2Client(id string, body swagger.OAuth2Client) (*swagger.OAuth2Client, *swagger.APIResponse, error)

--- a/sdk/go/hydra/swagger/docs/OAuth2Api.md
+++ b/sdk/go/hydra/swagger/docs/OAuth2Api.md
@@ -254,7 +254,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **ListOAuth2Clients**
-> []OAuth2Client ListOAuth2Clients()
+> []OAuth2Client ListOAuth2Clients($limit, $offset)
 
 List OAuth 2.0 Clients
 
@@ -262,7 +262,11 @@ This endpoint never returns passwords.   The subject making the request needs to
 
 
 ### Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **limit** | **int64**| The maximum amount of policies returned. | [optional] 
+ **offset** | **int64**| The offset from where to start looking. | [optional] 
 
 ### Return type
 

--- a/sdk/go/hydra/swagger/o_auth2_api.go
+++ b/sdk/go/hydra/swagger/o_auth2_api.go
@@ -573,9 +573,11 @@ func (a OAuth2Api) IntrospectOAuth2Token(token string, scope string) (*OAuth2Tok
  * List OAuth 2.0 Clients
  * This endpoint never returns passwords.   The subject making the request needs to be assigned to a policy containing:  &#x60;&#x60;&#x60; { \&quot;resources\&quot;: [\&quot;rn:hydra:clients\&quot;], \&quot;actions\&quot;: [\&quot;get\&quot;], \&quot;effect\&quot;: \&quot;allow\&quot; } &#x60;&#x60;&#x60;
  *
+ * @param limit The maximum amount of policies returned.
+ * @param offset The offset from where to start looking.
  * @return []OAuth2Client
  */
-func (a OAuth2Api) ListOAuth2Clients() ([]OAuth2Client, *APIResponse, error) {
+func (a OAuth2Api) ListOAuth2Clients(limit int64, offset int64) ([]OAuth2Client, *APIResponse, error) {
 
 	var localVarHttpMethod = strings.ToUpper("Get")
 	// create path and map variables
@@ -596,6 +598,8 @@ func (a OAuth2Api) ListOAuth2Clients() ([]OAuth2Client, *APIResponse, error) {
 	for key := range a.Configuration.DefaultHeader {
 		localVarHeaderParams[key] = a.Configuration.DefaultHeader[key]
 	}
+	localVarQueryParams.Add("limit", a.Configuration.APIClient.ParameterToString(limit, ""))
+	localVarQueryParams.Add("offset", a.Configuration.APIClient.ParameterToString(offset, ""))
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}

--- a/sdk/js/swagger/docs/OAuth2Api.md
+++ b/sdk/js/swagger/docs/OAuth2Api.md
@@ -439,7 +439,7 @@ Name | Type | Description  | Notes
 
 <a name="listOAuth2Clients"></a>
 # **listOAuth2Clients**
-> [OAuth2Client] listOAuth2Clients()
+> [OAuth2Client] listOAuth2Clients(opts)
 
 List OAuth 2.0 Clients
 
@@ -456,6 +456,11 @@ oauth2.accessToken = 'YOUR ACCESS TOKEN';
 
 var apiInstance = new HydraOAuth2OpenIdConnectServer.OAuth2Api();
 
+var opts = { 
+  'limit': 789, // Number | The maximum amount of policies returned.
+  'offset': 789 // Number | The offset from where to start looking.
+};
+
 var callback = function(error, data, response) {
   if (error) {
     console.error(error);
@@ -463,11 +468,15 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-apiInstance.listOAuth2Clients(callback);
+apiInstance.listOAuth2Clients(opts, callback);
 ```
 
 ### Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **limit** | **Number**| The maximum amount of policies returned. | [optional] 
+ **offset** | **Number**| The offset from where to start looking. | [optional] 
 
 ### Return type
 

--- a/sdk/js/swagger/src/api/OAuth2Api.js
+++ b/sdk/js/swagger/src/api/OAuth2Api.js
@@ -530,14 +530,21 @@
     /**
      * List OAuth 2.0 Clients
      * This endpoint never returns passwords.   The subject making the request needs to be assigned to a policy containing:  &#x60;&#x60;&#x60; { \&quot;resources\&quot;: [\&quot;rn:hydra:clients\&quot;], \&quot;actions\&quot;: [\&quot;get\&quot;], \&quot;effect\&quot;: \&quot;allow\&quot; } &#x60;&#x60;&#x60;
+     * @param {Object} opts Optional parameters
+     * @param {Number} opts.limit The maximum amount of policies returned.
+     * @param {Number} opts.offset The offset from where to start looking.
      * @param {module:api/OAuth2Api~listOAuth2ClientsCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link Array.<module:model/OAuth2Client>}
      */
-    this.listOAuth2Clients = function(callback) {
+    this.listOAuth2Clients = function(opts, callback) {
+      opts = opts || {}
       var postBody = null
 
       var pathParams = {}
-      var queryParams = {}
+      var queryParams = {
+        limit: opts['limit'],
+        offset: opts['offset']
+      }
       var headerParams = {}
       var formParams = {}
 

--- a/sdk/php/swagger/docs/Api/OAuth2Api.md
+++ b/sdk/php/swagger/docs/Api/OAuth2Api.md
@@ -408,7 +408,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **listOAuth2Clients**
-> \Hydra\SDK\Model\OAuth2Client[] listOAuth2Clients()
+> \Hydra\SDK\Model\OAuth2Client[] listOAuth2Clients($limit, $offset)
 
 List OAuth 2.0 Clients
 
@@ -423,9 +423,11 @@ require_once(__DIR__ . '/vendor/autoload.php');
 Hydra\SDK\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');
 
 $api_instance = new Hydra\SDK\Api\OAuth2Api();
+$limit = 789; // int | The maximum amount of policies returned.
+$offset = 789; // int | The offset from where to start looking.
 
 try {
-    $result = $api_instance->listOAuth2Clients();
+    $result = $api_instance->listOAuth2Clients($limit, $offset);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling OAuth2Api->listOAuth2Clients: ', $e->getMessage(), PHP_EOL;
@@ -434,7 +436,11 @@ try {
 ```
 
 ### Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **limit** | **int**| The maximum amount of policies returned. | [optional]
+ **offset** | **int**| The offset from where to start looking. | [optional]
 
 ### Return type
 

--- a/sdk/php/swagger/lib/Api/OAuth2Api.php
+++ b/sdk/php/swagger/lib/Api/OAuth2Api.php
@@ -871,12 +871,14 @@ class OAuth2Api
      *
      * Client for Hydra
      *
+     * @param int $limit The maximum amount of policies returned. (optional)
+     * @param int $offset The offset from where to start looking. (optional)
      * @throws \Hydra\SDK\ApiException on non-2xx response
      * @return \Hydra\SDK\Model\OAuth2Client[]
      */
-    public function listOAuth2Clients()
+    public function listOAuth2Clients($limit = null, $offset = null)
     {
-        list($response) = $this->listOAuth2ClientsWithHttpInfo();
+        list($response) = $this->listOAuth2ClientsWithHttpInfo($limit, $offset);
         return $response;
     }
 
@@ -887,10 +889,12 @@ class OAuth2Api
      *
      * Client for Hydra
      *
+     * @param int $limit The maximum amount of policies returned. (optional)
+     * @param int $offset The offset from where to start looking. (optional)
      * @throws \Hydra\SDK\ApiException on non-2xx response
      * @return array of \Hydra\SDK\Model\OAuth2Client[], HTTP status code, HTTP response headers (array of strings)
      */
-    public function listOAuth2ClientsWithHttpInfo()
+    public function listOAuth2ClientsWithHttpInfo($limit = null, $offset = null)
     {
         // parse inputs
         $resourcePath = "/clients";
@@ -904,6 +908,14 @@ class OAuth2Api
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
+        // query params
+        if ($limit !== null) {
+            $queryParams['limit'] = $this->apiClient->getSerializer()->toQueryValue($limit);
+        }
+        // query params
+        if ($offset !== null) {
+            $queryParams['offset'] = $this->apiClient->getSerializer()->toQueryValue($offset);
+        }
 
         // for model (json/xml)
         if (isset($_tempBody)) {


### PR DESCRIPTION
Previously, all clients were returned by `GET /clients`. To mitigate
DoS attacks against large databases, pagination has been introduced.

Closes #739
