### PR TITLE
 consent: Propagates oidc_context to consent request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Dockerfile-plugin-*
 plugin-*.so
 hydra-docker-bin
 cookies.txt
+vendor.orig

--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -434,16 +434,17 @@ func (s *DefaultStrategy) forwardConsentRequest(w http.ResponseWriter, r *http.R
 
 	if err := s.M.CreateConsentRequest(
 		&ConsentRequest{
-			Challenge:       challenge,
-			Verifier:        verifier,
-			CSRF:            csrf,
-			Skip:            skip,
-			RequestedScope:  []string(ar.GetRequestedScopes()),
-			Subject:         as.Subject,
-			Client:          sanitizeClientFromRequest(ar),
-			RequestURL:      as.AuthenticationRequest.RequestURL,
-			AuthenticatedAt: as.AuthenticatedAt,
-			RequestedAt:     as.RequestedAt,
+			Challenge:            challenge,
+			Verifier:             verifier,
+			CSRF:                 csrf,
+			Skip:                 skip,
+			RequestedScope:       []string(ar.GetRequestedScopes()),
+			Subject:              as.Subject,
+			Client:               sanitizeClientFromRequest(ar),
+			RequestURL:           as.AuthenticationRequest.RequestURL,
+			AuthenticatedAt:      as.AuthenticatedAt,
+			RequestedAt:          as.RequestedAt,
+			OpenIDConnectContext: as.AuthenticationRequest.OpenIDConnectContext,
 		},
 	); err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
This patch resolves an issue where oidc_context would be included in the login request but not the consent request.

Closes #900