### PR TITLE
cmd: Adds OpenID Connect refresh handler

### DIFF
--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -96,6 +96,7 @@ func newOAuth2Provider(c *config.Config) (fosite.OAuth2Provider, string) {
 		compose.OpenIDConnectExplicitFactory,
 		compose.OpenIDConnectHybridFactory,
 		compose.OpenIDConnectImplicitFactory,
+		compose.OpenIDConnectRefreshFactory,
 		compose.OAuth2TokenRevocationFactory,
 		warden.OAuth2TokenIntrospectionFactory,
 	), publicKey.KeyID


### PR DESCRIPTION
Previously, it was impossible to refresh OpenID Connect ID Tokens. This is now possible as the factory has been added to the oauth2 factory in the host process.

Closes #794
