### PR TITLE
cmd: Disable CORS by default

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -99,6 +99,13 @@ before finalizing the upgrade process.
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## 1.0.0-rc.1
+
+### CORS is disabled by default
+
+A new environment variable `CORS_ENABLED` was introduced. It sets whether CORS is enabled ("true") or not ("false")".
+Default is disabled.
+
 ## 1.0.0-beta.8
 
 ### Schema Changes

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -182,6 +182,9 @@ HTTPS CONTROLS
 
 CORS CONTROLS
 ==============
+- CORS_ENABLED: Switch CORS support on (true) or off (false). Default is off (false).
+	Example: CORS_ENABLED=true
+
 - CORS_ALLOWED_ORIGINS: A list of origins (comma separated values) a cross-domain request can be executed from.
 	If the special * value is present in the list, all origins will be allowed. An origin may contain a wildcard (*)
 	to replace 0 or more characters (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penality.

--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
@@ -57,7 +58,12 @@ func enhanceRouter(c *config.Config, cmd *cobra.Command, serverHandler *Handler,
 	}
 	n.UseFunc(serverHandler.rejectInsecureRequests)
 	n.UseHandler(router)
-	return context.ClearHandler(cors.New(corsx.ParseOptions()).Handler(n))
+	if os.Getenv("CORS_ENABLED") == "true" {
+		c.GetLogger().Info("Enabled CORS")
+		return context.ClearHandler(cors.New(corsx.ParseOptions()).Handler(n))
+	} else {
+		return context.ClearHandler(n)
+	}
 }
 
 func RunServeAdmin(c *config.Config) func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This patch introduces environment variable `CORS_ENABLED` which toggles CORS.

Closes #996