### PR TITLE
fix(cors): CORS_ENABLED should also work for Public Server

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -95,7 +95,7 @@ func RunServePublic(c *config.Config) func(cmd *cobra.Command, args []string) {
 		wg.Add(2)
 
 		cert := getOrCreateTLSCertificate(cmd, c)
-		go serve(c, cmd, EnhanceRouter(c, cmd, serverHandler, frontend, mws, false), c.GetFrontendAddress(), &wg, cert)
+		go serve(c, cmd, EnhanceRouter(c, cmd, serverHandler, frontend, mws, viper.GetString("CORS_ENABLED") == "true"), c.GetFrontendAddress(), &wg, cert)
 		// go serve(c, cmd, enhanceRouter(c, cmd, serverHandler, backend), c.GetBackendAddress(), &wg)
 
 		wg.Wait()
@@ -111,8 +111,9 @@ func RunServeAll(c *config.Config) func(cmd *cobra.Command, args []string) {
 		wg.Add(2)
 
 		cert := getOrCreateTLSCertificate(cmd, c)
-		go serve(c, cmd, EnhanceRouter(c, cmd, serverHandler, frontend, mws, false), c.GetFrontendAddress(), &wg, cert)
-		go serve(c, cmd, EnhanceRouter(c, cmd, serverHandler, backend, mws, viper.GetString("CORS_ENABLED") == "true"), c.GetBackendAddress(), &wg, cert)
+		corsEnabled := viper.GetString("CORS_ENABLED") == "true"
+		go serve(c, cmd, EnhanceRouter(c, cmd, serverHandler, frontend, mws, corsEnabled), c.GetFrontendAddress(), &wg, cert)
+		go serve(c, cmd, EnhanceRouter(c, cmd, serverHandler, backend, mws, corsEnabled), c.GetBackendAddress(), &wg, cert)
 
 		wg.Wait()
 	}


### PR DESCRIPTION
## Related issue
@aeneasr, as discussed in chat. The issue is,

- Situation: I have set the CORS_ENABLED=true, but still get No 'Access-Control-Allow-Origin' header is present error when access .well-known/openid-configuration,I checked the logs, there is hydra_1               | time="2018-10-23T11:30:20Z" level=info msg="Enabled CORS" in the log,  I also tried set  CORS_ALLOWED_ORIGINS=*, but still not work, but it will work in v0.11.12.

- Reason: https://github.com/ory/hydra/blob/master/cmd/server/handler.go#L99, `Public server` doesn't use the `CORS_ENABLED` flag.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Use `CORS_ENABLED` flag also for `public server`.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
