### PR TITLE
oauth2: Resolves client secrets from potentially leaking to the database in cleartext

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm"
+  ]
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
@@ -51,7 +54,33 @@
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonmessage","pkg/longpath","pkg/mount","pkg/pools","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/versions",
+    "opts",
+    "pkg/archive",
+    "pkg/fileutils",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/jsonmessage",
+    "pkg/longpath",
+    "pkg/mount",
+    "pkg/pools",
+    "pkg/stdcopy",
+    "pkg/system",
+    "pkg/term",
+    "pkg/term/windows"
+  ]
   revision = "fe8aac6f5ae413a967adb0adad0b54abdfb825c4"
 
 [[projects]]
@@ -129,13 +158,26 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/golang-lru"
-  packages = [".","simplelru"]
+  packages = [
+    ".",
+    "simplelru"
+  ]
   revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -153,7 +195,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/jmoiron/sqlx"
-  packages = [".","reflectx"]
+  packages = [
+    ".",
+    "reflectx"
+  ]
   revision = "3379e5993990b1f927fc8db926485e6f6becf2d2"
 
 [[projects]]
@@ -165,7 +210,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid"
+  ]
   revision = "b609790bd85edf8e9ab7e0f8912750a786177bcf"
 
 [[projects]]
@@ -206,13 +254,19 @@
 
 [[projects]]
   name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
+  packages = [
+    "specs-go",
+    "specs-go/v1"
+  ]
   revision = "ab7389ef9f50030c9b245bc16b981c7ddf192882"
   version = "v1.0.0"
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/system","libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user"
+  ]
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
@@ -224,9 +278,17 @@
 
 [[projects]]
   name = "github.com/ory/fosite"
-  packages = [".","compose","handler/oauth2","handler/openid","storage","token/hmac","token/jwt"]
+  packages = [
+    ".",
+    "compose",
+    "handler/oauth2",
+    "handler/openid",
+    "storage",
+    "token/hmac",
+    "token/jwt"
+  ]
   revision = "1ef3041c4da40d27ea25d56710e59d5f9352df5f"
-  version = "v0.16.1"
+  version = "v0.17.0"
 
 [[projects]]
   name = "github.com/ory/graceful"
@@ -242,7 +304,12 @@
 
 [[projects]]
   name = "github.com/ory/ladon"
-  packages = [".","compiler","manager/memory","manager/sql"]
+  packages = [
+    ".",
+    "compiler",
+    "manager/memory",
+    "manager/sql"
+  ]
   revision = "73217e44ed7e4a6bbd44ae7dd858d11932f08cf8"
   version = "v0.8.8"
 
@@ -291,7 +358,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/rubenv/sql-migrate"
-  packages = [".","sqlparse"]
+  packages = [
+    ".",
+    "sqlparse"
+  ]
   revision = "79fe99e24311fa42469fb2ca23eb3f8f065e6155"
 
 [[projects]]
@@ -315,7 +385,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "5660eeed305fe5f69c8fc6cf899132a459a97064"
 
 [[projects]]
@@ -350,13 +423,19 @@
 
 [[projects]]
   name = "github.com/square/go-jose"
-  packages = [".","json"]
+  packages = [
+    ".",
+    "json"
+  ]
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -381,36 +460,77 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish","ed25519","ed25519/internal/edwards25519","ssh/terminal"]
+  packages = [
+    "bcrypt",
+    "blowfish",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "ssh/terminal"
+  ]
   revision = "2509b142fb2b797aa7587dad548f113b2c0f20ce"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","idna","publicsuffix"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "idna",
+    "publicsuffix"
+  ]
   revision = "4b14673ba32bee7f5ac0f990a48f033919fd418b"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","clientcredentials","internal"]
+  packages = [
+    ".",
+    "clientcredentials",
+    "internal"
+  ]
   revision = "bb50c06baba3d0c76f9d125c0719093e315b5b44"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "e82597366816b6fa799040628e95490bbf6e6b2b"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "6eab0e8f74e86c598ec3b6fad4888e0c11482d48"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -422,7 +542,10 @@
 
 [[projects]]
   name = "gopkg.in/square/go-jose.v2"
-  packages = ["cipher","json"]
+  packages = [
+    "cipher",
+    "json"
+  ]
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
@@ -435,6 +558,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ae3e46dafffc920953db2766f35a1c0f3c87a46bbf740740bc778e37f3c33a34"
+  inputs-digest = "6ac3c005e9329d3744310c022f4591ec5c5ec0d7f1bdeee9346157659ec311d1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,7 +75,7 @@
 
 [[constraint]]
   name = "github.com/ory/fosite"
