### PR TITLE
Fix missing LoginChallenge and LoginSessionID from GetConsentRequest

### DIFF
--- a/consent/manager_test_helpers.go
+++ b/consent/manager_test_helpers.go
@@ -508,6 +508,7 @@ func compareAuthenticationRequest(t *testing.T, a, b *AuthenticationRequest) {
 	assert.EqualValues(t, a.RequestURL, b.RequestURL)
 	assert.EqualValues(t, a.CSRF, b.CSRF)
 	assert.EqualValues(t, a.Skip, b.Skip)
+	assert.EqualValues(t, a.SessionID, b.SessionID)
 }
 
 func compareConsentRequest(t *testing.T, a, b *ConsentRequest) {
@@ -520,4 +521,6 @@ func compareConsentRequest(t *testing.T, a, b *ConsentRequest) {
 	assert.EqualValues(t, a.RequestURL, b.RequestURL)
 	assert.EqualValues(t, a.CSRF, b.CSRF)
 	assert.EqualValues(t, a.Skip, b.Skip)
+	assert.EqualValues(t, a.LoginChallenge, b.LoginChallenge)
+	assert.EqualValues(t, a.LoginSessionID, b.LoginSessionID)
 }

--- a/consent/sql_helper.go
+++ b/consent/sql_helper.go
@@ -200,14 +200,13 @@ type sqlAuthenticationRequest struct {
 	CSRF                 string     `db:"csrf"`
 	AuthenticatedAt      *time.Time `db:"authenticated_at"`
 	RequestedAt          time.Time  `db:"requested_at"`
-	SessionID            string     `db:"login_session_id"`
+	LoginSessionID       string     `db:"login_session_id"`
 	WasHandled           bool       `db:"was_handled"`
 }
 
 type sqlConsentRequest struct {
 	sqlAuthenticationRequest
 	LoginChallenge          string `db:"login_challenge"`
-	LoginSessionID          string `db:"login_session_id"`
 	ForcedSubjectIdentifier string `db:"forced_subject_identifier"`
 }
 
@@ -244,9 +243,8 @@ func newSQLConsentRequest(c *ConsentRequest) (*sqlConsentRequest, error) {
 			CSRF:                 c.CSRF,
 			AuthenticatedAt:      toMySQLDateHack(c.AuthenticatedAt),
 			RequestedAt:          c.RequestedAt,
-			SessionID:            c.LoginSessionID,
+			LoginSessionID:       c.LoginSessionID,
 		},
-		LoginSessionID:          c.LoginSessionID,
 		LoginChallenge:          c.LoginChallenge,
 		ForcedSubjectIdentifier: c.ForceSubjectIdentifier,
 	}, nil
@@ -270,7 +268,7 @@ func newSQLAuthenticationRequest(c *AuthenticationRequest) (*sqlAuthenticationRe
 		CSRF:                 c.CSRF,
 		AuthenticatedAt:      toMySQLDateHack(c.AuthenticatedAt),
 		RequestedAt:          c.RequestedAt,
-		SessionID:            c.SessionID,
+		LoginSessionID:       c.SessionID,
 	}, nil
 }
 
@@ -293,6 +291,7 @@ func (s *sqlAuthenticationRequest) toAuthenticationRequest(client *client.Client
 		AuthenticatedAt:      fromMySQLDateHack(s.AuthenticatedAt),
 		RequestedAt:          s.RequestedAt,
 		WasHandled:           s.WasHandled,
+		SessionID:            s.LoginSessionID,
 	}, nil
 }
 
@@ -316,6 +315,8 @@ func (s *sqlConsentRequest) toConsentRequest(client *client.Client) (*ConsentReq
 		ForceSubjectIdentifier: s.ForcedSubjectIdentifier,
 		RequestedAt:            s.RequestedAt,
 		WasHandled:             s.WasHandled,
+		LoginSessionID:         s.LoginSessionID,
+		LoginChallenge:         s.LoginChallenge,
 	}, nil
 }
 

--- a/consent/sql_helper_test.go
+++ b/consent/sql_helper_test.go
@@ -54,6 +54,7 @@ func TestSQLAuthenticationConverter(t *testing.T) {
 		RequestedScope:  []string{"scopea", "scopeb"},
 		Verifier:        "verifier",
 		CSRF:            "csrf",
+		SessionID:       "session-id",
 	}
 
 	b := &HandledAuthenticationRequest{
@@ -112,6 +113,8 @@ func TestSQLConsentConverter(t *testing.T) {
 		Verifier:               "verifier",
 		CSRF:                   "csrf",
 		AuthenticatedAt:        time.Now().UTC().Add(-time.Minute),
+		LoginChallenge:         "login-challenge",
+		LoginSessionID:         "login-session-id",
 	}
 
 	b := &HandledConsentRequest{


### PR DESCRIPTION
I believe this was missing from #1013. Responses from `GET /oauth2/auth/requests/consent/:challenge` have the `login_challenge` and `login_session_id` fields, but they're always empty strings, because they were not being converted from the database response.

This PR adds the missing fields to the relevant SQL converter test and implementation.

cc @aeneasr 