### PR TITLE
Enable to validate by old system secret

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,6 +138,9 @@ func initConfig() {
 	viper.BindEnv("SYSTEM_SECRET")
 	viper.SetDefault("SYSTEM_SECRET", "")
 
+	viper.BindEnv("ROTATED_SYSTEM_SECRET")
+	viper.SetDefault("ROTATED_SYSTEM_SECRET", "")
+
 	viper.BindEnv("CLIENT_SECRET")
 	viper.SetDefault("CLIENT_SECRET", "")
 

--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -94,7 +94,7 @@ func newOAuth2Provider(c *config.Config) fosite.OAuth2Provider {
 	}
 
 	var coreStrategy foauth2.CoreStrategy
-	hmacStrategy := compose.NewOAuth2HMACStrategy(fc, c.GetSystemSecret(), nil)
+	hmacStrategy := compose.NewOAuth2HMACStrategy(fc, c.GetSystemSecret(), c.GetRotatedSystemSecrets())
 	if c.OAuth2AccessTokenStrategy == "jwt" {
 		kid := uuid.New()
 		if _, err := createOrGetJWK(c, oauth2.OAuth2JWTKeyName, kid, "private"); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -364,7 +364,8 @@ func (c *Config) Context() *Context {
 		Hasher:     hasher,
 		FositeStrategy: &foauth2.HMACSHAStrategy{
 			Enigma: &hmac.HMACStrategy{
-				GlobalSecret: c.GetSystemSecret(),
+				GlobalSecret:         c.GetSystemSecret(),
+				RotatedGlobalSecrets: c.GetRotatedSystemSecrets(),
 			},
 			AccessTokenLifespan:   c.GetAccessTokenLifespan(),
 			AuthorizeCodeLifespan: c.GetAuthCodeLifespan(),

--- a/config/config.go
+++ b/config/config.go
@@ -397,6 +397,10 @@ func (c *Config) GetCookieSecret() []byte {
 }
 
 func (c *Config) GetRotatedSystemSecrets() [][]byte {
+	if len(c.RotatedSystemSecret) == 0 {
+		return nil
+	}
+
 	return [][]byte{
 		pkg.HashStringSecret(c.RotatedSystemSecret),
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,6 +105,13 @@ func TestSystemSecret(t *testing.T) {
 	assert.EqualValues(t, c.GetSystemSecret(), c2.GetSystemSecret())
 }
 
+func TestRotatedSystemSecrets(t *testing.T) {
+	c := &Config{RotatedSystemSecret: "foobarbazbarasdfasdffoobarbazbarasdfasdf"}
+	assert.EqualValues(t, c.GetRotatedSystemSecrets(), c.GetRotatedSystemSecrets())
+	c2 := &Config{RotatedSystemSecret: ""}
+	assert.Nil(t, c2.GetRotatedSystemSecrets())
+}
+
 func TestResolve(t *testing.T) {
 	c := &Config{EndpointURL: "https://localhost:1234"}
 	assert.Equal(t, c.Resolve("foo", "bar").String(), "https://localhost:1234/foo/bar")


### PR DESCRIPTION
## Related issue

none

## Proposed changes

Enable to validate by old system secret when setting `ROTATED_SYSTEM_SECRET`.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

none