### PR TITLE
Bump fosite version to 0.23.0 + New tracing instrumented Hasher

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -392,7 +392,7 @@
   version = "v3.3.0"
 
 [[projects]]
-  digest = "1:0a0c89d174f4b76bfe9a10d18c92e5a1eb3f445d4073884889b8a0a389f0ea80"
+  digest = "1:7dbb1878852749a7734bb4cb75d3e3f7e60801465d4c4f958533dd1f6d982a4e"
   name = "github.com/ory/fosite"
   packages = [
     ".",
@@ -405,8 +405,8 @@
     "token/jwt",
   ]
   pruneopts = ""
-  revision = "514fdbd20393c2175c66f3a69eb7bb849b3d5dfa"
-  version = "v0.22.0"
+  revision = "805e0e9a36aa254b18e853b8a9c7881738deb010"
+  version = "v0.23.0"
 
 [[projects]]
   digest = "1:88233ef02f3da33b9d4cf4f6c514c206ce4efec67f455c5be6dd3aa0fdf3bd32"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,7 +75,7 @@
 
 [[constraint]]
   name = "github.com/ory/fosite"
-  version = "0.22.0"
+  version = "0.23.0"
 
 [[constraint]]
   name = "github.com/ory/graceful"

--- a/client/manager_memory.go
+++ b/client/manager_memory.go
@@ -74,7 +74,7 @@ func (m *MemoryManager) UpdateClient(ctx context.Context, c *Client) error {
 	if c.Secret == "" {
 		c.Secret = string(o.GetHashedSecret())
 	} else {
-		h, err := m.Hasher.Hash([]byte(c.Secret))
+		h, err := m.Hasher.Hash(ctx, []byte(c.Secret))
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -104,7 +104,7 @@ func (m *MemoryManager) Authenticate(ctx context.Context, id string, secret []by
 		return nil, err
 	}
 
-	if err := m.Hasher.Compare(c.GetHashedSecret(), secret); err != nil {
+	if err := m.Hasher.Compare(ctx, c.GetHashedSecret(), secret); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -119,7 +119,7 @@ func (m *MemoryManager) CreateClient(ctx context.Context, c *Client) error {
 	m.Lock()
 	defer m.Unlock()
 
-	hash, err := m.Hasher.Hash([]byte(c.Secret))
+	hash, err := m.Hasher.Hash(ctx, []byte(c.Secret))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -358,7 +358,7 @@ func (m *SQLManager) UpdateClient(ctx context.Context, c *Client) error {
 	if c.Secret == "" {
 		c.Secret = string(o.GetHashedSecret())
 	} else {
-		h, err := m.Hasher.Hash([]byte(c.Secret))
+		h, err := m.Hasher.Hash(ctx, []byte(c.Secret))
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -387,7 +387,7 @@ func (m *SQLManager) Authenticate(ctx context.Context, id string, secret []byte)
 		return nil, errors.WithStack(err)
 	}
 
-	if err := m.Hasher.Compare(c.GetHashedSecret(), secret); err != nil {
+	if err := m.Hasher.Compare(ctx, c.GetHashedSecret(), secret); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -395,7 +395,7 @@ func (m *SQLManager) Authenticate(ctx context.Context, id string, secret []byte)
 }
 
 func (m *SQLManager) CreateClient(ctx context.Context, c *Client) error {
-	h, err := m.Hasher.Hash([]byte(c.Secret))
+	h, err := m.Hasher.Hash(ctx, []byte(c.Secret))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -127,14 +127,15 @@ func setup(c *config.Config, cmd *cobra.Command, args []string, name string) (ha
 	w := herodot.NewJSONWriter(logger)
 	w.ErrorEnhancer = nil
 
-	handler = NewHandler(c, w)
-	handler.RegisterRoutes(frontend, backend)
-	c.ForceHTTP, _ = cmd.Flags().GetBool("dangerous-force-http")
 	if tracer, err := c.GetTracer(); err != nil {
 		c.GetLogger().Fatalf("Failed to initialize tracer: %s", err)
 	} else if tracer.IsLoaded() {
 		middlewares = append(middlewares, tracer)
 	}
+
+	handler = NewHandler(c, w)
+	handler.RegisterRoutes(frontend, backend)
+	c.ForceHTTP, _ = cmd.Flags().GetBool("dangerous-force-http")
 
 	if !c.ForceHTTP {
 		if c.Issuer == "" {

--- a/tracing/traced_bcrypt.go
+++ b/tracing/traced_bcrypt.go
@@ -1,0 +1,47 @@
+package tracing
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	HashOpName        = "bcrypt.hash"
+	CompareOpName     = "bcrypt.compare"
+	WorkFactorTagName = "bcrypt.workfactor"
+)
+
+// TracedBCrypt implements the Hasher interface
+type TracedBCrypt struct {
+	WorkFactor int
+}
+
+func (b *TracedBCrypt) Hash(ctx context.Context, data []byte) ([]byte, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, HashOpName)
+	defer span.Finish()
+	span.SetTag(WorkFactorTagName, b.WorkFactor)
+
+	s, err := bcrypt.GenerateFromPassword(data, b.WorkFactor)
+	if err != nil {
+		ext.Error.Set(span, true)
+		return nil, errors.WithStack(err)
+	}
+	return s, nil
+}
+
+func (b *TracedBCrypt) Compare(ctx context.Context, hash, data []byte) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, CompareOpName)
+	defer span.Finish()
+	span.SetTag(WorkFactorTagName, b.WorkFactor)
+
+	if err := bcrypt.CompareHashAndPassword(hash, data); err != nil {
+		ext.Error.Set(span, true)
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/tracing/traced_bcrypt_test.go
+++ b/tracing/traced_bcrypt_test.go
@@ -1,0 +1,134 @@
+package tracing_test
+
+import (
+	"testing"
+
+	"context"
+
+	"github.com/ory/hydra/tracing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompare(t *testing.T) {
+	workfactor := 10
+	hasher := &tracing.TracedBCrypt{
+		WorkFactor: workfactor,
+	}
+
+	expectedPassword := "hello world"
+	expectedPasswordHash, err := hasher.Hash(context.TODO(), []byte(expectedPassword))
+	assert.NoError(t, err)
+	assert.NotNil(t, expectedPasswordHash)
+
+	expectedTagsSuccess := map[string]interface{}{
+		tracing.WorkFactorTagName: int(workfactor),
+	}
+
+	expectedTagsError := map[string]interface{}{
+		tracing.WorkFactorTagName: int(workfactor),
+		"error":                   true,
+	}
+
+	testCases := []struct {
+		testDescription  string
+		providedPassword string
+		expectedTags     map[string]interface{}
+		shouldError      bool
+	}{
+		{
+			testDescription:  "should not return an error if hash of provided password matches hash of expected password",
+			providedPassword: expectedPassword,
+			expectedTags:     expectedTagsSuccess,
+			shouldError:      false,
+		},
+		{
+			testDescription:  "should return an error if hash of provided password does not match hash of expected password",
+			providedPassword: "some invalid password",
+			expectedTags:     expectedTagsError,
+			shouldError:      true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.testDescription, func(t *testing.T) {
+			hash, err := hasher.Hash(context.TODO(), []byte(test.providedPassword))
+			assert.NoError(t, err)
+			assert.NotNil(t, hash)
+
+			mockedTracer.Reset()
+
+			err = hasher.Compare(context.TODO(), expectedPasswordHash, []byte(test.providedPassword))
+			if test.shouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			spans := mockedTracer.FinishedSpans()
+			assert.Len(t, spans, 1)
+			span := spans[0]
+
+			assert.Equal(t, tracing.CompareOpName, span.OperationName)
+			assert.Equal(t, test.expectedTags, span.Tags())
+		})
+	}
+}
+
+func TestHashCreatesSpanWithCorrectTags(t *testing.T) {
+	validWorkFactor := 10
+	invalidWorkFactor := 1000 // this is an invalid work factor that will cause the call to Hash to fail!
+	password := []byte("bar")
+
+	expectedTagsSuccess := map[string]interface{}{
+		tracing.WorkFactorTagName: int(validWorkFactor),
+	}
+
+	expectedTagsError := map[string]interface{}{
+		tracing.WorkFactorTagName: int(invalidWorkFactor),
+		"error":                   true,
+	}
+
+	testCases := []struct {
+		testDescription string
+		expectedTags    map[string]interface{}
+		workFactor      int
+		shouldError     bool
+	}{
+		{
+			testDescription: "tests expected tags are created when call to Hash succeeds",
+			expectedTags:    expectedTagsSuccess,
+			workFactor:      validWorkFactor,
+			shouldError:     false,
+		},
+		{
+			testDescription: "tests expected tags are created when call to Hash fails",
+			expectedTags:    expectedTagsError,
+			workFactor:      invalidWorkFactor,
+			shouldError:     true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.testDescription, func(t *testing.T) {
+			mockedTracer.Reset()
+			hasher := &tracing.TracedBCrypt{
+				WorkFactor: test.workFactor,
+			}
+
+			_, err := hasher.Hash(context.TODO(), password)
+
+			if test.shouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			spans := mockedTracer.FinishedSpans()
+			assert.Len(t, spans, 1)
+			span := spans[0]
+
+			assert.Equal(t, tracing.HashOpName, span.OperationName)
+			assert.Equal(t, test.expectedTags, span.Tags())
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

This PR beings to leverage our previous efforts on context propagation.

- Bumps fosite version to `0.23.0`: [changes between current (0.22.0) and 0.23.0](https://github.com/ory/fosite/compare/v0.22.0...v0.23.0)
As seen in the diff, the breaking change was to the Hasher interface as its methods now accept a context. Consumers have been updated to pass along the request context down the call path.

- Implements a instrumented bcrypt hasher which now creates spans on calls to `Hash` and `Compare`. Hydra will now use this `Hasher` implementation if tracing has been enabled. 

- 100% test coverage for new instrumented `Hasher`

- Each commit can be 🚢'ed independently in order


## Cool, what does the span look like now?

Here is a trace that is created by as a result of a successful call to `oauth2/token` endpoint for a client credentials grant:

![image](https://user-images.githubusercontent.com/1800781/46037087-07ad9080-c0bc-11e8-94f7-d273578ca95d.png)

Here is what the trace looks like if the call failed (_e.g. the client passes invalid credentials_):

![image](https://user-images.githubusercontent.com/1800781/46037214-6246ec80-c0bc-11e8-8cc7-402f02654d12.png)

_Review: @aeneasr_
