### PR TITLE
Fix #1199: Generated composer autoloader non-functional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "ext-mbstring": "*"
   },
   "autoload": {
-    "psr-4": { "Hydra\\SDK\\" : "sdk/php/swagger/lib/" }
+    "psr-4": { "HydraSDK\\" : "sdk/php/swagger/lib/" }
   }
 }


### PR DESCRIPTION
## Related issue

Fixes #1199 @aeneasr 

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

Documentation should not be required as this merely fixes a bug and thus restores already documented behaviour.

This PR does not contain tests as I would not know how to test composer autoloading on an repository that I do not own. I hope this PR is OK anyways. I'll be happy to add a test case if I could receive some pointers on how to do that for this specific issue.
