### PR TITLE
cmd: configuration for secrets

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -103,6 +103,16 @@ before finalizing the upgrade process.
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## master
+
+### Configuration changes
+
+New environment variables `SYSTEM_SECRET_PATH` and `COOKIE_SECRET_PATH`
+allow to retrieve secrets from files, and avoid exposing secrets in environment variables.
+
+These new variables supplement `SYSTEM_SECRET` and `COOKIE_SECRET`
+respectively, and do not affect existing configurations.
+
 ## 1.0.0-beta.10
 
 ### Schema Changes

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -49,9 +49,13 @@ const serveControls = `CORE CONTROLS
 	is used to encrypt sensitive data using AES-GCM (256 bit) and validate HMAC signatures.
 	Example: SYSTEM_SECRET=jf89-jgklAS9gk3rkAF90dfsk
 
-- COOKIE_SECRET: A secret that is used to encrypt cookie sessions. Defaults to SYSTEM_SECRET. It is recommended to use
-	a separate secret in production.
+- SYSTEM_SECRET_PATH: A file containing SYSTEM_SECRET (see above)
+
+- COOKIE_SECRET: A secret that is used to encrypt cookie sessions. It must be at least 16 characters long.
+    Defaults to SYSTEM_SECRET. It is recommended to use a separate secret in production.
 	Example: COOKIE_SECRET=fjah8uFhgjSiuf-AS
+
+- COOKIE_SECRET_PATH: A file containing COOKIE_SECRET (see above).
 
 - PORT: The port hydra should listen on.
 	Defaults to PORT=4444


### PR DESCRIPTION
* Added SYSTEM_SECRET_PATH and COOKIE_SECRET_PATH env variables to
  retrieve secrets from a file rather than env
* Enforced COOKIE_SECRET to be at least 256 bits long (symmetric to SYSTEM_SECRET)

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>

**NOTE**: this PR allows to configure hydra secrets without exposing initialization secrets in environment and/or configuration files.