### PR TITLE
fix migrate sql command  at upgrading guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -535,10 +535,10 @@ This is a (potentially incomplete) summary of what needs to be done to upgrade f
    1. `$ keto migrate hydra $DATABASE_URL`.
    2. `$ keto migrate sql $DATABASE_URL`.
    3. Read how to update the JWK storage: [AES-GCM nonce storage](#aes-gcm-nonce-storage). If you only use auto-generated keys and have never used POST or PUT on the `/keys` API, you can probably just execute a `DELETE FROM hydra_jwk` to just remove all the auto-generated keys. When starting the ORY Hydra 1.0.0 CLI the required keys will be re-generated automatically.
-   4. `$ hydra migrate $DATABASE_URL`.
+   4. `$ hydra migrate sql $DATABASE_URL`.
 4. If you don't use Access Control Policies nor the Warden API, you can skip ORY Keto:
    1. Read how to update the JWK storage: [AES-GCM nonce storage](#aes-gcm-nonce-storage) and **read point 3.3 of this list**.
-   2. `$ hydra migrate $DATABASE_URL`.
+   2. `$ hydra migrate sql $DATABASE_URL`.
 5. `$ export SCOPE_STRATEGY=DEPRECATED_HIERARCHICAL_SCOPE_STRATEGY` - this will set the [scope strategy](#replacing-hierarchical-scope-strategy-with-wildcard-scope-strategy) to the old scope strategy used in version 0.9.x. If you set this, you don't need to update the scopes your OAuth 2.0 Clients are allowed to request.
 6. `$ hydra help serve`.
 7. `$ hydra serve --your-flags`.


### PR DESCRIPTION
## Related issue

none

## Proposed changes

Fix migrate sql command at upgrading guide.

`hydra migrate $DATABASE_URL` does not work.
But `hydra migrate sql $DATABASE_URL` works.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

none