### PR TITLE
consent: Populate consent session with default values

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -558,6 +558,18 @@ func (s *DefaultStrategy) verifyConsent(w http.ResponseWriter, r *http.Request, 
 		return nil, err
 	}
 
+	if session.Session == nil {
+		session.Session = newConsentRequestSessionData()
+	}
+
+	if session.Session.AccessToken == nil {
+		session.Session.AccessToken = map[string]interface{}{}
+	}
+
+	if session.Session.IDToken == nil {
+		session.Session.IDToken = map[string]interface{}{}
+	}
+
 	session.ConsentRequest.SubjectIdentifier = pw
 	session.AuthenticatedAt = session.ConsentRequest.AuthenticatedAt
 	return session, nil

--- a/consent/types.go
+++ b/consent/types.go
@@ -317,3 +317,10 @@ type ConsentRequestSessionData struct {
 
 	//UserInfo map[string]interface{} `json:"userinfo"`
 }
+
+func newConsentRequestSessionData() *ConsentRequestSessionData {
+	return &ConsentRequestSessionData{
+		AccessToken: map[string]interface{}{},
+		IDToken:     map[string]interface{}{},
+	}
+}


### PR DESCRIPTION
This resolves a panic when the session is not available. Closes #988