-  version = "0.16.1"
+  version = "0.17.0"
 
 [[constraint]]
   name = "github.com/ory/graceful"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ able to securely manage JSON Web Keys, and has a sophisticated policy-based acce
   - [Develop](#develop)
 - [Reception](#reception)
 - [Libraries and third-party projects](#libraries-and-third-party-projects)
-- [Blog posts & articles](#blog-posts--articles)
+- [Blog posts & articles](#blog-posts-&-articles)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - HYDRA_CLIENT_ID=admin
       - HYDRA_CLIENT_SECRET=demo-password
       - NODE_TLS_REJECT_UNAUTHORIZED=0
-    image: oryd/hydra-consent-app-express:v0.10.0-alpha.7
+    image: oryd/hydra-consent-app-express:v0.11.0
     links:
       - hydra
     ports:

--- a/oauth2/fosite_store_sql.go
+++ b/oauth2/fosite_store_sql.go
@@ -50,6 +50,16 @@ func sqlSchemaUp(table string, id string) string {
 	session_data  	text NOT NULL
 )`, table),
 		"2": fmt.Sprintf("ALTER TABLE hydra_oauth2_%s ADD subject varchar(255) NOT NULL DEFAULT ''", table),
+		"3": fmt.Sprintf(`CREATE TABLE IF NOT EXISTS hydra_oauth2_%s (
+	signature      	varchar(255) NOT NULL PRIMARY KEY,
+	request_id  	varchar(255) NOT NULL,
+	requested_at  	timestamp NOT NULL DEFAULT now(),
+	client_id  		text NOT NULL,
+	scope  			text NOT NULL,
+	granted_scope 	text NOT NULL,
+	form_data  		text NOT NULL,
+	session_data  	text NOT NULL
+)`, table),
 	}
 
 	return schemas[id]
@@ -59,6 +69,7 @@ func sqlSchemaDown(table string, id string) string {
 	schemas := map[string]string{
 		"1": fmt.Sprintf(`DROP TABLE %s)`, table),
 		"2": fmt.Sprintf("ALTER TABLE hydra_oauth2_%s DROP COLUMN subject", table),
+		"3": fmt.Sprintf(`DROP TABLE %s)`, table),
 	}
 
 	return schemas[id]
@@ -69,6 +80,7 @@ const (
 	sqlTableAccess  = "access"
 	sqlTableRefresh = "refresh"
 	sqlTableCode    = "code"
+	sqlTablePKCE    = "pkce"
 )
 
 var migrations = &migrate.MemoryMigrationSource{
@@ -101,6 +113,15 @@ var migrations = &migrate.MemoryMigrationSource{
 				sqlSchemaDown(sqlTableRefresh, "2"),
 				sqlSchemaDown(sqlTableCode, "2"),
 				sqlSchemaDown(sqlTableOpenID, "2"),
+			},
+		},
+		{
+			Id: "3",
+			Up: []string{
+				sqlSchemaUp(sqlTablePKCE, "3"),
+			},
+			Down: []string{
+				sqlSchemaDown(sqlTablePKCE, "3"),
 			},
 		},
 	},
@@ -279,6 +300,18 @@ func (s *FositeSQLStore) GetRefreshTokenSession(_ context.Context, signature str
 
 func (s *FositeSQLStore) DeleteRefreshTokenSession(_ context.Context, signature string) error {
 	return s.deleteSession(signature, sqlTableRefresh)
+}
+
+func (s *FositeSQLStore) CreatePKCERequestSession(_ context.Context, signature string, requester fosite.Requester) error {
+	return s.createSession(signature, requester, sqlTablePKCE)
+}
+
+func (s *FositeSQLStore) GetPKCERequestSession(_ context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
+	return s.findSessionBySignature(signature, session, sqlTablePKCE)
+}
+
+func (s *FositeSQLStore) DeletePKCERequestSession(_ context.Context, signature string) error {
+	return s.deleteSession(signature, sqlTablePKCE)
 }
 
 func (s *FositeSQLStore) CreateImplicitAccessTokenSession(ctx context.Context, signature string, requester fosite.Requester) error {

--- a/oauth2/fosite_store_sql.go
+++ b/oauth2/fosite_store_sql.go
@@ -58,7 +58,8 @@ func sqlSchemaUp(table string, id string) string {
 	scope  			text NOT NULL,
 	granted_scope 	text NOT NULL,
 	form_data  		text NOT NULL,
-	session_data  	text NOT NULL`,
+	session_data  	text NOT NULL
+)`,
 	}
 
 	return schemas[id]

--- a/oauth2/fosite_store_sql.go
+++ b/oauth2/fosite_store_sql.go
@@ -50,7 +50,7 @@ func sqlSchemaUp(table string, id string) string {
 	session_data  	text NOT NULL
 )`, table),
 		"2": fmt.Sprintf("ALTER TABLE hydra_oauth2_%s ADD subject varchar(255) NOT NULL DEFAULT ''", table),
-		"3": fmt.Sprintf(`CREATE TABLE IF NOT EXISTS hydra_oauth2_%s (
+		"3": `CREATE TABLE IF NOT EXISTS hydra_oauth2_pkce (
 	signature      	varchar(255) NOT NULL PRIMARY KEY,
 	request_id  	varchar(255) NOT NULL,
 	requested_at  	timestamp NOT NULL DEFAULT now(),
@@ -58,8 +58,7 @@ func sqlSchemaUp(table string, id string) string {
 	scope  			text NOT NULL,
 	granted_scope 	text NOT NULL,
 	form_data  		text NOT NULL,
-	session_data  	text NOT NULL
-)`, table),
+	session_data  	text NOT NULL`,
 	}
 
 	return schemas[id]
@@ -69,7 +68,7 @@ func sqlSchemaDown(table string, id string) string {
 	schemas := map[string]string{
 		"1": fmt.Sprintf(`DROP TABLE %s)`, table),
 		"2": fmt.Sprintf("ALTER TABLE hydra_oauth2_%s DROP COLUMN subject", table),
-		"3": fmt.Sprintf(`DROP TABLE %s)`, table),
+		"3": "DROP TABLE hydra_oauth2_pkce",
 	}
 
 	return schemas[id]

--- a/oauth2/fosite_store_test.go
+++ b/oauth2/fosite_store_test.go
@@ -111,3 +111,10 @@ func TestRevokeRefreshToken(t *testing.T) {
 		t.Run(fmt.Sprintf("case=%s", k), TestHelperRevokeRefreshToken(m))
 	}
 }
+
+func TestPKCEReuqest(t *testing.T) {
+	t.Parallel()
+	for k, m := range clientManagers {
+		t.Run(fmt.Sprintf("case=%s", k), TestHelperCreateGetDeletePKCERequestSession(m))
+	}
+}

--- a/oauth2/fosite_store_test_helpers.go
+++ b/oauth2/fosite_store_test_helpers.go
@@ -149,3 +149,25 @@ func TestHelperCreateGetDeleteAccessTokenSession(m pkg.FositeStorer) func(t *tes
 		assert.NotNil(t, err)
 	}
 }
+
+
+func TestHelperCreateGetDeletePKCERequestSession(m pkg.FositeStorer) func(t *testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		_, err := m.GetAccessTokenSession(ctx, "4321", &fosite.DefaultSession{})
+		assert.NotNil(t, err)
+
+		err = m.CreateAccessTokenSession(ctx, "4321", &defaultRequest)
+		require.NoError(t, err)
+
+		res, err := m.GetAccessTokenSession(ctx, "4321", &fosite.DefaultSession{})
+		require.NoError(t, err)
+		AssertObjectKeysEqual(t, &defaultRequest, res, "Scopes", "GrantedScopes", "Form", "Session")
+
+		err = m.DeleteAccessTokenSession(ctx, "4321")
+		require.NoError(t, err)
+
+		_, err = m.GetAccessTokenSession(ctx, "4321", &fosite.DefaultSession{})
+		assert.NotNil(t, err)
+	}
+}

