### PR TITLE
cmd: Resolve issues with secret migration

### DIFF
--- a/cmd/server/handler_jwk_factory.go
+++ b/cmd/server/handler_jwk_factory.go
@@ -22,9 +22,10 @@ package server
 
 import (
 	"github.com/julienschmidt/httprouter"
+	"github.com/spf13/viper"
+
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/client"
-	"github.com/spf13/viper"
 
 	"github.com/ory/herodot"
 	"github.com/ory/hydra/config"

--- a/config/backend_test.go
+++ b/config/backend_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/ory/dockertest"
 
 	"github.com/sirupsen/logrus"

--- a/pkg/secret.go
+++ b/pkg/secret.go
@@ -20,7 +20,11 @@
 
 package pkg
 
-import "github.com/ory/x/randx"
+import (
+	"crypto/sha256"
+
+	"github.com/ory/x/randx"
+)
 
 var secretCharSet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.~")
 
@@ -30,4 +34,22 @@ func GenerateSecret(length int) ([]byte, error) {
 		return []byte{}, err
 	}
 	return []byte(string(secret)), nil
+}
+
+// HashStringSecret hashes the secret for consumption by the AEAD encryption algorithm which expects exactly 32 bytes.
+//
+// The system secret is being hashed to always match exactly the 32 bytes required by AEAD, even if the secret is long or
+// shorter.
+func HashStringSecret(secret string) []byte {
+	return HashByteSecret([]byte(secret))
+}
+
+// HashByteSecret hashes the secret for consumption by the AEAD encryption algorithm which expects exactly 32 bytes.
+//
+// The system secret is being hashed to always match exactly the 32 bytes required by AEAD, even if the secret is long or
+// shorter.
+func HashByteSecret(secret []byte) []byte {
+	var r [32]byte
+	r = sha256.Sum256([]byte(secret))
+	return r[:]
 }


### PR DESCRIPTION
This patch resolves an issue which made it impossible to rotate secrets because an un-hashed version was used.

Closes #1026