### PR TITLE
tracing: use context aware database methods

### DIFF
--- a/client/manager_sql.go
+++ b/client/manager_sql.go
@@ -338,7 +338,7 @@ func (m *SQLManager) CreateSchemas() (int, error) {
 
 func (m *SQLManager) GetConcreteClient(ctx context.Context, id string) (*Client, error) {
 	var d sqlData
-	if err := m.DB.Get(&d, m.DB.Rebind("SELECT * FROM hydra_client WHERE id=?"), id); err != nil {
+	if err := m.DB.GetContext(ctx, &d, m.DB.Rebind("SELECT * FROM hydra_client WHERE id=?"), id); err != nil {
 		return nil, sqlcon.HandleError(err)
 	}
 
@@ -350,7 +350,7 @@ func (m *SQLManager) GetClient(ctx context.Context, id string) (fosite.Client, e
 }
 
 func (m *SQLManager) UpdateClient(ctx context.Context, c *Client) error {
-	o, err := m.GetClient(context.Background(), c.GetID())
+	o, err := m.GetClient(ctx, c.GetID())
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -375,7 +375,7 @@ func (m *SQLManager) UpdateClient(ctx context.Context, c *Client) error {
 		query = append(query, fmt.Sprintf("%s=:%s", param, param))
 	}
 
-	if _, err := m.DB.NamedExec(fmt.Sprintf(`UPDATE hydra_client SET %s WHERE id=:id`, strings.Join(query, ", ")), s); err != nil {
+	if _, err := m.DB.NamedExecContext(ctx, fmt.Sprintf(`UPDATE hydra_client SET %s WHERE id=:id`, strings.Join(query, ", ")), s); err != nil {
 		return sqlcon.HandleError(err)
 	}
 	return nil
@@ -406,7 +406,7 @@ func (m *SQLManager) CreateClient(ctx context.Context, c *Client) error {
 		return errors.WithStack(err)
 	}
 
-	if _, err := m.DB.NamedExec(fmt.Sprintf(
+	if _, err := m.DB.NamedExecContext(ctx, fmt.Sprintf(
 		"INSERT INTO hydra_client (%s) VALUES (%s)",
 		strings.Join(sqlParams, ", "),
 		":"+strings.Join(sqlParams, ", :"),
@@ -418,7 +418,7 @@ func (m *SQLManager) CreateClient(ctx context.Context, c *Client) error {
 }
 
 func (m *SQLManager) DeleteClient(ctx context.Context, id string) error {
-	if _, err := m.DB.Exec(m.DB.Rebind(`DELETE FROM hydra_client WHERE id=?`), id); err != nil {
+	if _, err := m.DB.ExecContext(ctx, m.DB.Rebind(`DELETE FROM hydra_client WHERE id=?`), id); err != nil {
 		return sqlcon.HandleError(err)
 	}
 	return nil
@@ -428,7 +428,7 @@ func (m *SQLManager) GetClients(ctx context.Context, limit, offset int) (clients
 	d := make([]sqlData, 0)
 	clients = make(map[string]Client)
 
-	if err := m.DB.Select(&d, m.DB.Rebind("SELECT * FROM hydra_client ORDER BY id LIMIT ? OFFSET ?"), limit, offset); err != nil {
+	if err := m.DB.SelectContext(ctx, &d, m.DB.Rebind("SELECT * FROM hydra_client ORDER BY id LIMIT ? OFFSET ?"), limit, offset); err != nil {
 		return nil, sqlcon.HandleError(err)
 	}
 

--- a/integration/sql_schema_test.go
+++ b/integration/sql_schema_test.go
@@ -84,5 +84,5 @@ func TestSQLSchema(t *testing.T) {
 		AuthenticatedAt: time.Now(),
 		Subject:         "bar",
 	}))
-	require.NoError(t, om.CreateAccessTokenSession(nil, "asdfasdf", r))
+	require.NoError(t, om.CreateAccessTokenSession(context.TODO(), "asdfasdf", r))
 }


### PR DESCRIPTION
This PR continues on our efforts of context propagation by using the associated context aware methods in the sqlx package.

This is necessary for when we [wrap the db driver](https://github.com/golang/go/issues/18080#issuecomment-287867357) with the tracing API, we will start getting spans out of the box 😉.  

Furthermore, using these methods comes with the added benefit that database drivers that support context cancellation will be able to quit early if there is no hope of completing a query/tx.

_Review: @aeneasr_ 
