### PR TITLE
fix error message of too short NEW_SYSTEM_SECRET

### DIFF
--- a/cmd/cli/handler_migrate.go
+++ b/cmd/cli/handler_migrate.go
@@ -122,7 +122,7 @@ func (h *MigrateHandler) MigrateSecret(cmd *cobra.Command, args []string) {
 	}
 
 	if len(newSecret) < 16 {
-		cmdx.Fatalf("Value of environment variable NEW_SYSTEM_SECRET has to be at least 16 characters long but got: %d", len(oldSecret))
+		cmdx.Fatalf("Value of environment variable NEW_SYSTEM_SECRET has to be at least 16 characters long but got: %d", len(newSecret))
 	}
 
 	fmt.Println("Rotating encryption keys for JSON Web Key storage...")


### PR DESCRIPTION
## Related issue

none

## Proposed changes

Show count of `NEW_SYSTEM_SECRET` length when `NEW_SYSTEM_SECRET` is too short

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

none