### PR TITLE
[Prometheus] Add new prometheus metrics and metrics endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,6 +29,12 @@
   version = "v7"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/cenk/backoff"
   packages = ["."]
   revision = "61153c768f31ee5f130071d08fc82b85208528de"
@@ -223,6 +229,12 @@
   version = "v1.7.3"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/meatballhat/negroni-logrus"
   packages = ["."]
@@ -349,6 +361,42 @@
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "e5b036cc37a466a0af27d604d1ee500211d16d6a"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
   name = "github.com/rs/cors"
@@ -559,6 +607,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "317cab4cb3c65a5029c1794f8a1a8d58fb8eb6f8a184d8da47482c94a6a73547"
+  inputs-digest = "e34494bb1a19a082a848bcfaa8fca2646d80557fc2615fe35d1c805418355622"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -144,3 +144,7 @@
 [[constraint]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "0.8.0"

--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -105,11 +105,13 @@ func RunHost(c *config.Config) func(cmd *cobra.Command, args []string) {
 		n := negroni.New()
 
 		if ok, _ := cmd.Flags().GetBool("disable-telemetry"); !ok && os.Getenv("DISABLE_TELEMETRY") != "1" {
-			metrics := c.GetMetrics()
-			go metrics.RegisterSegment()
-			go metrics.CommitMemoryStatistics()
-			n.Use(metrics)
+			telemetryMetrics := c.GetTelemetryMetrics()
+			go telemetryMetrics.RegisterSegment()
+			go telemetryMetrics.CommitMemoryStatistics()
+			n.Use(telemetryMetrics)
 		}
+
+		n.Use(c.GetPrometheusMetrics())
 
 		n.Use(negronilogrus.NewMiddlewareFromLogger(logger, c.Issuer))
 		n.UseFunc(serverHandler.rejectInsecureRequests)

--- a/cmd/server/handler_health_factory.go
+++ b/cmd/server/handler_health_factory.go
@@ -29,7 +29,7 @@ import (
 
 func newHealthHandler(c *config.Config, router *httprouter.Router) *health.Handler {
 	h := &health.Handler{
-		Metrics:        c.GetMetrics(),
+		Metrics:        c.GetTelemetryMetrics(),
 		H:              herodot.NewJSONWriter(c.GetLogger()),
 		W:              c.Context().Warden,
 		ResourcePrefix: c.AccessControlResourcePrefix,

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,8 @@ import (
 	foauth2 "github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/token/hmac"
 	"github.com/ory/hydra/health"
-	"github.com/ory/hydra/metrics"
+	"github.com/ory/hydra/metrics/prometheus"
+	"github.com/ory/hydra/metrics/telemetry"
 	"github.com/ory/hydra/pkg"
 	"github.com/ory/hydra/warden/group"
 	"github.com/ory/ladon"
@@ -84,15 +85,16 @@ type Config struct {
 	SendOAuth2DebugMessagesToClients bool   `mapstructure:"OAUTH2_SHARE_ERROR_DEBUG" yaml:"-"`
 	ForceHTTP                        bool   `yaml:"-"`
 
-	BuildVersion string                  `yaml:"-"`
-	BuildHash    string                  `yaml:"-"`
-	BuildTime    string                  `yaml:"-"`
-	logger       *logrus.Logger          `yaml:"-"`
-	metrics      *metrics.MetricsManager `yaml:"-"`
-	cluster      *url.URL                `yaml:"-"`
-	oauth2Client *http.Client            `yaml:"-"`
-	context      *Context                `yaml:"-"`
-	systemSecret []byte                  `yaml:"-"`
+	BuildVersion string                     `yaml:"-"`
+	BuildHash    string                     `yaml:"-"`
+	BuildTime    string                     `yaml:"-"`
+	logger       *logrus.Logger             `yaml:"-"`
+	telemetry    *telemetry.MetricsManager  `yaml:"-"`
+	prometheus   *prometheus.MetricsManager `yaml:"-"`
+	cluster      *url.URL                   `yaml:"-"`
+	oauth2Client *http.Client               `yaml:"-"`
+	context      *Context                   `yaml:"-"`
+	systemSecret []byte                     `yaml:"-"`
 }
 
 func (c *Config) GetClusterURLWithoutTailingSlash() string {
@@ -154,12 +156,21 @@ func (c *Config) GetLogger() *logrus.Logger {
 	return c.logger
 }
 
-func (c *Config) GetMetrics() *metrics.MetricsManager {
-	if c.metrics == nil {
-		c.metrics = metrics.NewMetricsManager(c.Issuer, c.DatabaseURL, c.GetLogger(), c.BuildVersion, c.BuildHash, c.BuildTime)
+func (c *Config) GetTelemetryMetrics() *telemetry.MetricsManager {
+	if c.telemetry == nil {
+		c.telemetry = telemetry.NewMetricsManager(c.Issuer, c.DatabaseURL, c.GetLogger(), c.BuildVersion, c.BuildHash, c.BuildTime)
 	}
 
-	return c.metrics
+	return c.telemetry
+}
+
+func (c *Config) GetPrometheusMetrics() *prometheus.MetricsManager {
+	if c.prometheus == nil {
+		c.GetLogger().Info("Setting up Prometheus metrics")
+		c.prometheus = prometheus.NewMetricsManager(c.BuildVersion, c.BuildHash, c.BuildTime)
+	}
+
+	return c.prometheus
 }
 
 func (c *Config) DoesRequestSatisfyTermination(r *http.Request) error {

--- a/health/handler.go
+++ b/health/handler.go
@@ -26,15 +26,17 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/ory/herodot"
 	"github.com/ory/hydra/firewall"
-	"github.com/ory/hydra/metrics"
+	"github.com/ory/hydra/metrics/telemetry"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
-	HealthStatusPath = "/health/status"
+	HealthStatusPath     = "/health/status"
+	PrometheusStatusPath = "/health/prometheus"
 )
 
 type Handler struct {
-	Metrics        *metrics.MetricsManager
+	Metrics        *telemetry.MetricsManager
 	H              *herodot.JSONWriter
 	W              firewall.Firewall
 	ResourcePrefix string
@@ -54,6 +56,7 @@ func (h *Handler) PrefixResource(resource string) string {
 
 func (h *Handler) SetRoutes(r *httprouter.Router) {
 	r.GET(HealthStatusPath, h.Health)
+	r.Handler("GET", PrometheusStatusPath, promhttp.Handler())
 }
 
 // swagger:route GET /health/status health getInstanceStatus

--- a/metrics/prometheus/metrics.go
+++ b/metrics/prometheus/metrics.go
@@ -1,0 +1,42 @@
+package prometheus
+
+// Metrics prototypes
+// Example:
+// 	Counter      *prometheus.CounterVec
+// 	ResponseTime *prometheus.HistogramVec
+type Metrics struct{}
+
+// Method for creation new custom Prometheus  metrics
+// Example:
+// 	pm := &Metrics{
+//		Counter: prometheus.NewCounterVec(
+//			prometheus.CounterOpts{
+//				Name:        "servicename_requests_total",
+//				Help:        "Description",
+//				ConstLabels: map[string]string{
+//					"version":   version,
+//					"hash":      hash,
+//					"buildTime": buildTime,
+//				},
+//			},
+//			[]string{"endpoint"},
+//		),
+//		ResponseTime: prometheus.NewHistogramVec(
+//			prometheus.HistogramOpts{
+//				Name:        "servicename_response_time_seconds",
+//				Help:        "Description",
+//				ConstLabels: map[string]string{
+//					"version":   version,
+//					"hash":      hash,
+//					"buildTime": buildTime,
+//				},
+//			},
+//			[]string{"endpoint"},
+//		),
+//	}
+//	prometheus.Register(pm.Counter)
+//  prometheus.Register(pm.ResponseTime)
+func NewMetrics(version, hash, buildTime string) *Metrics {
+	pm := &Metrics{}
+	return pm
+}

--- a/metrics/prometheus/middleware.go
+++ b/metrics/prometheus/middleware.go
@@ -1,0 +1,27 @@
+package prometheus
+
+import (
+	"net/http"
+)
+
+type MetricsManager struct {
+	prometheusMetrics *Metrics
+}
+
+func NewMetricsManager(version, hash, buildTime string) *MetricsManager {
+	return &MetricsManager{
+		prometheusMetrics: NewMetrics(version, hash, buildTime),
+	}
+}
+
+// Main middleware method to collect metrics for Prometheus.
+// Example:
+//	start := time.Now()
+//	next(rw, r)
+//	Request counter metric
+//	pmm.prometheusMetrics.Counter.WithLabelValues(r.URL.Path).Inc()
+//	Response time metric
+//	pmm.prometheusMetrics.ResponseTime.WithLabelValues(r.URL.Path).Observe(time.Since(start).Seconds())
+func (pmm *MetricsManager) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	next(rw, r)
+}

--- a/metrics/telemetry/metrics.go
+++ b/metrics/telemetry/metrics.go
@@ -18,7 +18,7 @@
  * @license 	Apache-2.0
  */
 
-package metrics
+package telemetry
 
 import (
 	"runtime"

--- a/metrics/telemetry/middleware.go
+++ b/metrics/telemetry/middleware.go
@@ -18,7 +18,7 @@
  * @license 	Apache-2.0
  */
 
-package metrics
+package telemetry
 
 import (
 	"crypto/sha256"
@@ -100,6 +100,7 @@ func NewMetricsManager(issuerURL string, databaseURL string, l logrus.FieldLogge
 		salt:         uuid.New(),
 		BuildTime:    buildTime, BuildVersion: version, BuildHash: hash,
 	}
+
 	return mm
 }
 

--- a/metrics/telemetry/middleware_test.go
+++ b/metrics/telemetry/middleware_test.go
@@ -18,7 +18,7 @@
  * @license 	Apache-2.0
  */
 
-package metrics
+package telemetry
 
 import (
 	"net/url"


### PR DESCRIPTION
Signed-off-by: Dmitry Dolbik <dolbik@gmail.com>

It is draft implementation to support Prometheus in Hydra (https://github.com/ory/hydra/issues/669). Prometheus collects all metrics and more then current telemetry does. Current telemetry and prometheus works together in this pull request
Added two new Prometheus metrics:
- Secure token service requests served per endpoint
- Secure token service response time per endpoint

The result of prometheus:
`
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
go_goroutines 16
go_memstats_alloc_bytes 3.479416e+06
go_memstats_alloc_bytes_total 3.479416e+06
go_memstats_buck_hash_sys_bytes 1.445704e+06
go_memstats_frees_total 1375
go_memstats_gc_sys_bytes 268288
go_memstats_heap_alloc_bytes 3.479416e+06
go_memstats_heap_idle_bytes 679936
go_memstats_heap_inuse_bytes 4.857856e+06
go_memstats_heap_objects 19294
go_memstats_heap_released_bytes_total 0
go_memstats_heap_sys_bytes 5.537792e+06
go_memstats_last_gc_time_seconds 0
go_memstats_lookups_total 12
go_memstats_mallocs_total 20669
go_memstats_mcache_inuse_bytes 13888
go_memstats_mcache_sys_bytes 16384
go_memstats_mspan_inuse_bytes 59280
go_memstats_mspan_sys_bytes 65536
go_memstats_next_gc_bytes 4.473924e+06
go_memstats_other_sys_bytes 1.028528e+06
go_memstats_stack_inuse_bytes 753664
go_memstats_stack_sys_bytes 753664
go_memstats_sys_bytes 9.115896e+06
sts_requests_total{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master"} 1
sts_requests_total{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="0.005"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="0.01"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="0.025"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="0.05"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="0.1"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="0.25"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="0.5"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="1"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="2.5"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="5"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="10"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master",le="+Inf"} 1
sts_response_time_seconds_sum{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master"} 0.001876666
sts_response_time_seconds_count{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/metrics",hash="undefined",version="dev-master"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="0.005"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="0.01"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="0.025"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="0.05"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="0.1"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="0.25"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="0.5"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="1"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="2.5"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="5"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="10"} 1
sts_response_time_seconds_bucket{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master",le="+Inf"} 1
sts_response_time_seconds_sum{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master"} 0.000721316
sts_response_time_seconds_count{buildTime="2018-04-26 06:44:37.592314 +0000 UTC",endpoint="/health/status",hash="undefined",version="dev-master"} 1`