--- a/oauth2/fosite_store_test_helpers.go
+++ b/oauth2/fosite_store_test_helpers.go
@@ -150,7 +150,6 @@ func TestHelperCreateGetDeleteAccessTokenSession(m pkg.FositeStorer) func(t *tes
 	}
 }
 
-
 func TestHelperCreateGetDeletePKCERequestSession(m pkg.FositeStorer) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()

--- a/pkg/joinURL.go
+++ b/pkg/joinURL.go
@@ -30,7 +30,7 @@ func JoinURLStrings(host string, parts ...string) string {
 
 	u, err := url.Parse(host)
 	if err != nil {
-		return fmt.Sprintf("%s%s%s", path.Join(append([]string{u.Path}, parts...)...), trailing)
+		return fmt.Sprintf("%s%s", path.Join(append([]string{u.Path}, parts...)...), trailing)
 	}
 
 	if u.Path == "" {


### PR DESCRIPTION
This release resolves a security issue (reported by [platform.sh](https://www.platform.sh)) related to the fosite storage implementation in this project. Fosite used to pass all of the request body from both authorize and token endpoints to the storage adapters. As some of these values are needed in consecutive requests, the storage adapter of this project chose to drop all of the key/value pairs to the database in plaintext.

This implied that confidential parameters, such as the `client_secret` which can be passed in the request body since fosite version 0.15.0, were stored as key/value pairs in plaintext in the database. While most client secrets are generated programmatically (as opposed to set by the user) and most popular OAuth2 providers choose to store the secret in plaintext for later retrieval, we see it as a considerable security issue nonetheless.

The issue has been resolved by sanitizing the request body and only including those values truly required by their respective handlers. This also implies that typos (eg `client_secet`) won't "leak" to the database.

There are no special upgrade paths required for this version.

This issue does not apply to you if you do not use an SQL backend. If you do upgrade to this version, you need to run `hydra migrate sql path://to.your/database`.

If your users use POST body client authentication, it might
be a good move to remove old data. There are multiple ways of doing that. **Back up your data before you do this**:

1. **Radical solution:** Drop all rows from tables `hydra_oauth2_refresh`, `hydra_oauth2_access`, `hydra_oauth2_oidc`,
`hydra_oauth2_code`. This implies that all your users have to re-authorize.
2. **Sensitive solution:** Replace all values in column `form_data` in tables `hydra_oauth2_refresh`, `hydra_oauth2_access` with
an empty string. This will keep all authorization sessions alive. Tables `hydra_oauth2_oidc` and `hydra_oauth2_code`
do not contain sensitive information, unless your users accidentally sent the client_secret to the `/oauth2/auth` endpoint.

We would like to thank [platform.sh](https://www.platform.sh) for sponsoring the development of a patch that resolves this issue.