### PR TITLE
config: disable plugin backend through 'noplugin' tag 

### DIFF
--- a/config/backend_plugin.go
+++ b/config/backend_plugin.go
@@ -1,22 +1,24 @@
-/*
- * Copyright © 2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
- * @copyright 	2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
- * @license 	Apache-2.0
- */
+//
+// Copyright © 2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+// @copyright 	2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+// @license 	Apache-2.0
+//
+
+// +build !noplugin
 
 package config
 

--- a/config/backend_plugin_noplugin.go
+++ b/config/backend_plugin_noplugin.go
@@ -1,0 +1,37 @@
+//
+// Copyright © 2015-2018 Gorka Lerchundi Osa <glertxundi@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// @author		Gorka Lerchundi Osa <glertxundi@gmail.com>
+// @copyright 	2015-2018 Gorka Lerchundi Osa <glertxundi@gmail.com>
+// @license 	Apache-2.0
+//
+
+// +build noplugin
+
+package config
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type PluginConnection struct {
+	Config *Config
+	Logger logrus.FieldLogger
+}
+
+func (c *PluginConnection) Load() error {
+	return errors.New("config: unable to load plugin connection because 'noplugin' tag was declared")
+}


### PR DESCRIPTION
Debugging Hydra in Go 1.10 and 1.11 (confirmed by one of its members),
is not possible due to [this unresolved
bug](https://github.com/golang/go/issues/23733) which is related to the
use of the plugin functionality.

This change allows passing a build tag which will disable plugin
implementation and therefore allow to debug in all the use-cases where
plugin backend is not needed.

Signed-off-by: Gorka Lerchundi Osa <glertxundi@gmail.com>