### PR TITLE
Support binding frontend/backend to unix sockets

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -61,14 +61,16 @@ var serveControls = `CORE CONTROLS
 - PUBLIC_PORT: The TCP port hydra should listen and handle public API requests on.
 	Defaults to PUBLIC_PORT=4444
 
-- PUBLIC_HOST: The interface hydra should listen and handle public API requests on. Leave empty to listen on all interfaces.
-	Example: PUBLIC_HOST=localhost
+- PUBLIC_HOST: The interface or unix socket hydra should listen and handle public API requests on.
+	Use the prefix "unix:" to specify a path to a unix socket. Leave empty to listen on all interfaces.
+	Example: PUBLIC_HOST=localhost or PUBLIC_HOST="unix:/path/to/public_socket"
 
 - ADMIN_PORT: The TCP port hydra should listen and handle administrative API requests on.
 	Defaults to ADMIN_PORT=4445
 
-- ADMIN_HOST: The interface hydra should listen and handle administartive API requests on. Leave empty to listen on all interfaces.
-	Example: ADMIN_HOST=localhost
+- ADMIN_HOST: The interface or unix socket hydra should listen and handle administrative API requests on.
+	Use the prefix "unix:" to specify a path to a unix socket. Leave empty to listen on all interfaces.
+	Example: ADMIN_HOST=localhost or ADMIN_HOST="unix:/path/to/admin_socket"
 
 - BCRYPT_COST: Set the bcrypt hashing cost. This is a trade off between
 	security and performance. Range is 4 =< x =< 31.

--- a/config/config.go
+++ b/config/config.go
@@ -425,12 +425,19 @@ func (c *Config) GetSystemSecret() []byte {
 	return pkg.HashByteSecret(secret)
 }
 
+func (c *Config) getAddress(address string, port int) string {
+	if strings.HasPrefix(address, "unix:") {
+		return address
+	}
+	return fmt.Sprintf("%s:%d", address, port)
+}
+
 func (c *Config) GetFrontendAddress() string {
-	return fmt.Sprintf("%s:%d", c.FrontendBindHost, c.FrontendBindPort)
+	return c.getAddress(c.FrontendBindHost, c.FrontendBindPort)
 }
 
 func (c *Config) GetBackendAddress() string {
-	return fmt.Sprintf("%s:%d", c.BackendBindHost, c.BackendBindPort)
+	return c.getAddress(c.BackendBindHost, c.BackendBindPort)
 }
 
 func (c *Config) Persist() error {


### PR DESCRIPTION
This allows the use of strings like "unix:/path/to/socket" as PUBLIC_HOST and/or PRIVATE_HOST.

Signed-off-by: Janis Meybohm <meybohm@traum-ferienwohnungen.de>

## Proposed changes
In some environments (kubernetes for example) securing TCP ports is a little tricky. Supporting unix sockets makes it easy to "hide" the administrative API. 

## Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments
I'm happy to add docs and tests (if applicable) if you're okay with this addition/change. Please let me know.
