### PR TITLE
Add missing indices to resolve #1067

### DIFF
--- a/oauth2/fosite_store_sql.go
+++ b/oauth2/fosite_store_sql.go
@@ -87,6 +87,8 @@ func sqlSchemaUp(table string, id string) string {
 	subject 		varchar(255) NOT NULL
 )`,
 		"4": fmt.Sprintf("ALTER TABLE hydra_oauth2_%s ADD active BOOL NOT NULL DEFAULT TRUE", table),
+		"5": fmt.Sprintf("CREATE UNIQUE INDEX hydra_oauth2_%s_request_id_idx ON hydra_oauth2_%s (request_id)", table, table),
+		"6": fmt.Sprintf("CREATE INDEX hydra_oauth2_%s_requested_at_idx ON hydra_oauth2_%s (requested_at)", table, table),
 	}
 
 	return schemas[id]
@@ -98,6 +100,8 @@ func sqlSchemaDown(table string, id string) string {
 		"2": fmt.Sprintf("ALTER TABLE hydra_oauth2_%s DROP COLUMN subject", table),
 		"3": "DROP TABLE hydra_oauth2_pkce",
 		"4": fmt.Sprintf("ALTER TABLE hydra_oauth2_%s DROP COLUMN active", table),
+		"5": fmt.Sprintf("DROP INDEX hydra_oauth2_%s_request_id_idx ON hydra_oauth2_%s", table, table),
+		"6": fmt.Sprintf("DROP INDEX hydra_oauth2_%s_requested_at_idx ON hydra_oauth2_%s", table, table),
 	}
 
 	return schemas[id]
@@ -167,6 +171,26 @@ var migrations = &migrate.MemoryMigrationSource{
 				sqlSchemaDown(sqlTableCode, "4"),
 				sqlSchemaDown(sqlTableOpenID, "4"),
 				sqlSchemaDown(sqlTablePKCE, "4"),
+			},
+		},
+		{
+			Id: "5",
+			Up: []string{
+				sqlSchemaUp(sqlTableAccess, "5"),
+				sqlSchemaUp(sqlTableRefresh, "5"),
+			},
+			Down: []string{
+				sqlSchemaDown(sqlTableAccess, "5"),
+				sqlSchemaDown(sqlTableRefresh, "5"),
+			},
+		},
+		{
+			Id: "6",
+			Up: []string{
+				sqlSchemaUp(sqlTableAccess, "6"),
+			},
+			Down: []string{
+				sqlSchemaDown(sqlTableAccess, "6"),
 			},
 		},
 	},

--- a/oauth2/fosite_store_test.go
+++ b/oauth2/fosite_store_test.go
@@ -99,6 +99,17 @@ func connectToMySQL() {
 	m.Unlock()
 }
 
+func TestUniqueConstraints(t *testing.T) {
+	t.Parallel()
+	for storageType, store := range fositeStores {
+		if storageType == "memory" {
+			// memory store does not deal with unique constraints
+			continue
+		}
+		t.Run(fmt.Sprintf("case=%s", storageType), TestHelperUniqueConstraints(store, storageType))
+	}
+}
+
 func TestCreateGetDeleteAuthorizeCodes(t *testing.T) {
 	t.Parallel()
 	for k, m := range fositeStores {

--- a/oauth2/fosite_store_test_helpers.go
+++ b/oauth2/fosite_store_test_helpers.go
@@ -88,20 +88,25 @@ func TestHelperCreateGetDeleteRefreshTokenSession(m pkg.FositeStorer) func(t *te
 func TestHelperRevokeRefreshToken(m pkg.FositeStorer) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
-		id := uuid.New()
 		_, err := m.GetRefreshTokenSession(ctx, "1111", &fosite.DefaultSession{})
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 
-		err = m.CreateRefreshTokenSession(ctx, "1111", &fosite.Request{ID: id, Client: &client.Client{ClientID: "foobar"}, RequestedAt: time.Now().UTC().Round(time.Second), Session: &fosite.DefaultSession{}})
+		reqIdOne := uuid.New()
+		reqIdTwo := uuid.New()
+
+		err = m.CreateRefreshTokenSession(ctx, "1111", &fosite.Request{ID: reqIdOne, Client: &client.Client{ClientID: "foobar"}, RequestedAt: time.Now().UTC().Round(time.Second), Session: &fosite.DefaultSession{}})
 		require.NoError(t, err)
 
-		err = m.CreateRefreshTokenSession(ctx, "1122", &fosite.Request{ID: id, Client: &client.Client{ClientID: "foobar"}, RequestedAt: time.Now().UTC().Round(time.Second), Session: &fosite.DefaultSession{}})
+		err = m.CreateRefreshTokenSession(ctx, "1122", &fosite.Request{ID: reqIdTwo, Client: &client.Client{ClientID: "foobar"}, RequestedAt: time.Now().UTC().Round(time.Second), Session: &fosite.DefaultSession{}})
 		require.NoError(t, err)
 
 		_, err = m.GetRefreshTokenSession(ctx, "1111", &fosite.DefaultSession{})
 		require.NoError(t, err)
 
-		err = m.RevokeRefreshToken(ctx, id)
+		err = m.RevokeRefreshToken(ctx, reqIdOne)
+		require.NoError(t, err)
+
+		err = m.RevokeRefreshToken(ctx, reqIdTwo)
 		require.NoError(t, err)
 
 		_, err = m.GetRefreshTokenSession(ctx, "1111", &fosite.DefaultSession{})


### PR DESCRIPTION
Resolves #1067 by adding indices to:

• `request_id` column in the hydra_oauth2_access & hydra_oauth2_refresh tables
• `requested_at` column in the hydra_oauth2_access table

_Review: @aeneasr_