### PR TITLE
oauth2: Returns token type on introspection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -271,8 +271,8 @@
     "token/hmac",
     "token/jwt"
   ]
-  revision = "018b5c12b71b0da443255f4a5cf0ac9543bbf9f7"
-  version = "v0.17.0"
+  revision = "2bf9b6c4177be3050ff9ba3b82c6474e4c324c39"
+  version = "v0.18.0"
 
 [[projects]]
   name = "github.com/ory/graceful"
@@ -545,6 +545,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4d67506c9823ebf2da89def430b63fb31fc90f19eb167c505ddacbaa8c34822a"
+  inputs-digest = "33ad6060ba98ec0df48b987abfb552bace7263bf08d56a91deac2f8a31b75553"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,7 +75,7 @@
 
 [[constraint]]
   name = "github.com/ory/fosite"
-  version = "0.17.0"
+  version = "0.18.0"
 
 [[constraint]]
   name = "github.com/ory/graceful"

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -311,7 +311,7 @@ func (h *Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request, _ ht
 
 	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
 	if err = json.NewEncoder(w).Encode(&Introspection{
-		Active:    true,
+		Active:    resp.IsActive(),
 		ClientID:  resp.GetAccessRequester().GetClient().GetID(),
 		Scope:     strings.Join(resp.GetAccessRequester().GetGrantedScopes(), " "),
 		ExpiresAt: exp.Unix(),
@@ -321,6 +321,7 @@ func (h *Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request, _ ht
 		Extra:     resp.GetAccessRequester().GetSession().(*Session).Extra,
 		Audience:  resp.GetAccessRequester().GetSession().(*Session).Audience,
 		Issuer:    h.Issuer,
+		TokenType: string(resp.GetTokenType()),
 	}); err != nil {
 		pkg.LogError(errors.WithStack(err), h.L)
 	}

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -217,7 +217,7 @@ func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request, _ http
 	}
 
 	if tokenType != fosite.AccessToken {
-		h.H.WriteErrorCode(w,r,http.StatusUnauthorized,errors.New("Only access tokens are allowed in the authorization header"))
+		h.H.WriteErrorCode(w, r, http.StatusUnauthorized, errors.New("Only access tokens are allowed in the authorization header"))
 		return
 	}
 

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -210,9 +210,14 @@ func (h *Handler) WellKnownHandler(w http.ResponseWriter, r *http.Request, _ htt
 //       500: genericError
 func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	session := NewSession("")
-	ar, err := h.OAuth2.IntrospectToken(r.Context(), fosite.AccessTokenFromRequest(r), fosite.AccessToken, session)
+	tokenType, ar, err := h.OAuth2.IntrospectToken(r.Context(), fosite.AccessTokenFromRequest(r), fosite.AccessToken, session)
 	if err != nil {
 		h.H.WriteError(w, r, err)
+		return
+	}
+
+	if tokenType != fosite.AccessToken {
+		h.H.WriteErrorCode(w,r,http.StatusUnauthorized,errors.New("Only access tokens are allowed in the authorization header"))
 		return
 	}
 

--- a/oauth2/introspector.go
+++ b/oauth2/introspector.go
@@ -70,6 +70,9 @@ type Introspection struct {
 	// Issuer is a string representing the issuer of this token
 	Issuer string `json:"iss,omitempty"`
 
+	// TokenType is the introspected token's type, for example `access_token` or `refresh_token`.
+	TokenType string `json:"token_type,omitempty"`
+
 	// Extra is arbitrary data set by the session.
 	Extra map[string]interface{} `json:"ext,omitempty"`
 }


### PR DESCRIPTION
This patch adds the ability to return the token type ("refresh_token", "access_token") upon token introspection.

Closes #831