### PR TITLE
fix token flush CLI description

### DIFF
--- a/cmd/token_flush.go
+++ b/cmd/token_flush.go
@@ -37,7 +37,7 @@ var tokenFlushCmd = &cobra.Command{
 func init() {
 	tokenCmd.AddCommand(tokenFlushCmd)
 
-	tokenFlushCmd.Flags().Duration("min-age", time.Duration(0), "Skip removing tokens which do not satisfy the minimum age (1s, 1m, 1h, 1d)")
+	tokenFlushCmd.Flags().Duration("min-age", time.Duration(0), "Skip removing tokens which do not satisfy the minimum age (1s, 1m, 1h)")
 	tokenFlushCmd.Flags().String("access-token", os.Getenv("OAUTH2_ACCESS_TOKEN"), "Set an access token to be used in the Authorization header, defaults to environment variable OAUTH2_ACCESS_TOKEN")
 	tokenFlushCmd.Flags().String("endpoint", os.Getenv("HYDRA_ADMIN_URL"), "Set the URL where ORY Hydra is hosted, defaults to environment variable HYDRA_ADMIN_URL")
 }


### PR DESCRIPTION
## Related issue

none

## Proposed changes

"1d" is unavailable unit so that I fixed token flush CLI description.
Only we can use  these units: "ns", "us" (or "µs"), "ms", "s", "m", "h".
https://godoc.org/time#ParseDuration

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
