### PR TITLE
propagate context through to the sql store

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -107,7 +107,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	}
 
 	secret := c.Secret
-	if err := h.Manager.CreateClient(&c); err != nil {
+	if err := h.Manager.CreateClient(r.Context(), &c); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
@@ -159,7 +159,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request, ps httprouter.P
 		return
 	}
 
-	if err := h.Manager.UpdateClient(&c); err != nil {
+	if err := h.Manager.UpdateClient(r.Context(), &c); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
@@ -191,7 +191,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request, ps httprouter.P
 //       500: genericError
 func (h *Handler) List(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	limit, offset := pagination.Parse(r, 100, 0, 500)
-	c, err := h.Manager.GetClients(limit, offset)
+	c, err := h.Manager.GetClients(r.Context(), limit, offset)
 	if err != nil {
 		h.H.WriteError(w, r, err)
 		return
@@ -233,7 +233,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 func (h *Handler) Get(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var id = ps.ByName("id")
 
-	c, err := h.Manager.GetConcreteClient(id)
+	c, err := h.Manager.GetConcreteClient(r.Context(), id)
 	if err != nil {
 		h.H.WriteError(w, r, err)
 		return
@@ -267,7 +267,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var id = ps.ByName("id")
 
-	if err := h.Manager.DeleteClient(id); err != nil {
+	if err := h.Manager.DeleteClient(r.Context(), id); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}

--- a/client/manager.go
+++ b/client/manager.go
@@ -21,25 +21,27 @@
 package client
 
 import (
+	"context"
+
 	"github.com/ory/fosite"
 )
 
 type Manager interface {
 	Storage
 
-	Authenticate(id string, secret []byte) (*Client, error)
+	Authenticate(ctx context.Context, id string, secret []byte) (*Client, error)
 }
 
 type Storage interface {
 	fosite.Storage
 
-	CreateClient(c *Client) error
+	CreateClient(ctx context.Context, c *Client) error
 
-	UpdateClient(c *Client) error
+	UpdateClient(ctx context.Context, c *Client) error
 
-	DeleteClient(id string) error
+	DeleteClient(ctx context.Context, id string) error
 
-	GetClients(limit, offset int) (map[string]Client, error)
+	GetClients(ctx context.Context, limit, offset int) (map[string]Client, error)
 
-	GetConcreteClient(id string) (*Client, error)
+	GetConcreteClient(ctx context.Context, id string) (*Client, error)
 }

--- a/client/manager_0_sql_migrations_test.go
+++ b/client/manager_0_sql_migrations_test.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"testing"
 
+	"context"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/client"
@@ -197,7 +199,7 @@ func TestMigrations(t *testing.T) {
 			for _, key := range []string{"1-data", "2-data", "3-data", "4-data", "5-data"} {
 				t.Run("client="+key, func(t *testing.T) {
 					s := &client.SQLManager{DB: db, Hasher: &fosite.BCrypt{WorkFactor: 4}}
-					c, err := s.GetConcreteClient(key)
+					c, err := s.GetConcreteClient(context.TODO(), key)
 					require.NoError(t, err)
 					assert.EqualValues(t, c.GetID(), key)
 				})

--- a/client/manager_memory.go
+++ b/client/manager_memory.go
@@ -48,7 +48,7 @@ func NewMemoryManager(hasher fosite.Hasher) *MemoryManager {
 	}
 }
 
-func (m *MemoryManager) GetConcreteClient(id string) (*Client, error) {
+func (m *MemoryManager) GetConcreteClient(ctx context.Context, id string) (*Client, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -61,12 +61,12 @@ func (m *MemoryManager) GetConcreteClient(id string) (*Client, error) {
 	return nil, errors.WithStack(sqlcon.ErrNoRows)
 }
 
-func (m *MemoryManager) GetClient(_ context.Context, id string) (fosite.Client, error) {
-	return m.GetConcreteClient(id)
+func (m *MemoryManager) GetClient(ctx context.Context, id string) (fosite.Client, error) {
+	return m.GetConcreteClient(ctx, id)
 }
 
-func (m *MemoryManager) UpdateClient(c *Client) error {
-	o, err := m.GetClient(context.Background(), c.GetID())
+func (m *MemoryManager) UpdateClient(ctx context.Context, c *Client) error {
+	o, err := m.GetClient(ctx, c.GetID())
 	if err != nil {
 		return err
 	}
@@ -95,11 +95,11 @@ func (m *MemoryManager) UpdateClient(c *Client) error {
 	return nil
 }
 
-func (m *MemoryManager) Authenticate(id string, secret []byte) (*Client, error) {
+func (m *MemoryManager) Authenticate(ctx context.Context, id string, secret []byte) (*Client, error) {
 	m.RLock()
 	defer m.RUnlock()
 
-	c, err := m.GetConcreteClient(id)
+	c, err := m.GetConcreteClient(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -111,8 +111,8 @@ func (m *MemoryManager) Authenticate(id string, secret []byte) (*Client, error) 
 	return c, nil
 }
 
-func (m *MemoryManager) CreateClient(c *Client) error {
-	if _, err := m.GetConcreteClient(c.GetID()); err == nil {
+func (m *MemoryManager) CreateClient(ctx context.Context, c *Client) error {
+	if _, err := m.GetConcreteClient(ctx, c.GetID()); err == nil {
 		return sqlcon.ErrUniqueViolation
 	}
 
@@ -129,7 +129,7 @@ func (m *MemoryManager) CreateClient(c *Client) error {
 	return nil
 }
 
-func (m *MemoryManager) DeleteClient(id string) error {
+func (m *MemoryManager) DeleteClient(ctx context.Context, id string) error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -143,7 +143,7 @@ func (m *MemoryManager) DeleteClient(id string) error {
 	return nil
 }
 
-func (m *MemoryManager) GetClients(limit, offset int) (clients map[string]Client, err error) {
+func (m *MemoryManager) GetClients(ctx context.Context, limit, offset int) (clients map[string]Client, err error) {
 	m.RLock()
 	defer m.RUnlock()
 	clients = make(map[string]Client)

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -336,7 +336,7 @@ func (m *SQLManager) CreateSchemas() (int, error) {
 	return n, nil
 }
 
-func (m *SQLManager) GetConcreteClient(id string) (*Client, error) {
+func (m *SQLManager) GetConcreteClient(ctx context.Context, id string) (*Client, error) {
 	var d sqlData
 	if err := m.DB.Get(&d, m.DB.Rebind("SELECT * FROM hydra_client WHERE id=?"), id); err != nil {
 		return nil, sqlcon.HandleError(err)
@@ -345,11 +345,11 @@ func (m *SQLManager) GetConcreteClient(id string) (*Client, error) {
 	return d.ToClient()
 }
 
-func (m *SQLManager) GetClient(_ context.Context, id string) (fosite.Client, error) {
-	return m.GetConcreteClient(id)
+func (m *SQLManager) GetClient(ctx context.Context, id string) (fosite.Client, error) {
+	return m.GetConcreteClient(ctx, id)
 }
 
-func (m *SQLManager) UpdateClient(c *Client) error {
+func (m *SQLManager) UpdateClient(ctx context.Context, c *Client) error {
 	o, err := m.GetClient(context.Background(), c.GetID())
 	if err != nil {
 		return errors.WithStack(err)
@@ -381,8 +381,8 @@ func (m *SQLManager) UpdateClient(c *Client) error {
 	return nil
 }
 
-func (m *SQLManager) Authenticate(id string, secret []byte) (*Client, error) {
-	c, err := m.GetConcreteClient(id)
+func (m *SQLManager) Authenticate(ctx context.Context, id string, secret []byte) (*Client, error) {
+	c, err := m.GetConcreteClient(ctx, id)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -394,7 +394,7 @@ func (m *SQLManager) Authenticate(id string, secret []byte) (*Client, error) {
 	return c, nil
 }
 
-func (m *SQLManager) CreateClient(c *Client) error {
+func (m *SQLManager) CreateClient(ctx context.Context, c *Client) error {
 	h, err := m.Hasher.Hash([]byte(c.Secret))
 	if err != nil {
 		return errors.WithStack(err)
@@ -417,14 +417,14 @@ func (m *SQLManager) CreateClient(c *Client) error {
 	return nil
 }
 
-func (m *SQLManager) DeleteClient(id string) error {
+func (m *SQLManager) DeleteClient(ctx context.Context, id string) error {
 	if _, err := m.DB.Exec(m.DB.Rebind(`DELETE FROM hydra_client WHERE id=?`), id); err != nil {
 		return sqlcon.HandleError(err)
 	}
 	return nil
 }
 
-func (m *SQLManager) GetClients(limit, offset int) (clients map[string]Client, err error) {
+func (m *SQLManager) GetClients(ctx context.Context, limit, offset int) (clients map[string]Client, err error) {
 	d := make([]sqlData, 0)
 	clients = make(map[string]Client)
 

--- a/cmd/server/helper_cert.go
+++ b/cmd/server/helper_cert.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
 	"github.com/ory/hydra/config"
 	"github.com/ory/hydra/jwk"
 	"github.com/ory/hydra/pkg"
@@ -105,10 +107,10 @@ func getOrCreateTLSCertificate(cmd *cobra.Command, c *config.Config) tls.Certifi
 		}
 
 		privateKey.Certificates = []*x509.Certificate{cert}
-		if err := ctx.KeyManager.DeleteKey(tlsKeyName, privateKey.KeyID); err != nil {
+		if err := ctx.KeyManager.DeleteKey(context.TODO(), tlsKeyName, privateKey.KeyID); err != nil {
 			c.GetLogger().WithError(err).Fatalf(`Could not update (delete) the self signed TLS certificate.`)
 		}
-		if err := ctx.KeyManager.AddKey(tlsKeyName, privateKey); err != nil {
+		if err := ctx.KeyManager.AddKey(context.TODO(), tlsKeyName, privateKey); err != nil {
 			c.GetLogger().WithError(err).Fatalf(`Could not update (add) the self signed TLS certificate.`)
 		}
 	}

--- a/cmd/server/helper_cors.go
+++ b/cmd/server/helper_cors.go
@@ -36,7 +36,7 @@ import (
 func newCORSMiddleware(
 	enable bool, c *config.Config,
 	o func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error),
-	clm func(id string) (*client.Client, error),
+	clm func(ctx context.Context, id string) (*client.Client, error),
 ) func(h http.Handler) http.Handler {
 	if !enable {
 		return func(h http.Handler) http.Handler {
@@ -76,7 +76,7 @@ func newCORSMiddleware(
 				username = ar.GetClient().GetID()
 			}
 
-			cl, err := clm(username)
+			cl, err := clm(r.Context(), username)
 			if err != nil {
 				return false
 			}

--- a/cmd/server/helper_cors_test.go
+++ b/cmd/server/helper_cors_test.go
@@ -59,7 +59,7 @@ func TestCORSMiddleware(t *testing.T) {
 		},
 		{
 			d: "should reject when basic auth but client does not exist",
-			mw: newCORSMiddleware(true, c, nil, func(id string) (*client.Client, error) {
+			mw: newCORSMiddleware(true, c, nil, func(ctx context.Context, id string) (*client.Client, error) {
 				return nil, errors.New("")
 			}),
 			code:         204,
@@ -68,7 +68,7 @@ func TestCORSMiddleware(t *testing.T) {
 		},
 		{
 			d: "should reject when basic auth client exists but origin not allowed",
-			mw: newCORSMiddleware(true, c, nil, func(id string) (*client.Client, error) {
+			mw: newCORSMiddleware(true, c, nil, func(ctx context.Context, id string) (*client.Client, error) {
 				return &client.Client{AllowedCORSOrigins: []string{"http://not-foobar.com"}}, nil
 			}),
 			code:         204,
@@ -77,7 +77,7 @@ func TestCORSMiddleware(t *testing.T) {
 		},
 		{
 			d: "should accept when basic auth client exists and origin allowed",
-			mw: newCORSMiddleware(true, c, nil, func(id string) (*client.Client, error) {
+			mw: newCORSMiddleware(true, c, nil, func(ctx context.Context, id string) (*client.Client, error) {
 				return &client.Client{AllowedCORSOrigins: []string{"http://foobar.com"}}, nil
 			}),
 			code:         204,
@@ -88,7 +88,7 @@ func TestCORSMiddleware(t *testing.T) {
 			d: "should fail when token introspection fails",
 			mw: newCORSMiddleware(true, c, func(ctx context.Context, token string, tokenType fosite.TokenType, session fosite.Session, scope ...string) (fosite.TokenType, fosite.AccessRequester, error) {
 				return "", nil, errors.New("")
-			}, func(id string) (*client.Client, error) {
+			}, func(ctx context.Context, id string) (*client.Client, error) {
 				return &client.Client{AllowedCORSOrigins: []string{"http://foobar.com"}}, nil
 			}),
 			code:         204,
@@ -102,7 +102,7 @@ func TestCORSMiddleware(t *testing.T) {
 					return "", nil, errors.New("")
 				}
 				return "", &fosite.AccessRequest{Request: fosite.Request{Client: &client.Client{ClientID: "asdf"}}}, nil
-			}, func(id string) (*client.Client, error) {
+			}, func(ctx context.Context, id string) (*client.Client, error) {
 				if id != "asdf" {
 					return nil, errors.New("")
 				}

--- a/cmd/server/helper_keys.go
+++ b/cmd/server/helper_keys.go
@@ -24,6 +24,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 
+	"context"
+
 	"github.com/ory/hydra/config"
 	"github.com/ory/hydra/jwk"
 	"github.com/ory/hydra/pkg"
@@ -36,7 +38,7 @@ func createOrGetJWK(c *config.Config, set string, kid string, prefix string) (ke
 
 	expectDependency(c.GetLogger(), ctx.KeyManager)
 
-	keys, err := ctx.KeyManager.GetKeySet(set)
+	keys, err := ctx.KeyManager.GetKeySet(context.TODO(), set)
 	if errors.Cause(err) == pkg.ErrNotFound || keys != nil && len(keys.Keys) == 0 {
 		c.GetLogger().Infof("JSON Web Key Set %s does not exist yet, generating new key pair...", set)
 		keys, err = createJWKS(ctx, set, kid)
@@ -77,7 +79,7 @@ func createJWKS(ctx *config.Context, set, kid string) (*jose.JSONWebKeySet, erro
 		keys.Keys[i] = k
 	}
 
-	err = ctx.KeyManager.AddKeySet(set, keys)
+	err = ctx.KeyManager.AddKeySet(context.TODO(), set, keys)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not persist %s key", set)
 	}

--- a/consent/handler_test.go
+++ b/consent/handler_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/gorilla/sessions"
 	"github.com/julienschmidt/httprouter"
 	"github.com/ory/herodot"
@@ -50,7 +52,7 @@ func TestLogout(t *testing.T) {
 
 	r.Handle("GET", "/login", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		cookie, _ := cs.Get(r, cookieAuthenticationName)
-		require.NoError(t, h.M.CreateAuthenticationSession(&AuthenticationSession{
+		require.NoError(t, h.M.CreateAuthenticationSession(context.TODO(), &AuthenticationSession{
 			ID:              sid,
 			Subject:         "foo",
 			AuthenticatedAt: time.Now(),

--- a/consent/manager.go
+++ b/consent/manager.go
@@ -20,6 +20,8 @@
 
 package consent
 
+import "context"
+
 type ForcedObfuscatedAuthenticationSession struct {
 	ClientID          string `db:"client_id"`
 	Subject           string `db:"subject"`
@@ -27,27 +29,27 @@ type ForcedObfuscatedAuthenticationSession struct {
 }
 
 type Manager interface {
-	CreateConsentRequest(*ConsentRequest) error
-	GetConsentRequest(challenge string) (*ConsentRequest, error)
-	HandleConsentRequest(challenge string, r *HandledConsentRequest) (*ConsentRequest, error)
-	RevokeUserConsentSession(user string) error
-	RevokeUserClientConsentSession(user, client string) error
+	CreateConsentRequest(ctx context.Context, req *ConsentRequest) error
+	GetConsentRequest(ctx context.Context, challenge string) (*ConsentRequest, error)
+	HandleConsentRequest(ctx context.Context, challenge string, r *HandledConsentRequest) (*ConsentRequest, error)
+	RevokeUserConsentSession(ctx context.Context, user string) error
+	RevokeUserClientConsentSession(ctx context.Context, user, client string) error
 
-	VerifyAndInvalidateConsentRequest(verifier string) (*HandledConsentRequest, error)
-	FindPreviouslyGrantedConsentRequests(client string, user string) ([]HandledConsentRequest, error)
-	FindPreviouslyGrantedConsentRequestsByUser(user string, limit, offset int) ([]HandledConsentRequest, error)
+	VerifyAndInvalidateConsentRequest(ctx context.Context, verifier string) (*HandledConsentRequest, error)
+	FindPreviouslyGrantedConsentRequests(ctx context.Context, client string, user string) ([]HandledConsentRequest, error)
+	FindPreviouslyGrantedConsentRequestsByUser(ctx context.Context, user string, limit, offset int) ([]HandledConsentRequest, error)
 
 	// Cookie management
-	GetAuthenticationSession(id string) (*AuthenticationSession, error)
-	CreateAuthenticationSession(*AuthenticationSession) error
-	DeleteAuthenticationSession(id string) error
-	RevokeUserAuthenticationSession(user string) error
+	GetAuthenticationSession(ctx context.Context, id string) (*AuthenticationSession, error)
+	CreateAuthenticationSession(ctx context.Context, session *AuthenticationSession) error
+	DeleteAuthenticationSession(ctx context.Context, id string) error
+	RevokeUserAuthenticationSession(ctx context.Context, user string) error
 
-	CreateAuthenticationRequest(*AuthenticationRequest) error
-	GetAuthenticationRequest(challenge string) (*AuthenticationRequest, error)
-	HandleAuthenticationRequest(challenge string, r *HandledAuthenticationRequest) (*AuthenticationRequest, error)
-	VerifyAndInvalidateAuthenticationRequest(verifier string) (*HandledAuthenticationRequest, error)
+	CreateAuthenticationRequest(ctx context.Context, req *AuthenticationRequest) error
+	GetAuthenticationRequest(ctx context.Context, challenge string) (*AuthenticationRequest, error)
+	HandleAuthenticationRequest(ctx context.Context, challenge string, r *HandledAuthenticationRequest) (*AuthenticationRequest, error)
+	VerifyAndInvalidateAuthenticationRequest(ctx context.Context, verifier string) (*HandledAuthenticationRequest, error)
 
-	CreateForcedObfuscatedAuthenticationSession(*ForcedObfuscatedAuthenticationSession) error
-	GetForcedObfuscatedAuthenticationSession(client, obfuscated string) (*ForcedObfuscatedAuthenticationSession, error)
+	CreateForcedObfuscatedAuthenticationSession(ctx context.Context, session *ForcedObfuscatedAuthenticationSession) error
+	GetForcedObfuscatedAuthenticationSession(ctx context.Context, client, obfuscated string) (*ForcedObfuscatedAuthenticationSession, error)
 }

--- a/consent/manager_sql.go
+++ b/consent/manager_sql.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/client"
@@ -223,7 +225,7 @@ func (m *SQLManager) GetConsentRequest(challenge string) (*ConsentRequest, error
 		return nil, sqlcon.HandleError(err)
 	}
 
-	c, err := m.c.GetConcreteClient(d.Client)
+	c, err := m.c.GetConcreteClient(context.TODO(), d.Client)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +260,7 @@ func (m *SQLManager) GetAuthenticationRequest(challenge string) (*Authentication
 		return nil, sqlcon.HandleError(err)
 	}
 
-	c, err := m.c.GetConcreteClient(d.Client)
+	c, err := m.c.GetConcreteClient(context.TODO(), d.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/consent/manager_test.go
+++ b/consent/manager_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	"github.com/ory/fosite"
@@ -279,7 +281,7 @@ func TestManagers(t *testing.T) {
 				} {
 					t.Run("key="+tc.key, func(t *testing.T) {
 						c, h := mockConsentRequest(tc.key, tc.remember, tc.rememberFor, tc.hasError, tc.skip, tc.authAt)
-						clientManager.CreateClient(c.Client) // Ignore errors that are caused by duplication
+						clientManager.CreateClient(context.TODO(), c.Client) // Ignore errors that are caused by duplication
 
 						_, err := m.GetConsentRequest("challenge" + tc.key)
 						require.Error(t, err)
@@ -348,7 +350,7 @@ func TestManagers(t *testing.T) {
 				} {
 					t.Run("key="+tc.key, func(t *testing.T) {
 						c, h := mockAuthRequest(tc.key, tc.authAt)
-						clientManager.CreateClient(c.Client) // Ignore errors that are caused by duplication
+						clientManager.CreateClient(context.TODO(), c.Client) // Ignore errors that are caused by duplication
 
 						_, err := m.GetAuthenticationRequest("challenge" + tc.key)
 						require.Error(t, err)
@@ -429,8 +431,8 @@ func TestManagers(t *testing.T) {
 		for k, m := range managers {
 			cr1, hcr1 := mockConsentRequest("rv1", false, 0, false, false, false)
 			cr2, hcr2 := mockConsentRequest("rv2", false, 0, false, false, false)
-			clientManager.CreateClient(cr1.Client)
-			clientManager.CreateClient(cr2.Client)
+			clientManager.CreateClient(context.TODO(), cr1.Client)
+			clientManager.CreateClient(context.TODO(), cr2.Client)
 
 			require.NoError(t, m.CreateConsentRequest(cr1))
 			require.NoError(t, m.CreateConsentRequest(cr2))
@@ -500,8 +502,8 @@ func TestManagers(t *testing.T) {
 		for k, m := range managers {
 			cr1, hcr1 := mockConsentRequest("rv1", true, 0, false, false, false)
 			cr2, hcr2 := mockConsentRequest("rv2", false, 0, false, false, false)
-			clientManager.CreateClient(cr1.Client)
-			clientManager.CreateClient(cr2.Client)
+			clientManager.CreateClient(context.TODO(), cr1.Client)
+			clientManager.CreateClient(context.TODO(), cr2.Client)
 
 			require.NoError(t, m.CreateConsentRequest(cr1))
 			require.NoError(t, m.CreateConsentRequest(cr2))

--- a/consent/manager_test.go
+++ b/consent/manager_test.go
@@ -225,13 +225,13 @@ func TestManagers(t *testing.T) {
 					},
 				} {
 					t.Run("case=create-get-"+tc.s.ID, func(t *testing.T) {
-						_, err := m.GetAuthenticationSession(tc.s.ID)
+						_, err := m.GetAuthenticationSession(context.TODO(), tc.s.ID)
 						require.EqualError(t, err, pkg.ErrNotFound.Error())
 
-						err = m.CreateAuthenticationSession(&tc.s)
+						err = m.CreateAuthenticationSession(context.TODO(), &tc.s)
 						require.NoError(t, err)
 
-						got, err := m.GetAuthenticationSession(tc.s.ID)
+						got, err := m.GetAuthenticationSession(context.TODO(), tc.s.ID)
 						require.NoError(t, err)
 						assert.EqualValues(t, tc.s.ID, got.ID)
 						assert.EqualValues(t, tc.s.AuthenticatedAt.Unix(), got.AuthenticatedAt.Unix())
@@ -249,10 +249,10 @@ func TestManagers(t *testing.T) {
 					},
 				} {
 					t.Run("case=delete-get-"+tc.id, func(t *testing.T) {
-						err := m.DeleteAuthenticationSession(tc.id)
+						err := m.DeleteAuthenticationSession(context.TODO(), tc.id)
 						require.NoError(t, err)
 
-						_, err = m.GetAuthenticationSession(tc.id)
+						_, err = m.GetAuthenticationSession(context.TODO(), tc.id)
 						require.Error(t, err)
 					})
 				}
@@ -283,25 +283,25 @@ func TestManagers(t *testing.T) {
 						c, h := mockConsentRequest(tc.key, tc.remember, tc.rememberFor, tc.hasError, tc.skip, tc.authAt)
 						clientManager.CreateClient(context.TODO(), c.Client) // Ignore errors that are caused by duplication
 
-						_, err := m.GetConsentRequest("challenge" + tc.key)
+						_, err := m.GetConsentRequest(context.TODO(), "challenge"+tc.key)
 						require.Error(t, err)
 
-						require.NoError(t, m.CreateConsentRequest(c))
+						require.NoError(t, m.CreateConsentRequest(context.TODO(), c))
 
-						got1, err := m.GetConsentRequest("challenge" + tc.key)
+						got1, err := m.GetConsentRequest(context.TODO(), "challenge"+tc.key)
 						require.NoError(t, err)
 						compareConsentRequest(t, c, got1)
 
-						got1, err = m.HandleConsentRequest("challenge"+tc.key, h)
+						got1, err = m.HandleConsentRequest(context.TODO(), "challenge"+tc.key, h)
 						require.NoError(t, err)
 						compareConsentRequest(t, c, got1)
 
-						got2, err := m.VerifyAndInvalidateConsentRequest("verifier" + tc.key)
+						got2, err := m.VerifyAndInvalidateConsentRequest(context.TODO(), "verifier"+tc.key)
 						require.NoError(t, err)
 						compareConsentRequest(t, c, got2.ConsentRequest)
 						assert.Equal(t, c.Challenge, got2.Challenge)
 
-						_, err = m.VerifyAndInvalidateConsentRequest("verifier" + tc.key)
+						_, err = m.VerifyAndInvalidateConsentRequest(context.TODO(), "verifier"+tc.key)
 						require.Error(t, err)
 					})
 				}
@@ -321,7 +321,7 @@ func TestManagers(t *testing.T) {
 					{"6", "6", 0},
 				} {
 					t.Run("key="+tc.keyC+"-"+tc.keyS, func(t *testing.T) {
-						rs, err := m.FindPreviouslyGrantedConsentRequests("client"+tc.keyC, "subject"+tc.keyS)
+						rs, err := m.FindPreviouslyGrantedConsentRequests(context.TODO(), "client"+tc.keyC, "subject"+tc.keyS)
 						if tc.expectedLength == 0 {
 							assert.EqualError(t, err, ErrNoPreviousConsentFound.Error())
 						} else {
@@ -352,25 +352,25 @@ func TestManagers(t *testing.T) {
 						c, h := mockAuthRequest(tc.key, tc.authAt)
 						clientManager.CreateClient(context.TODO(), c.Client) // Ignore errors that are caused by duplication
 
-						_, err := m.GetAuthenticationRequest("challenge" + tc.key)
+						_, err := m.GetAuthenticationRequest(context.TODO(), "challenge"+tc.key)
 						require.Error(t, err)
 
-						require.NoError(t, m.CreateAuthenticationRequest(c))
+						require.NoError(t, m.CreateAuthenticationRequest(context.TODO(), c))
 
-						got1, err := m.GetAuthenticationRequest("challenge" + tc.key)
+						got1, err := m.GetAuthenticationRequest(context.TODO(), "challenge"+tc.key)
 						require.NoError(t, err)
 						compareAuthenticationRequest(t, c, got1)
 
-						got1, err = m.HandleAuthenticationRequest("challenge"+tc.key, h)
+						got1, err = m.HandleAuthenticationRequest(context.TODO(), "challenge"+tc.key, h)
 						require.NoError(t, err)
 						compareAuthenticationRequest(t, c, got1)
 
-						got2, err := m.VerifyAndInvalidateAuthenticationRequest("verifier" + tc.key)
+						got2, err := m.VerifyAndInvalidateAuthenticationRequest(context.TODO(), "verifier"+tc.key)
 						require.NoError(t, err)
 						compareAuthenticationRequest(t, c, got2.AuthenticationRequest)
 						assert.Equal(t, c.Challenge, got2.Challenge)
 
-						_, err = m.VerifyAndInvalidateAuthenticationRequest("verifier" + tc.key)
+						_, err = m.VerifyAndInvalidateAuthenticationRequest(context.TODO(), "verifier"+tc.key)
 						require.Error(t, err)
 					})
 				}
@@ -380,19 +380,19 @@ func TestManagers(t *testing.T) {
 
 	t.Run("case=revoke-auth-request", func(t *testing.T) {
 		for k, m := range managers {
-			require.NoError(t, m.CreateAuthenticationSession(&AuthenticationSession{
+			require.NoError(t, m.CreateAuthenticationSession(context.TODO(), &AuthenticationSession{
 				ID:              "rev-session-1",
 				AuthenticatedAt: time.Now(),
 				Subject:         "subject-1",
 			}))
 
-			require.NoError(t, m.CreateAuthenticationSession(&AuthenticationSession{
+			require.NoError(t, m.CreateAuthenticationSession(context.TODO(), &AuthenticationSession{
 				ID:              "rev-session-2",
 				AuthenticatedAt: time.Now(),
 				Subject:         "subject-2",
 			}))
 
-			require.NoError(t, m.CreateAuthenticationSession(&AuthenticationSession{
+			require.NoError(t, m.CreateAuthenticationSession(context.TODO(), &AuthenticationSession{
 				ID:              "rev-session-3",
 				AuthenticatedAt: time.Now(),
 				Subject:         "subject-1",
@@ -413,11 +413,11 @@ func TestManagers(t *testing.T) {
 					},
 				} {
 					t.Run(fmt.Sprintf("case=%d/subject=%s", i, tc.subject), func(t *testing.T) {
-						require.NoError(t, m.RevokeUserAuthenticationSession(tc.subject))
+						require.NoError(t, m.RevokeUserAuthenticationSession(context.TODO(), tc.subject))
 
 						for _, id := range tc.ids {
 							t.Run(fmt.Sprintf("id=%s", id), func(t *testing.T) {
-								_, err := m.GetAuthenticationSession(id)
+								_, err := m.GetAuthenticationSession(context.TODO(), id)
 								assert.EqualError(t, err, pkg.ErrNotFound.Error())
 							})
 						}
@@ -434,11 +434,11 @@ func TestManagers(t *testing.T) {
 			clientManager.CreateClient(context.TODO(), cr1.Client)
 			clientManager.CreateClient(context.TODO(), cr2.Client)
 
-			require.NoError(t, m.CreateConsentRequest(cr1))
-			require.NoError(t, m.CreateConsentRequest(cr2))
-			_, err := m.HandleConsentRequest("challengerv1", hcr1)
+			require.NoError(t, m.CreateConsentRequest(context.TODO(), cr1))
+			require.NoError(t, m.CreateConsentRequest(context.TODO(), cr2))
+			_, err := m.HandleConsentRequest(context.TODO(), "challengerv1", hcr1)
 			require.NoError(t, err)
-			_, err = m.HandleConsentRequest("challengerv2", hcr2)
+			_, err = m.HandleConsentRequest(context.TODO(), "challengerv2", hcr2)
 			require.NoError(t, err)
 
 			t.Run("manager="+k, func(t *testing.T) {
@@ -474,14 +474,14 @@ func TestManagers(t *testing.T) {
 						assert.True(t, found)
 
 						if tc.client == "" {
-							require.NoError(t, m.RevokeUserConsentSession(tc.subject))
+							require.NoError(t, m.RevokeUserConsentSession(context.TODO(), tc.subject))
 						} else {
-							require.NoError(t, m.RevokeUserClientConsentSession(tc.subject, tc.client))
+							require.NoError(t, m.RevokeUserClientConsentSession(context.TODO(), tc.subject, tc.client))
 						}
 
 						for _, id := range tc.ids {
 							t.Run(fmt.Sprintf("id=%s", id), func(t *testing.T) {
-								_, err := m.GetConsentRequest(id)
+								_, err := m.GetConsentRequest(context.TODO(), id)
 								assert.EqualError(t, err, pkg.ErrNotFound.Error())
 							})
 						}
@@ -505,11 +505,11 @@ func TestManagers(t *testing.T) {
 			clientManager.CreateClient(context.TODO(), cr1.Client)
 			clientManager.CreateClient(context.TODO(), cr2.Client)
 
-			require.NoError(t, m.CreateConsentRequest(cr1))
-			require.NoError(t, m.CreateConsentRequest(cr2))
-			_, err := m.HandleConsentRequest("challengerv1", hcr1)
+			require.NoError(t, m.CreateConsentRequest(context.TODO(), cr1))
+			require.NoError(t, m.CreateConsentRequest(context.TODO(), cr2))
+			_, err := m.HandleConsentRequest(context.TODO(), "challengerv1", hcr1)
 			require.NoError(t, err)
-			_, err = m.HandleConsentRequest("challengerv2", hcr2)
+			_, err = m.HandleConsentRequest(context.TODO(), "challengerv2", hcr2)
 			require.NoError(t, err)
 
 			t.Run("manager="+k, func(t *testing.T) {
@@ -530,7 +530,7 @@ func TestManagers(t *testing.T) {
 					},
 				} {
 					t.Run(fmt.Sprintf("case=%d/subject=%s", i, tc.subject), func(t *testing.T) {
-						consents, err := m.FindPreviouslyGrantedConsentRequestsByUser(tc.subject, 100, 0)
+						consents, err := m.FindPreviouslyGrantedConsentRequestsByUser(context.TODO(), tc.subject, 100, 0)
 						assert.Equal(t, len(tc.challenges), len(consents))
 
 						if len(tc.challenges) == 0 {
@@ -551,7 +551,7 @@ func TestManagers(t *testing.T) {
 		t.Run("case=obfuscated", func(t *testing.T) {
 			for k, m := range managers {
 				t.Run(fmt.Sprintf("manager=%s", k), func(t *testing.T) {
-					got, err := m.GetForcedObfuscatedAuthenticationSession("client-1", "obfuscated-1")
+					got, err := m.GetForcedObfuscatedAuthenticationSession(context.TODO(), "client-1", "obfuscated-1")
 					require.EqualError(t, err, pkg.ErrNotFound.Error())
 
 					expect := &ForcedObfuscatedAuthenticationSession{
@@ -559,9 +559,9 @@ func TestManagers(t *testing.T) {
 						Subject:           "subject-1",
 						SubjectObfuscated: "obfuscated-1",
 					}
-					require.NoError(t, m.CreateForcedObfuscatedAuthenticationSession(expect))
+					require.NoError(t, m.CreateForcedObfuscatedAuthenticationSession(context.TODO(), expect))
 
-					got, err = m.GetForcedObfuscatedAuthenticationSession("client-1", "obfuscated-1")
+					got, err = m.GetForcedObfuscatedAuthenticationSession(context.TODO(), "client-1", "obfuscated-1")
 					require.NoError(t, err)
 					assert.EqualValues(t, expect, got)
 
@@ -570,13 +570,13 @@ func TestManagers(t *testing.T) {
 						Subject:           "subject-1",
 						SubjectObfuscated: "obfuscated-2",
 					}
-					require.NoError(t, m.CreateForcedObfuscatedAuthenticationSession(expect))
+					require.NoError(t, m.CreateForcedObfuscatedAuthenticationSession(context.TODO(), expect))
 
-					got, err = m.GetForcedObfuscatedAuthenticationSession("client-1", "obfuscated-2")
+					got, err = m.GetForcedObfuscatedAuthenticationSession(context.TODO(), "client-1", "obfuscated-2")
 					require.NoError(t, err)
 					assert.EqualValues(t, expect, got)
 
-					got, err = m.GetForcedObfuscatedAuthenticationSession("client-1", "obfuscated-1")
+					got, err = m.GetForcedObfuscatedAuthenticationSession(context.TODO(), "client-1", "obfuscated-1")
 					require.EqualError(t, err, pkg.ErrNotFound.Error())
 				})
 			}

--- a/consent/sdk_test.go
+++ b/consent/sdk_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/gorilla/sessions"
 	"github.com/julienschmidt/httprouter"
 	"github.com/ory/herodot"
@@ -51,27 +53,27 @@ func TestSDK(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, m.CreateAuthenticationSession(&AuthenticationSession{
+	require.NoError(t, m.CreateAuthenticationSession(context.TODO(), &AuthenticationSession{
 		ID:      "session1",
 		Subject: "subject1",
 	}))
 
 	ar1, _ := mockAuthRequest("1", false)
 	ar2, _ := mockAuthRequest("2", false)
-	require.NoError(t, m.CreateAuthenticationRequest(ar1))
-	require.NoError(t, m.CreateAuthenticationRequest(ar2))
+	require.NoError(t, m.CreateAuthenticationRequest(context.TODO(), ar1))
+	require.NoError(t, m.CreateAuthenticationRequest(context.TODO(), ar2))
 
 	cr1, hcr1 := mockConsentRequest("1", false, 0, false, false, false)
 	cr2, hcr2 := mockConsentRequest("2", false, 0, false, false, false)
 	cr3, hcr3 := mockConsentRequest("3", true, 3600, false, false, false)
-	require.NoError(t, m.CreateConsentRequest(cr1))
-	require.NoError(t, m.CreateConsentRequest(cr2))
-	require.NoError(t, m.CreateConsentRequest(cr3))
-	_, err = m.HandleConsentRequest("challenge1", hcr1)
+	require.NoError(t, m.CreateConsentRequest(context.TODO(), cr1))
+	require.NoError(t, m.CreateConsentRequest(context.TODO(), cr2))
+	require.NoError(t, m.CreateConsentRequest(context.TODO(), cr3))
+	_, err = m.HandleConsentRequest(context.TODO(), "challenge1", hcr1)
 	require.NoError(t, err)
-	_, err = m.HandleConsentRequest("challenge2", hcr2)
+	_, err = m.HandleConsentRequest(context.TODO(), "challenge2", hcr2)
 	require.NoError(t, err)
-	_, err = m.HandleConsentRequest("challenge3", hcr3)
+	_, err = m.HandleConsentRequest(context.TODO(), "challenge3", hcr3)
 	require.NoError(t, err)
 
 	crGot, res, err := sdk.GetConsentRequest("challenge1")

--- a/integration/sql_schema_test.go
+++ b/integration/sql_schema_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	"github.com/ory/fosite"
@@ -76,7 +78,7 @@ func TestSQLSchema(t *testing.T) {
 
 	require.NoError(t, jm.AddKey("integration-test-foo", jwk.First(p1)))
 	require.NoError(t, pm.Create(&ladon.DefaultPolicy{ID: "integration-test-foo", Resources: []string{"foo"}, Actions: []string{"bar"}, Subjects: []string{"baz"}, Effect: "allow"}))
-	require.NoError(t, cm.CreateClient(&client.Client{ClientID: "integration-test-foo"}))
+	require.NoError(t, cm.CreateClient(context.TODO(), &client.Client{ClientID: "integration-test-foo"}))
 	require.NoError(t, crm.CreateAuthenticationSession(&consent.AuthenticationSession{
 		ID:              "foo",
 		AuthenticatedAt: time.Now(),

--- a/integration/sql_schema_test.go
+++ b/integration/sql_schema_test.go
@@ -79,7 +79,7 @@ func TestSQLSchema(t *testing.T) {
 	require.NoError(t, jm.AddKey(context.TODO(), "integration-test-foo", jwk.First(p1)))
 	require.NoError(t, pm.Create(&ladon.DefaultPolicy{ID: "integration-test-foo", Resources: []string{"foo"}, Actions: []string{"bar"}, Subjects: []string{"baz"}, Effect: "allow"}))
 	require.NoError(t, cm.CreateClient(context.TODO(), &client.Client{ClientID: "integration-test-foo"}))
-	require.NoError(t, crm.CreateAuthenticationSession(&consent.AuthenticationSession{
+	require.NoError(t, crm.CreateAuthenticationSession(context.TODO(), &consent.AuthenticationSession{
 		ID:              "foo",
 		AuthenticatedAt: time.Now(),
 		Subject:         "bar",

--- a/integration/sql_schema_test.go
+++ b/integration/sql_schema_test.go
@@ -76,7 +76,7 @@ func TestSQLSchema(t *testing.T) {
 	_, err = crm.CreateSchemas()
 	require.NoError(t, err)
 
-	require.NoError(t, jm.AddKey("integration-test-foo", jwk.First(p1)))
+	require.NoError(t, jm.AddKey(context.TODO(), "integration-test-foo", jwk.First(p1)))
 	require.NoError(t, pm.Create(&ladon.DefaultPolicy{ID: "integration-test-foo", Resources: []string{"foo"}, Actions: []string{"bar"}, Subjects: []string{"baz"}, Effect: "allow"}))
 	require.NoError(t, cm.CreateClient(context.TODO(), &client.Client{ClientID: "integration-test-foo"}))
 	require.NoError(t, crm.CreateAuthenticationSession(&consent.AuthenticationSession{

--- a/jwk/handler.go
+++ b/jwk/handler.go
@@ -110,7 +110,7 @@ func (h *Handler) WellKnown(w http.ResponseWriter, r *http.Request, ps httproute
 	var jwks jose.JSONWebKeySet
 
 	for _, set := range h.WellKnownKeys {
-		keys, err := h.Manager.GetKeySet(set)
+		keys, err := h.Manager.GetKeySet(r.Context(), set)
 		if err != nil {
 			h.H.WriteError(w, r, err)
 			return
@@ -153,7 +153,7 @@ func (h *Handler) GetKey(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	var setName = ps.ByName("set")
 	var keyName = ps.ByName("key")
 
-	keys, err := h.Manager.GetKey(setName, keyName)
+	keys, err := h.Manager.GetKey(r.Context(), setName, keyName)
 	if err != nil {
 		h.H.WriteError(w, r, err)
 		return
@@ -186,7 +186,7 @@ func (h *Handler) GetKey(w http.ResponseWriter, r *http.Request, ps httprouter.P
 func (h *Handler) GetKeySet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var setName = ps.ByName("set")
 
-	keys, err := h.Manager.GetKeySet(setName)
+	keys, err := h.Manager.GetKeySet(r.Context(), setName)
 	if err != nil {
 		h.H.WriteError(w, r, err)
 		return
@@ -236,7 +236,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, ps httprouter.P
 		return
 	}
 
-	if err := h.Manager.AddKeySet(set, keys); err != nil {
+	if err := h.Manager.AddKeySet(r.Context(), set, keys); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
@@ -274,7 +274,7 @@ func (h *Handler) UpdateKeySet(w http.ResponseWriter, r *http.Request, ps httpro
 		return
 	}
 
-	if err := h.Manager.AddKeySet(set, &keySet); err != nil {
+	if err := h.Manager.AddKeySet(r.Context(), set, &keySet); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
@@ -312,12 +312,12 @@ func (h *Handler) UpdateKey(w http.ResponseWriter, r *http.Request, ps httproute
 		return
 	}
 
-	if err := h.Manager.DeleteKey(set, key.KeyID); err != nil {
+	if err := h.Manager.DeleteKey(r.Context(), set, key.KeyID); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
 
-	if err := h.Manager.AddKey(set, &key); err != nil {
+	if err := h.Manager.AddKey(r.Context(), set, &key); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
@@ -349,7 +349,7 @@ func (h *Handler) UpdateKey(w http.ResponseWriter, r *http.Request, ps httproute
 func (h *Handler) DeleteKeySet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var setName = ps.ByName("set")
 
-	if err := h.Manager.DeleteKeySet(setName); err != nil {
+	if err := h.Manager.DeleteKeySet(r.Context(), setName); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
@@ -382,7 +382,7 @@ func (h *Handler) DeleteKey(w http.ResponseWriter, r *http.Request, ps httproute
 	var setName = ps.ByName("set")
 	var keyName = ps.ByName("key")
 
-	if err := h.Manager.DeleteKey(setName, keyName); err != nil {
+	if err := h.Manager.DeleteKey(r.Context(), setName, keyName); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}

--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -26,6 +26,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"context"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/ory/herodot"
 	. "github.com/ory/hydra/jwk"
@@ -47,7 +49,7 @@ func init() {
 		herodot.NewJSONWriter(nil),
 		[]string{},
 	)
-	h.Manager.AddKeySet(IDTokenKeyName, IDKS)
+	h.Manager.AddKeySet(context.TODO(), IDTokenKeyName, IDKS)
 	h.SetRoutes(router, router)
 	testServer = httptest.NewServer(router)
 }

--- a/jwk/jwt_strategy.go
+++ b/jwk/jwt_strategy.go
@@ -24,6 +24,8 @@ import (
 	"crypto/rsa"
 	"strings"
 
+	"context"
+
 	jwt2 "github.com/dgrijalva/jwt-go"
 	"github.com/ory/fosite/token/jwt"
 	"github.com/pkg/errors"
@@ -104,7 +106,7 @@ func (j *RS256JWTStrategy) GetPublicKeyID() (string, error) {
 }
 
 func (j *RS256JWTStrategy) refresh() error {
-	keys, err := j.Manager.GetKeySet(j.Set)
+	keys, err := j.Manager.GetKeySet(context.TODO(), j.Set)
 	if err != nil {
 		return err
 	}

--- a/jwk/jwt_strategy_test.go
+++ b/jwk/jwt_strategy_test.go
@@ -23,6 +23,8 @@ package jwk
 import (
 	"testing"
 
+	"context"
+
 	jwt2 "github.com/dgrijalva/jwt-go"
 	"github.com/ory/fosite/token/jwt"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +41,7 @@ func TestRS256JWTStrategy(t *testing.T) {
 
 	ks, err := testGenerator.Generate("foo", "sig")
 	require.NoError(t, err)
-	require.NoError(t, m.AddKeySet("foo-set", ks))
+	require.NoError(t, m.AddKeySet(context.TODO(), "foo-set", ks))
 
 	s, err := NewRS256JWTStrategy(m, "foo-set")
 	require.NoError(t, err)
@@ -57,7 +59,7 @@ func TestRS256JWTStrategy(t *testing.T) {
 
 	ks, err = testGenerator.Generate("bar", "sig")
 	require.NoError(t, err)
-	require.NoError(t, m.AddKeySet("foo-set", ks))
+	require.NoError(t, m.AddKeySet(context.TODO(), "foo-set", ks))
 
 	a, b, err = s.Generate(jwt2.MapClaims{"foo": "bar"}, &jwt.Headers{})
 	require.NoError(t, err)

--- a/jwk/manager.go
+++ b/jwk/manager.go
@@ -20,18 +20,22 @@
 
 package jwk
 
-import "gopkg.in/square/go-jose.v2"
+import (
+	"context"
+
+	"gopkg.in/square/go-jose.v2"
+)
 
 type Manager interface {
-	AddKey(set string, key *jose.JSONWebKey) error
+	AddKey(ctx context.Context, set string, key *jose.JSONWebKey) error
 
-	AddKeySet(set string, keys *jose.JSONWebKeySet) error
+	AddKeySet(ctx context.Context, set string, keys *jose.JSONWebKeySet) error
 
-	GetKey(set, kid string) (*jose.JSONWebKeySet, error)
+	GetKey(ctx context.Context, set, kid string) (*jose.JSONWebKeySet, error)
 
-	GetKeySet(set string) (*jose.JSONWebKeySet, error)
+	GetKeySet(ctx context.Context, set string) (*jose.JSONWebKeySet, error)
 
-	DeleteKey(set, kid string) error
+	DeleteKey(ctx context.Context, set, kid string) error
 
-	DeleteKeySet(set string) error
+	DeleteKeySet(ctx context.Context, set string) error
 }

--- a/jwk/manager_memory.go
+++ b/jwk/manager_memory.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"context"
+
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/pkg"
 	"github.com/pkg/errors"
@@ -37,7 +39,7 @@ type MemoryManager struct {
 	sync.RWMutex
 }
 
-func (m *MemoryManager) AddKey(set string, key *jose.JSONWebKey) error {
+func (m *MemoryManager) AddKey(ctx context.Context, set string, key *jose.JSONWebKey) error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -60,14 +62,14 @@ func (m *MemoryManager) AddKey(set string, key *jose.JSONWebKey) error {
 	return nil
 }
 
-func (m *MemoryManager) AddKeySet(set string, keys *jose.JSONWebKeySet) error {
+func (m *MemoryManager) AddKeySet(ctx context.Context, set string, keys *jose.JSONWebKeySet) error {
 	for _, key := range keys.Keys {
-		m.AddKey(set, &key)
+		m.AddKey(ctx, set, &key)
 	}
 	return nil
 }
 
-func (m *MemoryManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
+func (m *MemoryManager) GetKey(ctx context.Context, set, kid string) (*jose.JSONWebKeySet, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -87,7 +89,7 @@ func (m *MemoryManager) GetKey(set, kid string) (*jose.JSONWebKeySet, error) {
 	}, nil
 }
 
-func (m *MemoryManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
+func (m *MemoryManager) GetKeySet(ctx context.Context, set string) (*jose.JSONWebKeySet, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -104,8 +106,8 @@ func (m *MemoryManager) GetKeySet(set string) (*jose.JSONWebKeySet, error) {
 	return keys, nil
 }
 
-func (m *MemoryManager) DeleteKey(set, kid string) error {
-	keys, err := m.GetKeySet(set)
+func (m *MemoryManager) DeleteKey(ctx context.Context, set, kid string) error {
+	keys, err := m.GetKeySet(ctx, set)
 	if err != nil {
 		return err
 	}
@@ -123,7 +125,7 @@ func (m *MemoryManager) DeleteKey(set, kid string) error {
 	return nil
 }
 
-func (m *MemoryManager) DeleteKeySet(set string) error {
+func (m *MemoryManager) DeleteKeySet(ctx context.Context, set string) error {
 	m.Lock()
 	defer m.Unlock()
 

--- a/jwk/manager_test.go
+++ b/jwk/manager_test.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"testing"
 
+	"context"
+
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	. "github.com/ory/hydra/jwk"
@@ -130,15 +132,15 @@ func TestManagerRotate(t *testing.T) {
 			require.NoError(t, err)
 			t.Logf("Applied %d migrations to %s", n, name)
 
-			require.NoError(t, m.AddKeySet("TestManagerRotate", ks))
+			require.NoError(t, m.AddKeySet(context.TODO(), "TestManagerRotate", ks))
 
 			require.NoError(t, m.RotateKeys(newCipher))
 
-			_, err = m.GetKeySet("TestManagerRotate")
+			_, err = m.GetKeySet(context.TODO(), "TestManagerRotate")
 			require.Error(t, err)
 
 			m.Cipher = newCipher
-			got, err := m.GetKeySet("TestManagerRotate")
+			got, err := m.GetKeySet(context.TODO(), "TestManagerRotate")
 			require.NoError(t, err)
 
 			for _, key := range ks.Keys {

--- a/jwk/manager_test_helpers.go
+++ b/jwk/manager_test_helpers.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,24 +48,24 @@ func TestHelperManagerKey(m Manager, keys *jose.JSONWebKeySet, suffix string) fu
 
 	return func(t *testing.T) {
 		t.Parallel()
-		_, err := m.GetKey("faz", "baz")
+		_, err := m.GetKey(context.TODO(), "faz", "baz")
 		assert.NotNil(t, err)
 
-		err = m.AddKey("faz", First(priv))
+		err = m.AddKey(context.TODO(), "faz", First(priv))
 		require.NoError(t, err)
 
-		got, err := m.GetKey("faz", "private:"+suffix)
-		require.NoError(t, err)
-		assert.Equal(t, priv, got.Keys)
-
-		err = m.AddKey("faz", First(pub))
-		require.NoError(t, err)
-
-		got, err = m.GetKey("faz", "private:"+suffix)
+		got, err := m.GetKey(context.TODO(), "faz", "private:"+suffix)
 		require.NoError(t, err)
 		assert.Equal(t, priv, got.Keys)
 
-		got, err = m.GetKey("faz", "public:"+suffix)
+		err = m.AddKey(context.TODO(), "faz", First(pub))
+		require.NoError(t, err)
+
+		got, err = m.GetKey(context.TODO(), "faz", "private:"+suffix)
+		require.NoError(t, err)
+		assert.Equal(t, priv, got.Keys)
+
+		got, err = m.GetKey(context.TODO(), "faz", "public:"+suffix)
 		require.NoError(t, err)
 		assert.Equal(t, pub, got.Keys)
 
@@ -71,20 +73,20 @@ func TestHelperManagerKey(m Manager, keys *jose.JSONWebKeySet, suffix string) fu
 		time.Sleep(time.Second * 2)
 
 		First(pub).KeyID = "new-key-id:" + suffix
-		err = m.AddKey("faz", First(pub))
+		err = m.AddKey(context.TODO(), "faz", First(pub))
 		require.NoError(t, err)
 
-		_, err = m.GetKey("faz", "new-key-id:"+suffix)
+		_, err = m.GetKey(context.TODO(), "faz", "new-key-id:"+suffix)
 		require.NoError(t, err)
 
-		keys, err = m.GetKeySet("faz")
+		keys, err = m.GetKeySet(context.TODO(), "faz")
 		require.NoError(t, err)
 		assert.EqualValues(t, "new-key-id:"+suffix, First(keys.Keys).KeyID)
 
-		err = m.DeleteKey("faz", "public:"+suffix)
+		err = m.DeleteKey(context.TODO(), "faz", "public:"+suffix)
 		require.NoError(t, err)
 
-		_, err = m.GetKey("faz", "public:"+suffix)
+		_, err = m.GetKey(context.TODO(), "faz", "public:"+suffix)
 		require.Error(t, err)
 	}
 }
@@ -92,21 +94,21 @@ func TestHelperManagerKey(m Manager, keys *jose.JSONWebKeySet, suffix string) fu
 func TestHelperManagerKeySet(m Manager, keys *jose.JSONWebKeySet, suffix string) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		_, err := m.GetKeySet("foo")
+		_, err := m.GetKeySet(context.TODO(), "foo")
 		require.Error(t, err)
 
-		err = m.AddKeySet("bar", keys)
+		err = m.AddKeySet(context.TODO(), "bar", keys)
 		require.NoError(t, err)
 
-		got, err := m.GetKeySet("bar")
+		got, err := m.GetKeySet(context.TODO(), "bar")
 		require.NoError(t, err)
 		assert.Equal(t, keys.Key("public:"+suffix), got.Key("public:"+suffix))
 		assert.Equal(t, keys.Key("private:"+suffix), got.Key("private:"+suffix))
 
-		err = m.DeleteKeySet("bar")
+		err = m.DeleteKeySet(context.TODO(), "bar")
 		require.NoError(t, err)
 
-		_, err = m.GetKeySet("bar")
+		_, err = m.GetKeySet(context.TODO(), "bar")
 		require.Error(t, err)
 	}
 }

--- a/oauth2/fosite_store_sql.go
+++ b/oauth2/fosite_store_sql.go
@@ -265,7 +265,7 @@ func (s *FositeSQLStore) hashSignature(signature, table string) string {
 	return signature
 }
 
-func (s *FositeSQLStore) createSession(signature string, requester fosite.Requester, table string) error {
+func (s *FositeSQLStore) createSession(ctx context.Context, signature string, requester fosite.Requester, table string) error {
 	signature = s.hashSignature(signature, table)
 
 	data, err := sqlSchemaFromRequest(signature, requester, s.L)
@@ -285,7 +285,7 @@ func (s *FositeSQLStore) createSession(signature string, requester fosite.Reques
 	return nil
 }
 
-func (s *FositeSQLStore) findSessionBySignature(signature string, session fosite.Session, table string) (fosite.Requester, error) {
+func (s *FositeSQLStore) findSessionBySignature(ctx context.Context, signature string, session fosite.Session, table string) (fosite.Requester, error) {
 	signature = s.hashSignature(signature, table)
 
 	var d sqlData
@@ -306,7 +306,7 @@ func (s *FositeSQLStore) findSessionBySignature(signature string, session fosite
 	return d.toRequest(session, s.Manager, s.L)
 }
 
-func (s *FositeSQLStore) deleteSession(signature string, table string) error {
+func (s *FositeSQLStore) deleteSession(ctx context.Context, signature string, table string) error {
 	signature = s.hashSignature(signature, table)
 
 	if _, err := s.DB.Exec(s.DB.Rebind(fmt.Sprintf("DELETE FROM hydra_oauth2_%s WHERE signature=?", table)), signature); err != nil {
@@ -324,24 +324,24 @@ func (s *FositeSQLStore) CreateSchemas() (int, error) {
 	return n, nil
 }
 
-func (s *FositeSQLStore) CreateOpenIDConnectSession(_ context.Context, signature string, requester fosite.Requester) error {
-	return s.createSession(signature, requester, sqlTableOpenID)
+func (s *FositeSQLStore) CreateOpenIDConnectSession(ctx context.Context, signature string, requester fosite.Requester) error {
+	return s.createSession(ctx, signature, requester, sqlTableOpenID)
 }
 
-func (s *FositeSQLStore) GetOpenIDConnectSession(_ context.Context, signature string, requester fosite.Requester) (fosite.Requester, error) {
-	return s.findSessionBySignature(signature, requester.GetSession(), sqlTableOpenID)
+func (s *FositeSQLStore) GetOpenIDConnectSession(ctx context.Context, signature string, requester fosite.Requester) (fosite.Requester, error) {
+	return s.findSessionBySignature(ctx, signature, requester.GetSession(), sqlTableOpenID)
 }
 
-func (s *FositeSQLStore) DeleteOpenIDConnectSession(_ context.Context, signature string) error {
-	return s.deleteSession(signature, sqlTableOpenID)
+func (s *FositeSQLStore) DeleteOpenIDConnectSession(ctx context.Context, signature string) error {
+	return s.deleteSession(ctx, signature, sqlTableOpenID)
 }
 
-func (s *FositeSQLStore) CreateAuthorizeCodeSession(_ context.Context, signature string, requester fosite.Requester) error {
-	return s.createSession(signature, requester, sqlTableCode)
+func (s *FositeSQLStore) CreateAuthorizeCodeSession(ctx context.Context, signature string, requester fosite.Requester) error {
+	return s.createSession(ctx, signature, requester, sqlTableCode)
 }
 
-func (s *FositeSQLStore) GetAuthorizeCodeSession(_ context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
-	return s.findSessionBySignature(signature, session, sqlTableCode)
+func (s *FositeSQLStore) GetAuthorizeCodeSession(ctx context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
+	return s.findSessionBySignature(ctx, signature, session, sqlTableCode)
 }
 
 func (s *FositeSQLStore) InvalidateAuthorizeCodeSession(ctx context.Context, signature string) error {
@@ -355,40 +355,40 @@ func (s *FositeSQLStore) InvalidateAuthorizeCodeSession(ctx context.Context, sig
 	return nil
 }
 
-func (s *FositeSQLStore) CreateAccessTokenSession(_ context.Context, signature string, requester fosite.Requester) error {
-	return s.createSession(signature, requester, sqlTableAccess)
+func (s *FositeSQLStore) CreateAccessTokenSession(ctx context.Context, signature string, requester fosite.Requester) error {
+	return s.createSession(ctx, signature, requester, sqlTableAccess)
 }
 
-func (s *FositeSQLStore) GetAccessTokenSession(_ context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
-	return s.findSessionBySignature(signature, session, sqlTableAccess)
+func (s *FositeSQLStore) GetAccessTokenSession(ctx context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
+	return s.findSessionBySignature(ctx, signature, session, sqlTableAccess)
 }
 
-func (s *FositeSQLStore) DeleteAccessTokenSession(_ context.Context, signature string) error {
-	return s.deleteSession(signature, sqlTableAccess)
+func (s *FositeSQLStore) DeleteAccessTokenSession(ctx context.Context, signature string) error {
+	return s.deleteSession(ctx, signature, sqlTableAccess)
 }
 
-func (s *FositeSQLStore) CreateRefreshTokenSession(_ context.Context, signature string, requester fosite.Requester) error {
-	return s.createSession(signature, requester, sqlTableRefresh)
+func (s *FositeSQLStore) CreateRefreshTokenSession(ctx context.Context, signature string, requester fosite.Requester) error {
+	return s.createSession(ctx, signature, requester, sqlTableRefresh)
 }
 
-func (s *FositeSQLStore) GetRefreshTokenSession(_ context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
-	return s.findSessionBySignature(signature, session, sqlTableRefresh)
+func (s *FositeSQLStore) GetRefreshTokenSession(ctx context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
+	return s.findSessionBySignature(ctx, signature, session, sqlTableRefresh)
 }
 
-func (s *FositeSQLStore) DeleteRefreshTokenSession(_ context.Context, signature string) error {
-	return s.deleteSession(signature, sqlTableRefresh)
+func (s *FositeSQLStore) DeleteRefreshTokenSession(ctx context.Context, signature string) error {
+	return s.deleteSession(ctx, signature, sqlTableRefresh)
 }
 
-func (s *FositeSQLStore) CreatePKCERequestSession(_ context.Context, signature string, requester fosite.Requester) error {
-	return s.createSession(signature, requester, sqlTablePKCE)
+func (s *FositeSQLStore) CreatePKCERequestSession(ctx context.Context, signature string, requester fosite.Requester) error {
+	return s.createSession(ctx, signature, requester, sqlTablePKCE)
 }
 
-func (s *FositeSQLStore) GetPKCERequestSession(_ context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
-	return s.findSessionBySignature(signature, session, sqlTablePKCE)
+func (s *FositeSQLStore) GetPKCERequestSession(ctx context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
+	return s.findSessionBySignature(ctx, signature, session, sqlTablePKCE)
 }
 
-func (s *FositeSQLStore) DeletePKCERequestSession(_ context.Context, signature string) error {
-	return s.deleteSession(signature, sqlTablePKCE)
+func (s *FositeSQLStore) DeletePKCERequestSession(ctx context.Context, signature string) error {
+	return s.deleteSession(ctx, signature, sqlTablePKCE)
 }
 
 func (s *FositeSQLStore) CreateImplicitAccessTokenSession(ctx context.Context, signature string, requester fosite.Requester) error {

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -21,7 +21,6 @@
 package oauth2
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -342,7 +341,7 @@ func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request) {
 //       401: genericError
 //       500: genericError
 func (h *Handler) RevocationHandler(w http.ResponseWriter, r *http.Request) {
-	var ctx = fosite.NewContext()
+	var ctx = r.Context()
 
 	err := h.OAuth2.NewRevocationRequest(ctx, r)
 	if err != nil {
@@ -378,7 +377,7 @@ func (h *Handler) RevocationHandler(w http.ResponseWriter, r *http.Request) {
 //       500: genericError
 func (h *Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var session = NewSession("")
-	var ctx = fosite.NewContext()
+	var ctx = r.Context()
 
 	if r.Method != "POST" {
 		err := errors.WithStack(fosite.ErrInvalidRequest.WithHintf("HTTP method is \"%s\", expected \"POST\".", r.Method))
@@ -480,7 +479,7 @@ func (h *Handler) FlushHandler(w http.ResponseWriter, r *http.Request, _ httprou
 		fr.NotAfter = time.Now()
 	}
 
-	if err := h.Storage.FlushInactiveAccessTokens(context.Background(), fr.NotAfter); err != nil {
+	if err := h.Storage.FlushInactiveAccessTokens(r.Context(), fr.NotAfter); err != nil {
 		h.H.WriteError(w, r, err)
 		return
 	}
@@ -515,7 +514,7 @@ func (h *Handler) FlushHandler(w http.ResponseWriter, r *http.Request, _ httprou
 //       500: genericError
 func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	var session = NewSession("")
-	var ctx = fosite.NewContext()
+	var ctx = r.Context()
 
 	accessRequest, err := h.OAuth2.NewAccessRequest(ctx, r, session)
 	if err != nil {
@@ -577,7 +576,7 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 //       401: genericError
 //       500: genericError
 func (h *Handler) AuthHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	var ctx = fosite.NewContext()
+	var ctx = r.Context()
 
 	authorizeRequest, err := h.OAuth2.NewAuthorizeRequest(ctx, r)
 	if err != nil {

--- a/oauth2/handler_test.go
+++ b/oauth2/handler_test.go
@@ -147,7 +147,7 @@ func TestUserinfo(t *testing.T) {
 	jm := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 	keys, err := (&jwk.RS256Generator{}).Generate("signing", "sig")
 	require.NoError(t, err)
-	require.NoError(t, jm.AddKeySet(oauth2.OpenIDConnectKeyName, keys))
+	require.NoError(t, jm.AddKeySet(context.TODO(), oauth2.OpenIDConnectKeyName, keys))
 	jwtStrategy, err := jwk.NewRS256JWTStrategy(jm, oauth2.OpenIDConnectKeyName)
 
 	h := &oauth2.Handler{

--- a/oauth2/introspector_test.go
+++ b/oauth2/introspector_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
@@ -54,7 +56,7 @@ func TestIntrospectorSDK(t *testing.T) {
 	jm := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 	keys, err := (&jwk.RS256Generator{}).Generate("", "sig")
 	require.NoError(t, err)
-	require.NoError(t, jm.AddKeySet(oauth2.OpenIDConnectKeyName, keys))
+	require.NoError(t, jm.AddKeySet(context.TODO(), oauth2.OpenIDConnectKeyName, keys))
 	jwtStrategy, err := jwk.NewRS256JWTStrategy(jm, oauth2.OpenIDConnectKeyName)
 
 	router := httprouter.New()

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -171,7 +171,7 @@ func TestAuthCodeWithDefaultStrategy(t *testing.T) {
 					jm := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 					keys, err := (&jwk.RS256Generator{}).Generate("", "sig")
 					require.NoError(t, err)
-					require.NoError(t, jm.AddKeySet(OpenIDConnectKeyName, keys))
+					require.NoError(t, jm.AddKeySet(context.TODO(), OpenIDConnectKeyName, keys))
 					jwtStrategy, err := jwk.NewRS256JWTStrategy(jm, OpenIDConnectKeyName)
 
 					handler := &Handler{
@@ -720,7 +720,7 @@ func TestAuthCodeWithMockStrategy(t *testing.T) {
 			jm := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 			keys, err := (&jwk.RS256Generator{}).Generate("", "sig")
 			require.NoError(t, err)
-			require.NoError(t, jm.AddKeySet(OpenIDConnectKeyName, keys))
+			require.NoError(t, jm.AddKeySet(context.TODO(), OpenIDConnectKeyName, keys))
 			jwtStrategy, err := jwk.NewRS256JWTStrategy(jm, OpenIDConnectKeyName)
 
 			handler := &Handler{

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -34,6 +34,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	djwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/sessions"
 	"github.com/julienschmidt/httprouter"
@@ -80,7 +82,7 @@ func mockProvider(h *func(w http.ResponseWriter, r *http.Request)) *httptest.Ser
 }
 
 type clientCreator interface {
-	CreateClient(client *hc.Client) error
+	CreateClient(cxt context.Context, client *hc.Client) error
 }
 
 // TestAuthCodeWithDefaultStrategy runs proper integration tests against in-memory and database connectors, specifically
@@ -214,7 +216,7 @@ func TestAuthCodeWithDefaultStrategy(t *testing.T) {
 						RedirectURL: client.RedirectURIs[0], Scopes: []string{"hydra", "offline", "openid"},
 					}
 
-					require.NoError(t, fs.(clientCreator).CreateClient(&client))
+					require.NoError(t, fs.(clientCreator).CreateClient(context.TODO(), &client))
 					apiClient := swagger.NewOAuth2ApiWithBasePath(api.URL)
 
 					var callbackHandler *httprouter.Handle
@@ -757,7 +759,7 @@ func TestAuthCodeWithMockStrategy(t *testing.T) {
 			})
 			m := sync.Mutex{}
 
-			store.CreateClient(&hc.Client{
+			store.CreateClient(context.TODO(), &hc.Client{
 				ClientID:      "app-client",
 				Secret:        "secret",
 				RedirectURIs:  []string{ts.URL + "/callback"},

--- a/oauth2/oauth2_client_credentials_test.go
+++ b/oauth2/oauth2_client_credentials_test.go
@@ -87,7 +87,7 @@ func TestClientCredentials(t *testing.T) {
 			jm := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 			keys, err := (&jwk.RS256Generator{}).Generate("", "sig")
 			require.NoError(t, err)
-			require.NoError(t, jm.AddKeySet(OpenIDConnectKeyName, keys))
+			require.NoError(t, jm.AddKeySet(context.TODO(), OpenIDConnectKeyName, keys))
 			jwtStrategy, err := jwk.NewRS256JWTStrategy(jm, OpenIDConnectKeyName)
 
 			ts := httptest.NewServer(router)

--- a/oauth2/oauth2_client_credentials_test.go
+++ b/oauth2/oauth2_client_credentials_test.go
@@ -115,7 +115,7 @@ func TestClientCredentials(t *testing.T) {
 				return h
 			})
 
-			require.NoError(t, store.CreateClient(&hc.Client{
+			require.NoError(t, store.CreateClient(context.TODO(), &hc.Client{
 				ClientID:      "app-client",
 				Secret:        "secret",
 				RedirectURIs:  []string{ts.URL + "/callback"},

--- a/oauth2/revocator_test.go
+++ b/oauth2/revocator_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
@@ -72,7 +74,7 @@ func TestRevoke(t *testing.T) {
 	jm := &jwk.MemoryManager{Keys: map[string]*jose.JSONWebKeySet{}}
 	keys, err := (&jwk.RS256Generator{}).Generate("", "sig")
 	require.NoError(t, err)
-	require.NoError(t, jm.AddKeySet(oauth2.OpenIDConnectKeyName, keys))
+	require.NoError(t, jm.AddKeySet(context.TODO(), oauth2.OpenIDConnectKeyName, keys))
 	jwtStrategy, err := jwk.NewRS256JWTStrategy(jm, oauth2.OpenIDConnectKeyName)
 
 	handler := &oauth2.Handler{


### PR DESCRIPTION
With the introduction of https://github.com/ory/hydra/pull/1019 we will need to start propagating the request context down to sql store(s) so we can instrument our database calls. 

Notes:

- Creating the spans will be done in a follow-up PR. 
- Same thing will need to be done for the other handlers.