### PR TITLE
Remove coveralls token from circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: go-acc -o coverage.txt ./...
       - run: go test -race -short $(go list ./... | grep -v cmd)
       - run: ./scripts/test-e2e.sh
-      - run: goveralls -service=circle-ci -coverprofile=coverage.txt -repotoken=$COVERALLS_REPO_TOKEN
+      - run: goveralls -service=circle-ci -coverprofile=coverage.txt
 
   swagger:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: go-acc -o coverage.txt ./...
       - run: go test -race -short $(go list ./... | grep -v cmd)
       - run: ./scripts/test-e2e.sh
-      - run: goveralls -service=circle-ci -coverprofile=coverage.txt
+      - run: [ -z "$CIRCLE_PR_NUMBER" ] && goveralls -service=circle-ci -coverprofile=coverage.txt -repotoken=$COVERALLS_REPO_TOKEN || echo "forks are not allowed to push to coveralls"
 
   swagger:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: go-acc -o coverage.txt ./...
       - run: go test -race -short $(go list ./... | grep -v cmd)
       - run: ./scripts/test-e2e.sh
-      - run: [ -z "$CIRCLE_PR_NUMBER" ] && goveralls -service=circle-ci -coverprofile=coverage.txt -repotoken=$COVERALLS_REPO_TOKEN || echo "forks are not allowed to push to coveralls"
+      - run: test -z "$CIRCLE_PR_NUMBER" && goveralls -service=circle-ci -coverprofile=coverage.txt -repotoken=$COVERALLS_REPO_TOKEN || echo "forks are not allowed to push to coveralls"
 
   swagger:
     docker:


### PR DESCRIPTION
Before forked PRs failed on circleci because $COVERALLS_REPO_TOKEN was not set. This token does seem not to be necessary at all because hydra is a public repository (see #782).
closes #782 