### PR TITLE
SDK: Displays accurate error information when client create request failed

### DIFF
--- a/sdk/go/hydra/swagger/admin_api.go
+++ b/sdk/go/hydra/swagger/admin_api.go
@@ -276,6 +276,10 @@ func (a AdminApi) CreateOAuth2Client(body OAuth2Client) (*OAuth2Client, *APIResp
 	var successPayload = new(OAuth2Client)
 	localVarHttpResponse, err := a.Configuration.APIClient.CallAPI(localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 
+	if localVarHttpResponse.StatusCode() >= 300 {
+		return nil, nil, fmt.Errorf("HTTP request is failed. status code is %d", localVarHttpResponse.StatusCode())
+	}
+
 	var localVarURL, _ = url.Parse(localVarPath)
 	localVarURL.RawQuery = localVarQueryParams.Encode()
 	var localVarAPIResponse = &APIResponse{Operation: "CreateOAuth2Client", Method: localVarHttpMethod, RequestURL: localVarURL.String()}


### PR DESCRIPTION
## Related issue

#1244 

## Proposed changes

Displays accurate error information when client create request failed.

Currently, hydra shows JSON parse error when client create request failed due to parse HTML in spite of getting error response.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
