### PR TITLE
Use latest version of sqlcon

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -360,8 +360,8 @@
     ".",
     "dockertest"
   ]
-  revision = "55ff643dd57cca178e1689ff050f6e7f9122e72d"
-  version = "v0.0.6"
+  revision = "068c69998749cdb876c4adf179a8ed702864ad2b"
+  version = "v0.0.7"
 
 [[projects]]
   name = "github.com/pborman/uuid"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/ory/sqlcon"
-  version = "0.0.6"
+  version = "0.0.7"
 
 [[constraint]]
   name = "github.com/gorilla/context"


### PR DESCRIPTION
Use the latest version of sqlcon (fixes issue where certain characters were being escaped in the username before being passed to sql driver, required to allow DB's hosted on Azure MySQL as they always use an @ in the username).