### PR TITLE
cli: fix reporting of epected vs. received status codes

### DIFF
--- a/cmd/cli/handler_helper.go
+++ b/cmd/cli/handler_helper.go
@@ -41,7 +41,7 @@ func checkResponse(response *hydra.APIResponse, err error, expectedStatusCode in
 	}
 
 	if response.StatusCode != expectedStatusCode {
-		fmt.Fprintf(os.Stderr, "Command failed because calling \"%s %s\" resulted in status code \"%d\" but code \"%d\" was expected.\n%s\n", response.Request.Method, response.RequestURL, expectedStatusCode, response.StatusCode, response.Payload)
+		fmt.Fprintf(os.Stderr, "Command failed because calling \"%s %s\" resulted in status code \"%d\" but code \"%d\" was expected.\n%s\n", response.Request.Method, response.RequestURL, response.StatusCode, expectedStatusCode, response.Payload)
 		os.Exit(1)
 		return
 	}


### PR DESCRIPTION
Asking for a non-existent client results in the following confusing error message:

```
Command failed because calling "GET http://hydra:4444/clients/no-such-client" resulted in status code "200" but code "404" was expected.
{"error":"Unable to locate the resource","error_description":"","status_code":404}
```

This commit fixes the expectedStatusCode and response.StatusCode arguments to fmt.Fprintf which were reversed.



<!--
Before creating your pull request, make sure that you have
[signed the DOC](https://github.com/ory/hydra/blob/master/.github/CONTRIBUTING.md#developers-certificate-of-origin).
You can ammend your signature to the current commit using `git commit --amend -s`.

Please create PRs only for bugs, or features that have been discussed with the maintainers, either at the
[ORY Community](https://community.ory.sh/) or join the [ORY Chat](https://www.ory.sh/chat).

If you think you found a security vulnerability, please refrain from posting it publicly on the forums, the chat, or GitHub
and send us an email to [hi@ory.am](mailto:hi@ory.am) instead.
-->