### PR TITLE
config: Fix use of uninitialized logger

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -100,11 +100,11 @@ type Config struct {
 
 func (c *Config) MustValidate() {
 	if stringslice.Has(c.GetSubjectTypesSupported(), "pairwise") && c.OAuth2AccessTokenStrategy == "jwt" {
-		c.logger.Fatalf(`The pairwise subject identifier algorithm is not supported by the JWT OAuth 2.0 Access Token Strategy. Please remove "pairwise" from OIDC_SUBJECT_TYPES_SUPPORTED or set OAUTH2_ACCESS_TOKEN_STRATEGY to "opaque"`)
+		c.GetLogger().Fatalf(`The pairwise subject identifier algorithm is not supported by the JWT OAuth 2.0 Access Token Strategy. Please remove "pairwise" from OIDC_SUBJECT_TYPES_SUPPORTED or set OAUTH2_ACCESS_TOKEN_STRATEGY to "opaque"`)
 	}
 
 	if stringslice.Has(c.GetSubjectTypesSupported(), "pairwise") && len(c.SubjectIdentifierAlgorithmSalt) < 8 {
-		c.logger.Fatalf(`The pairwise subject identifier algorithm was set but length of OIDC_SUBJECT_TYPE_PAIRWISE_SALT is too small (%d < 8), please set OIDC_SUBJECT_TYPE_PAIRWISE_SALT to a random string with 8 characters or more`, len(c.SubjectIdentifierAlgorithmSalt))
+		c.GetLogger().Fatalf(`The pairwise subject identifier algorithm was set but length of OIDC_SUBJECT_TYPE_PAIRWISE_SALT is too small (%d < 8), please set OIDC_SUBJECT_TYPE_PAIRWISE_SALT to a random string with 8 characters or more`, len(c.SubjectIdentifierAlgorithmSalt))
 	}
 }
 


### PR DESCRIPTION
The MustValidate() function is sometimes called before any other logging
function has been called and this results in a crash. An easy way to
reproduce the crash is to change OAUTH2_ACCESS_TOKEN_STRATEGY=jwt in the
default docker-compose.yml

Signed-off-by: Vishesh Handa <vishesh.handa@telefonica.com>

<!--
Before creating your pull request, make sure that you have
[signed the DOC](https://github.com/ory/hydra/blob/master/.github/CONTRIBUTING.md#developers-certificate-of-origin).
You can ammend your signature to the current commit using `git commit --amend -s`.

Please create PRs only for bugs, or features that have been discussed with the maintainers, either at the
[ORY Community](https://community.ory.sh/) or join the [ORY Chat](https://www.ory.sh/chat).

If you think you found a security vulnerability, please refrain from posting it publicly on the forums, the chat, or GitHub
and send us an email to [hi@ory.am](mailto:hi@ory.am) instead.
-->
