### PR TITLE
client: rename grant type authorize_code to authorization_code

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -49,7 +49,7 @@ type Client struct {
 
 	// GrantTypes is an array of grant types the client is allowed to use.
 	//
-	// Pattern: client_credentials|authorize_code|implicit|refresh_token
+	// Pattern: client_credentials|authorization_code|implicit|refresh_token
 	GrantTypes []string `json:"grant_types"`
 
 	// ResponseTypes is an array of the OAuth 2.0 response type strings that the client can

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
-	"gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/square/go-jose.v2"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
@@ -1017,7 +1017,7 @@ func TestAuthCodeWithDefaultStrategy(t *testing.T) {
 	}
 }
 
-// TestAuthCodeWithMockStrategy runs the authorize_code flow against various ConsentStrategy scenarios.
+// TestAuthCodeWithMockStrategy runs the authorization_code flow against various ConsentStrategy scenarios.
 // For that purpose, the consent strategy is mocked so all scenarios can be applied properly. This test suite checks:
 //
 // - [x] should pass request if strategy passes


### PR DESCRIPTION
Signed-off-by: Steve Kaliski <sjkaliski@gmail.com>

## Related issue

https://github.com/ory/docs/issues/78, cc @aeneasr

## Proposed changes

The grant_type pattern is incorrect, replaces `authorize_code` with `authorization_code`.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
