### PR TITLE
health: Register healthx.AliveCheckPath route for frontend

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -271,7 +271,10 @@ func (h *Handler) RegisterRoutes(frontend, backend *httprouter.Router) {
 	h.Keys = newJWKHandler(c, frontend, backend, oauth2Provider, clientsManager)
 	h.Consent = newConsentHandler(c, frontend, backend)
 	h.OAuth2 = newOAuth2Handler(c, frontend, backend, ctx.ConsentManager, oauth2Provider, clientsManager)
-	_ = newHealthHandler(c, backend)
+	healthHandler := newHealthHandler(c, backend)
+
+	// Register AliveCheckPath for frontend too
+	frontend.GET(healthx.AliveCheckPath, healthHandler.Alive)
 }
 
 func (h *Handler) RejectInsecureRequests(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {

--- a/cmd/server/handler_test.go
+++ b/cmd/server/handler_test.go
@@ -29,12 +29,13 @@ import (
 )
 
 func TestStart(t *testing.T) {
-	router := httprouter.New()
+	frontend := httprouter.New()
+	backend := httprouter.New()
 	h := &Handler{
 		Config: &config.Config{
 			DatabaseURL:               "memory",
 			OAuth2AccessTokenStrategy: "opaque",
 		},
 	}
-	h.RegisterRoutes(router, router)
+	h.RegisterRoutes(frontend, backend)
 }


### PR DESCRIPTION
## Related issue
As discussed on discord.

## Proposed changes
Add the `/health/alive` route to the frontend httpRouter to be used for black box monitoring and/or health checks from external infrastructure (GCE loadbalancer for example).

## Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments
Is there a place (in docs) where I need to define that `/health/alive` is now reachable via the frontend port? As far as I can see the API docs don't distinguish between frontend/backend routes.