### PR TITLE
oauth2: Enable client specific CORS settings

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,6 +23,12 @@
   revision = "cd527374f1e5bff4938207604a14f2e38a9cf512"
 
 [[projects]]
+  name = "github.com/aeneasr/cors"
+  packages = ["."]
+  revision = "3fb1b69b103a84de38a19c3c6ec073dd6caa4d3f"
+  version = "v1.5.0"
+
+[[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
   revision = "73945b6115bfbbcc57d89b7316e28109364124e1"
@@ -637,6 +643,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c4398344f70a0ba6d5db1b004bc09a354eef45f3c6fdf63227feb78b74fef415"
+  inputs-digest = "c16af2ef7a4de1a072384d6ddd8ca446693376c776ee866f7139027476b30084"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -25,7 +25,7 @@
 [[projects]]
   name = "github.com/aeneasr/cors"
   packages = ["."]
-  revision = "3fb1b69b103a84de38a19c3c6ec073dd6caa4d3f"
+  revision = "1bbd41dfc0e2d813965f77b0a8600571b3dc4f72"
   version = "v1.5.0"
 
 [[projects]]

--- a/client/client.go
+++ b/client/client.go
@@ -74,6 +74,12 @@ type Client struct {
 	// retains, and discloses personal data.
 	PolicyURI string `json:"policy_uri"`
 
+	// AllowedCORSOrigins are one or more URLs (scheme://host[:port]) which are allowed to make CORS requests
+	// to the /oauth/token endpoint. If this array is empty, the sever's CORS origin configuration (`CORS_ALLOWED_ORIGINS`)
+	// will be used instead. If this array is set, the allowed origins are appended to the server's CORS origin configuration.
+	// Be aware that environment variable `CORS_ENABLED` MUST be set to `true` for this to work.
+	AllowedCORSOrigins []string `json:"allowed_cors_origins"`
+
 	// TermsOfServiceURI is a URL string that points to a human-readable terms of service
 	// document for the client that describes a contractual relationship
 	// between the end-user and the client that the end-user accepts when

--- a/client/manager_0_sql_migrations_test.go
+++ b/client/manager_0_sql_migrations_test.go
@@ -90,6 +90,24 @@ var createClientMigrations = []*migrate.Migration{
 			`DELETE FROM hydra_client WHERE id='6-data'`,
 		},
 	},
+	{
+		Id: "7-data",
+		Up: []string{
+			`INSERT INTO hydra_client (id, allowed_cors_origins, client_name, client_secret, redirect_uris, grant_types, response_types, scope, owner, policy_uri, tos_uri, client_uri, logo_uri, contacts, client_secret_expires_at, sector_identifier_uri, jwks, jwks_uri, token_endpoint_auth_method, request_uris, request_object_signing_alg, userinfo_signed_response_alg, subject_type) VALUES ('7-data', 'http://localhost|http://google', 'some-client', 'abcdef', 'http://localhost|http://google', 'authorize_code|implicit', 'token|id_token', 'foo|bar', 'aeneas', 'http://policy', 'http://tos', 'http://client', 'http://logo', 'aeneas|foo', 0, 'http://sector', '{"keys": []}', 'http://jwks', 'none', 'http://uri1|http://uri2', 'rs256', 'rs526', 'public')`,
+		},
+		Down: []string{
+			`DELETE FROM hydra_client WHERE id='7-data'`,
+		},
+	},
+	{
+		Id: "8-data",
+		Up: []string{
+			`INSERT INTO hydra_client (id, allowed_cors_origins, client_name, client_secret, redirect_uris, grant_types, response_types, scope, owner, policy_uri, tos_uri, client_uri, logo_uri, contacts, client_secret_expires_at, sector_identifier_uri, jwks, jwks_uri, token_endpoint_auth_method, request_uris, request_object_signing_alg, userinfo_signed_response_alg, subject_type) VALUES ('8-data', 'http://localhost|http://google', 'some-client', 'abcdef', 'http://localhost|http://google', 'authorize_code|implicit', 'token|id_token', 'foo|bar', 'aeneas', 'http://policy', 'http://tos', 'http://client', 'http://logo', 'aeneas|foo', 0, 'http://sector', '{"keys": []}', 'http://jwks', 'none', 'http://uri1|http://uri2', 'rs256', 'rs526', 'public')`,
+		},
+		Down: []string{
+			`DELETE FROM hydra_client WHERE id='8-data'`,
+		},
+	},
 }
 
 var migrations = map[string]*migrate.MemoryMigrationSource{
@@ -108,6 +126,10 @@ var migrations = map[string]*migrate.MemoryMigrationSource{
 			createClientMigrations[4],
 			client.Migrations["mysql"].Migrations[5],
 			createClientMigrations[5],
+			client.Migrations["mysql"].Migrations[6],
+			createClientMigrations[6],
+			client.Migrations["mysql"].Migrations[7],
+			createClientMigrations[7],
 		},
 	},
 	"postgres": {
@@ -125,6 +147,10 @@ var migrations = map[string]*migrate.MemoryMigrationSource{
 			createClientMigrations[4],
 			client.Migrations["postgres"].Migrations[5],
 			createClientMigrations[5],
+			client.Migrations["postgres"].Migrations[6],
+			createClientMigrations[6],
+			client.Migrations["postgres"].Migrations[7],
+			createClientMigrations[7],
 		},
 	},
 }

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -168,7 +168,10 @@ var Migrations = map[string]*migrate.MemoryMigrationSource{
 				`ALTER TABLE hydra_client ALTER COLUMN request_uris SET NOT NULL`,
 			},
 			Down: []string{
-				`ALTER TABLE hydra_client ALTER COLUMN allowed_cors_origins DROP NOT NULL`,
+				`ALTER TABLE hydra_client ALTER COLUMN sector_identifier_uri DROP NOT NULL`,
+				`ALTER TABLE hydra_client ALTER COLUMN jwks DROP NOT NULL`,
+				`ALTER TABLE hydra_client ALTER COLUMN jwks_uri DROP NOT NULL`,
+				`ALTER TABLE hydra_client ALTER COLUMN request_uris DROP NOT NULL`,
 			},
 		},
 		sharedMigrations[3],

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -218,7 +218,7 @@ type sqlData struct {
 	SubjectType                   string `db:"subject_type"`
 	RequestObjectSigningAlgorithm string `db:"request_object_signing_alg"`
 	UserinfoSignedResponseAlg     string `db:"userinfo_signed_response_alg"`
-	AllowedCORSOrigins            string `db:"allowed_cors_origins "`
+	AllowedCORSOrigins            string `db:"allowed_cors_origins"`
 }
 
 var sqlParams = []string{

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -108,6 +108,15 @@ var sharedMigrations = []*migrate.Migration{
 			`ALTER TABLE hydra_client DROP COLUMN subject_type`,
 		},
 	},
