### PR TITLE
two littles things that bugs me when I compile or run tests

### DIFF
--- a/cmd/server/helper_cert.go
+++ b/cmd/server/helper_cert.go
@@ -76,7 +76,7 @@ func loadCertificateFromEnv(c *config.Config) *tls.Certificate {
 	var cert tls.Certificate
 	var err error
 	if cert, err = tls.X509KeyPair([]byte(certString), []byte(keyString)); err != nil {
-		c.GetLogger().Warningf("Could not parse x509 key pair from env: %s", cert)
+		c.GetLogger().Warningf("Could not parse x509 key pair from env: %s", err)
 		return nil
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -378,7 +378,7 @@ func (c *Config) GetSystemSecret() []byte {
 	}
 
 	if len(c.SystemSecret) > 0 {
-		c.GetLogger().Fatalln("System secret must be undefined or have at least 16 characters, but it has %d characters.", len(c.SystemSecret))
+		c.GetLogger().Fatalf("System secret must be undefined or have at least 16 characters, but it has %d characters.", len(c.SystemSecret))
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Pierre-David Bélanger <pierredavidbelanger@gmail.com>

this PR fixes those two warnings:

github.com/ory/hydra/cmd/server
cmd/server/helper_cert.go:79: Logger.Warningf format %s has arg cert of wrong type crypto/tls.Certificate

github.com/ory/hydra/config
config/config.go:381: Logger.Fatalln call has possible formatting directive %d