### PR TITLE
cmd: Resolves an issue with broken build time display

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,8 +21,6 @@ import (
 	"runtime"
 	"strings"
 
-	"time"
-
 	"github.com/ory/hydra/cmd/cli"
 	"github.com/ory/hydra/config"
 	"github.com/ory/hydra/oauth2"
@@ -34,7 +32,7 @@ var cfgFile string
 
 var (
 	Version   = "dev-master"
-	BuildTime = time.Now().UTC().String()
+	BuildTime = "undefined"
 	GitHash   = "undefined"
 )
 


### PR DESCRIPTION
Previously, the build time was always the current time. This patch
resolves that issue.

Closes #792