+	{
+		Id: "7",
+		Up: []string{
+			`ALTER TABLE hydra_client ADD allowed_cors_origins TEXT`,
+		},
+		Down: []string{
+			`ALTER TABLE hydra_client DROP COLUMN allowed_cors_origins`,
+		},
+	},
 }
 
 var Migrations = map[string]*migrate.MemoryMigrationSource{
@@ -133,6 +142,17 @@ var Migrations = map[string]*migrate.MemoryMigrationSource{
 		},
 		sharedMigrations[3],
 		sharedMigrations[4],
+		sharedMigrations[5],
+		{
+			Id: "7",
+			Up: []string{
+				`UPDATE hydra_client SET allowed_cors_origins=''`,
+				`ALTER TABLE hydra_client MODIFY allowed_cors_origins TEXT NOT NULL`,
+			},
+			Down: []string{
+				`ALTER TABLE hydra_client MODIFY allowed_cors_origins TEXT`,
+			},
+		},
 	}},
 	"postgres": {Migrations: []*migrate.Migration{
 		sharedMigrations[0],
@@ -148,14 +168,22 @@ var Migrations = map[string]*migrate.MemoryMigrationSource{
 				`ALTER TABLE hydra_client ALTER COLUMN request_uris SET NOT NULL`,
 			},
 			Down: []string{
-				`ALTER TABLE hydra_client ALTER COLUMN sector_identifier_uri DROP NOT NULL`,
-				`ALTER TABLE hydra_client ALTER COLUMN jwks DROP NOT NULL`,
-				`ALTER TABLE hydra_client ALTER COLUMN jwks_uri DROP NOT NULL`,
-				`ALTER TABLE hydra_client ALTER COLUMN request_uris DROP NOT NULL`,
+				`ALTER TABLE hydra_client ALTER COLUMN allowed_cors_origins DROP NOT NULL`,
 			},
 		},
 		sharedMigrations[3],
 		sharedMigrations[4],
+		sharedMigrations[5],
+		{
+			Id: "7",
+			Up: []string{
+				`UPDATE hydra_client SET allowed_cors_origins=''`,
+				`ALTER TABLE hydra_client ALTER COLUMN allowed_cors_origins SET NOT NULL`,
+			},
+			Down: []string{
+				`ALTER TABLE hydra_client ALTER COLUMN allowed_cors_origins DROP NOT NULL`,
+			},
+		},
 	}},
 }
 

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -144,7 +144,7 @@ var Migrations = map[string]*migrate.MemoryMigrationSource{
 		sharedMigrations[4],
 		sharedMigrations[5],
 		{
-			Id: "7",
+			Id: "8",
 			Up: []string{
 				`UPDATE hydra_client SET allowed_cors_origins=''`,
 				`ALTER TABLE hydra_client MODIFY allowed_cors_origins TEXT NOT NULL`,
@@ -175,7 +175,7 @@ var Migrations = map[string]*migrate.MemoryMigrationSource{
 		sharedMigrations[4],
 		sharedMigrations[5],
 		{
-			Id: "7",
+			Id: "8",
 			Up: []string{
 				`UPDATE hydra_client SET allowed_cors_origins=''`,
 				`ALTER TABLE hydra_client ALTER COLUMN allowed_cors_origins SET NOT NULL`,

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -215,6 +215,7 @@ type sqlData struct {
 	SubjectType                   string `db:"subject_type"`
 	RequestObjectSigningAlgorithm string `db:"request_object_signing_alg"`
 	UserinfoSignedResponseAlg     string `db:"userinfo_signed_response_alg"`
+	AllowedCORSOrigins            string `db:"allowed_cors_origins "`
 }
 
 var sqlParams = []string{
@@ -240,6 +241,7 @@ var sqlParams = []string{
 	"request_uris",
 	"request_object_signing_alg",
 	"userinfo_signed_response_alg",
+	"allowed_cors_origins",
 }
 
 func sqlDataFromClient(d *Client) (*sqlData, error) {
@@ -276,6 +278,7 @@ func sqlDataFromClient(d *Client) (*sqlData, error) {
 		RequestURIs:                   strings.Join(d.RequestURIs, "|"),
 		UserinfoSignedResponseAlg:     d.UserinfoSignedResponseAlg,
 		SubjectType:                   d.SubjectType,
+		AllowedCORSOrigins:            strings.Join(d.AllowedCORSOrigins, "|"),
 	}, nil
 }
 
@@ -302,6 +305,7 @@ func (d *sqlData) ToClient() (*Client, error) {
 		RequestURIs:                   stringsx.Splitx(d.RequestURIs, "|"),
 		UserinfoSignedResponseAlg:     d.UserinfoSignedResponseAlg,
 		SubjectType:                   d.SubjectType,
+		AllowedCORSOrigins:            stringsx.Splitx(d.AllowedCORSOrigins, "|"),
 	}
 
 	if d.JSONWebKeys != "" {

--- a/client/manager_test_helpers.go
+++ b/client/manager_test_helpers.go
@@ -89,6 +89,7 @@ func TestHelperCreateGetDeleteClient(k string, m Storage) func(t *testing.T) {
 			JSONWebKeysURI:                "https://...",
 			TokenEndpointAuthMethod:       "none",
 			RequestURIs:                   []string{"foo", "bar"},
+			AllowedCORSOrigins:            []string{"foo", "bar"},
 			RequestObjectSigningAlgorithm: "rs256",
 			UserinfoSignedResponseAlg:     "RS256",
 		}

--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -258,7 +258,7 @@ func (h *Handler) registerRoutes(frontend, backend *httprouter.Router) {
 	h.Clients = newClientHandler(c, backend, clientsManager)
 	h.Keys = newJWKHandler(c, frontend, backend)
 	h.Consent = newConsentHandler(c, frontend, backend)
-	h.OAuth2 = newOAuth2Handler(c, frontend, backend, ctx.ConsentManager, oauth2Provider)
+	h.OAuth2 = newOAuth2Handler(c, frontend, backend, ctx.ConsentManager, oauth2Provider, clientsManager)
 	_ = newHealthHandler(c, backend)
 }
 

--- a/cmd/server/helper_cors.go
+++ b/cmd/server/helper_cors.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ */
+
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aeneasr/cors"
+	"github.com/ory/fosite"
+	"github.com/ory/go-convenience/corsx"
+	"github.com/ory/go-convenience/stringslice"
+	"github.com/ory/hydra/client"
+	"github.com/ory/hydra/config"
+	"github.com/ory/hydra/oauth2"
+)
+
+func newCORSMiddleware(
+	enable bool, c *config.Config,
+	o func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error),
+	clm func(id string) (*client.Client, error),
+) func(h http.Handler) http.Handler {
+	if !enable {
+		return func(h http.Handler) http.Handler {
+			return h
+		}
+	}
+
+	c.GetLogger().Info("Enabled CORS")
+	po := corsx.ParseOptions()
+	options := cors.Options{
+		AllowedOrigins:     po.AllowedOrigins,
+		AllowedMethods:     po.AllowedMethods,
+		AllowedHeaders:     po.AllowedHeaders,
+		ExposedHeaders:     po.ExposedHeaders,
+		MaxAge:             po.MaxAge,
+		AllowCredentials:   po.AllowCredentials,
+		OptionsPassthrough: po.OptionsPassthrough,
+		Debug:              po.Debug,
+		AllowOriginRequestFunc: func(r *http.Request, origin string) bool {
+			if stringslice.Has(po.AllowedOrigins, origin) {
+				return true
+			}
+
+			username, _, ok := r.BasicAuth()
+			if !ok || username == "" {
+				token := fosite.AccessTokenFromRequest(r)
+				if token == "" {
+					return false
+				}
+
+				session := oauth2.NewSession("")
+				_, ar, err := o(context.Background(), token, fosite.AccessToken, session)
+				if err != nil {
+					return false
+				}
+
+				username = ar.GetClient().GetID()
+			}
+
+			cl, err := clm(username)
+			if err != nil {
+				return false
+			}
+
+			if stringslice.Has(cl.AllowedCORSOrigins, origin) {
+				return true
+			}
+
+			return false
+		},
+	}
+	return cors.New(options).Handler
+}

--- a/cmd/server/helper_cors_test.go
+++ b/cmd/server/helper_cors_test.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ */
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/ory/fosite"
+	"github.com/ory/hydra/client"
+	"github.com/ory/hydra/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORSMiddleware(t *testing.T) {
+	handler := httprouter.New()
+	handler.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	c := new(config.Config)
+	for k, tc := range []struct {
+		d            string
+		mw           func(http.Handler) http.Handler
+		code         int
+		header       http.Header
+		expectHeader http.Header
+	}{
+		{
+			d:            "should ignore when disabled",
+			mw:           newCORSMiddleware(false, nil, nil, nil),
+			code:         204,
+			header:       http.Header{},
+			expectHeader: http.Header{},
+		},
+		{
+			d: "should reject when basic auth but client does not exist",
+			mw: newCORSMiddleware(true, c, nil, func(id string) (*client.Client, error) {
+				return nil, errors.New("")
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}},
+		},
+		{
+			d: "should reject when basic auth client exists but origin not allowed",
+			mw: newCORSMiddleware(true, c, nil, func(id string) (*client.Client, error) {
+				return &client.Client{AllowedCORSOrigins: []string{"http://not-foobar.com"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}},
+		},
+		{
+			d: "should accept when basic auth client exists and origin allowed",
+			mw: newCORSMiddleware(true, c, nil, func(id string) (*client.Client, error) {
+				return &client.Client{AllowedCORSOrigins: []string{"http://foobar.com"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foobar.com"}},
+		},
+		{
+			d: "should fail when token introspection fails",
+			mw: newCORSMiddleware(true, c, func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error) {
+				return "", nil, errors.New("")
+			}, func(id string) (*client.Client, error) {
+				return &client.Client{AllowedCORSOrigins: []string{"http://foobar.com"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Basic Zm9vOmJhcg=="}},
+			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foobar.com"}},
+		},
+		{
+			d: "should fail when token introspection fails",
+			mw: newCORSMiddleware(true, c, func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error) {
+				if token != "1234" {
+					return "", nil, errors.New("")
+				}
+				return "", &fosite.AccessRequest{Request: fosite.Request{Client: &client.Client{ClientID: "asdf"}}}, nil
+			}, func(id string) (*client.Client, error) {
+				if id != "asdf" {
+					return nil, errors.New("")
+				}
+				return &client.Client{AllowedCORSOrigins: []string{"http://foobar.com"}}, nil
+			}),
+			code:         204,
+			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"bearer 1234"}},
+			expectHeader: http.Header{"Vary": {"Origin"}, "Access-Control-Allow-Origin": {"http://foobar.com"}},
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://foobar.com/", nil)
+			require.NoError(t, err)
+			for k := range tc.header {
+				req.Header.Set(k, tc.header.Get(k))
+			}
+
+			res := httptest.NewRecorder()
+			tc.mw(handler).ServeHTTP(res, req)
+			require.NoError(t, err)
+			assert.EqualValues(t, tc.expectHeader, res.Header())
+		})
+	}
+}

--- a/oauth2/handler_fallback_endpoints_test.go
+++ b/oauth2/handler_fallback_endpoints_test.go
@@ -38,7 +38,9 @@ func TestHandlerConsent(t *testing.T) {
 		ScopeStrategy: fosite.HierarchicScopeStrategy,
 	}
 	r := httprouter.New()
-	h.SetRoutes(r, r)
+	h.SetRoutes(r, r, func(h http.Handler) http.Handler {
+		return h
+	})
 	ts := httptest.NewServer(r)
 
 	res, err := http.Get(ts.URL + DefaultConsentPath)

--- a/oauth2/handler_test.go
+++ b/oauth2/handler_test.go
@@ -96,7 +96,9 @@ func TestHandlerFlushHandler(t *testing.T) {
 	}
 
 	r := httprouter.New()
-	h.SetRoutes(r, r)
+	h.SetRoutes(r, r, func(h http.Handler) http.Handler {
+		return h
+	})
 	ts := httptest.NewServer(r)
 	c := hydra.NewOAuth2ApiWithBasePath(ts.URL)
 
@@ -154,7 +156,9 @@ func TestUserinfo(t *testing.T) {
 		OpenIDJWTStrategy: jwtStrategy,
 	}
 	router := httprouter.New()
-	h.SetRoutes(router, router)
+	h.SetRoutes(router, router, func(h http.Handler) http.Handler {
+		return h
+	})
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
@@ -368,7 +372,9 @@ func TestHandlerWellKnown(t *testing.T) {
 	JWKPathT := "/.well-known/jwks.json"
 
 	r := httprouter.New()
-	h.SetRoutes(r, r)
+	h.SetRoutes(r, r, func(h http.Handler) http.Handler {
+		return h
+	})
 	ts := httptest.NewServer(r)
 
 	res, err := http.Get(ts.URL + "/.well-known/openid-configuration")

--- a/oauth2/introspector_test.go
+++ b/oauth2/introspector_test.go
@@ -75,7 +75,9 @@ func TestIntrospectorSDK(t *testing.T) {
 		IssuerURL:         "foobariss",
 		OpenIDJWTStrategy: jwtStrategy,
 	}
-	handler.SetRoutes(router, router)
+	handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
+		return h
+	})
 	server := httptest.NewServer(router)
 
 	now := time.Now().UTC().Round(time.Minute)

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -193,7 +193,9 @@ func TestAuthCodeWithDefaultStrategy(t *testing.T) {
 						IssuerURL: ts.URL, ForcedHTTP: true, L: l,
 						OpenIDJWTStrategy: jwtStrategy,
 					}
-					handler.SetRoutes(router, router)
+					handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
+						return h
+					})
 
 					apiHandler := consent.NewHandler(herodot.NewJSONWriter(l), cm, cookieStore, "")
 					apiRouter := httprouter.New()
@@ -745,7 +747,9 @@ func TestAuthCodeWithMockStrategy(t *testing.T) {
 				IssuerURL:         ts.URL,
 				OpenIDJWTStrategy: jwtStrategy,
 			}
-			handler.SetRoutes(router, router)
+			handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
+				return h
+			})
 
 			var callbackHandler *httprouter.Handle
 			router.GET("/callback", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/oauth2/oauth2_client_credentials_test.go
+++ b/oauth2/oauth2_client_credentials_test.go
@@ -23,6 +23,7 @@ package oauth2_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -110,7 +111,9 @@ func TestClientCredentials(t *testing.T) {
 				OpenIDJWTStrategy: jwtStrategy,
 			}
 
-			handler.SetRoutes(router, router)
+			handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
+				return h
+			})
 
 			require.NoError(t, store.CreateClient(&hc.Client{
 				ClientID:      "app-client",

--- a/oauth2/revocator_test.go
+++ b/oauth2/revocator_test.go
@@ -92,7 +92,9 @@ func TestRevoke(t *testing.T) {
 	}
 
 	router := httprouter.New()
-	handler.SetRoutes(router, router)
+	handler.SetRoutes(router, router, func(h http.Handler) http.Handler {
+		return h
+	})
 	server := httptest.NewServer(router)
 
 	createAccessTokenSession("alice", "my-client", tokens[0][0], now.Add(time.Hour), store, nil)


### PR DESCRIPTION
Field `allowed_cors_origins` was added to OAuth 2.0 Clients. It enables
CORS for the whitelisted URLS for paths which clients interact with,
such as /oauth2/token.

Closes #975

Depends on:
* [ ] https://github.com/rs/cors/pull/60
* [ ] https://github.com/rs/cors/pull/59