### PR TITLE
check length of array before get[0], split replaced by splitx

### DIFF
--- a/client/validator.go
+++ b/client/validator.go
@@ -134,7 +134,7 @@ func (v *Validator) Validate(c *Client) error {
 			return errors.WithStack(fosite.ErrInvalidRequest.WithHint(fmt.Sprintf("Subject type %s is not supported by server, only %v are allowed.", c.SubjectType, v.SubjectTypes)))
 		}
 	} else {
-		if stringslice.Has(v.SubjectTypes, "public") {
+		if len(v.SubjectTypes) == 0 || stringslice.Has(v.SubjectTypes, "public") {
 			c.SubjectType = "public"
 		} else {
 			c.SubjectType = v.SubjectTypes[0]

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/ory/fosite"
 	foauth2 "github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/go-convenience/stringsx"
 	"github.com/ory/fosite/token/hmac"
 	"github.com/ory/go-convenience/stringslice"
 	"github.com/ory/go-convenience/urlx"
@@ -118,7 +119,7 @@ func (c *Config) MustValidate() {
 }
 
 func (c *Config) GetSubjectTypesSupported() []string {
-	types := strings.Split(c.SubjectTypesSupported, ",")
+	types := stringsx.Splitx(c.SubjectTypesSupported, ",")
 	if len(types) == 0 {
 		return []string{"public"}
 	}


### PR DESCRIPTION
## Related issue

As discussed in the Discord channel, the array SubjectTypes is queried without checking for the length. When it is empty, the values [0] is selected which leads to a panic.

In the same vein: when the SubjectTypesSupported is empty, the split returns a length of 1 which is incorrect.

## Proposed changes

Check the length of the array before selecting element [0].

Switch to stringsx.Splitx() for splitting the array.
