### PR TITLE
fixes #1238 bump go to 1.11.3 (CVE-2018-16875)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,20 @@ version: 2
 jobs:
   format:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11.3
     working_directory: /go/src/github.com/ory/hydra
     steps:
 # This is disabled for now because goimports is really slow when go modules are used, see
 # https://github.com/golang/go/issues/27287
 #
 #      - run:
-#          name: Enable go1.11 modules
+#          name: Enable go modules
 #          command: |
 #            echo 'export GO111MODULE=on' >> $BASH_ENV
 #            source $BASH_ENV
       - checkout
       - run:
-          name: Enable go1.11 modules
+          name: Enable go modules
           command: |
             echo 'export GO111MODULE=on' >> $BASH_ENV
             source $BASH_ENV
@@ -30,7 +30,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11.3
         environment:
         - TEST_DATABASE_POSTGRESQL=postgres://test:test@localhost:5432/hydra?sslmode=disable
         - TEST_DATABASE_MYSQL=root:test@(localhost:3306)/mysql?parseTime=true
@@ -45,7 +45,7 @@ jobs:
     working_directory: /go/src/github.com/ory/hydra
     steps:
       - run:
-          name: Enable go1.11 modules
+          name: Enable go modules
           command: |
             echo 'export GO111MODULE=on' >> $BASH_ENV
             source $BASH_ENV
@@ -59,7 +59,7 @@ jobs:
 
   test-e2e-opaque:
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.11.3
       environment:
       - DATABASE_URL_POSTGRES=postgres://test:test@localhost:5432/hydra?sslmode=disable
       - DATABASE_URL_MYSQL=mysql://root:test@(localhost:3306)/mysql?parseTime=true
@@ -74,7 +74,7 @@ jobs:
     working_directory: /go/src/github.com/ory/hydra
     steps:
     - run:
-        name: Enable go1.11 modules
+        name: Enable go modules
         command: |
           echo 'export GO111MODULE=on' >> $BASH_ENV
           source $BASH_ENV
@@ -90,11 +90,11 @@ jobs:
 
   test-e2e-plugin:
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.11.3
     working_directory: /go/src/github.com/ory/hydra
     steps:
     - run:
-        name: Enable go1.11 modules
+        name: Enable go modules
         command: |
           echo 'export GO111MODULE=on' >> $BASH_ENV
           source $BASH_ENV
@@ -106,7 +106,7 @@ jobs:
 
   test-e2e-jwt:
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.11.3
       environment:
       - DATABASE_URL_POSTGRES=postgres://test:test@localhost:5432/hydra?sslmode=disable
       - DATABASE_URL_MYSQL=mysql://root:test@(localhost:3306)/mysql?parseTime=true
@@ -121,7 +121,7 @@ jobs:
     working_directory: /go/src/github.com/ory/hydra
     steps:
     - run:
-        name: Enable go1.11 modules
+        name: Enable go modules
         command: |
           echo 'export GO111MODULE=on' >> $BASH_ENV
           source $BASH_ENV
@@ -171,11 +171,11 @@ jobs:
 
   release-docker:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11.3
     working_directory: /go/src/github.com/ory/hydra
     steps:
       - run:
-          name: Enable go1.11 modules
+          name: Enable go modules
           command: |
             echo 'export GO111MODULE=on' >> $BASH_ENV
             source $BASH_ENV
@@ -202,11 +202,11 @@ jobs:
 
   release-binaries:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11.3
     working_directory: /go/src/github.com/ory/hydra
     steps:
       - run:
-          name: Enable go1.11 modules
+          name: Enable go modules
           command: |
             echo 'export GO111MODULE=on' >> $BASH_ENV
             source $BASH_ENV
@@ -248,11 +248,11 @@ jobs:
 
   benchmark:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11.3
     working_directory: /go/src/github.com/ory/hydra
     steps:
       - run:
-          name: Enable go1.11 modules
+          name: Enable go modules
           command: |
             echo 'export GO111MODULE=on' >> $BASH_ENV
             source $BASH_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine
+FROM golang:1.11.3-alpine
 
 ARG git_tag
 ARG git_commit

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine
+FROM golang:1.11.3-alpine
 
 ARG git_tag
 ARG git_commit


### PR DESCRIPTION
FYI: **this version of go introduces a known regression** which will be addressed in the next patch release. I guess they were moving fast to address the CVE.

> We are aware of a functionality regression in "go get" when executed in GOPATH mode on an import path pattern containing "..." (e.g., "go get github.com/golang/pkg/..."), when downloading packages not already present in the GOPATH workspace. This is issue golang.org/issue/29241. It will be resolved in the next minor patch releases, Go 1.11.4 and Go 1.10.7, which we plan to release soon. We apologize for any disruption.
https://groups.google.com/forum/#!msg/golang-announce/Kw31K8G7Fi0/z2olKn-QCAAJ

👀 @aeneasr 