### PR TITLE
cmd: Add --allowed-cors-origins to client create.

### DIFF
--- a/cmd/cli/handler_client.go
+++ b/cmd/cli/handler_client.go
@@ -106,6 +106,7 @@ func (h *ClientHandler) CreateClient(cmd *cobra.Command, args []string) {
 		PolicyUri:               flagx.MustGetString(cmd, "policy-uri"),
 		LogoUri:                 flagx.MustGetString(cmd, "logo-uri"),
 		ClientUri:               flagx.MustGetString(cmd, "client-uri"),
+		AllowedCorsOrigins:      flagx.MustGetStringSlice(cmd, "allowed-cors-origins"),
 		SubjectType:             flagx.MustGetString(cmd, "subject-type"),
 		Audience:                flagx.MustGetStringSlice(cmd, "audience"),
 	}

--- a/cmd/clients_create.go
+++ b/cmd/clients_create.go
@@ -54,6 +54,7 @@ func init() {
 	clientsCreateCmd.Flags().String("tos-uri", "", "A URL string that points to a human-readable terms of service document for the client that describes a contractual relationship between the end-user and the client that the end-user accepts when authorizing the client")
 	clientsCreateCmd.Flags().String("client-uri", "", "A URL string of a web page providing information about the client")
 	clientsCreateCmd.Flags().String("logo-uri", "", "A URL string that references a logo for the client")
+	clientsCreateCmd.Flags().StringSlice("allowed-cors-origins", []string{}, "The list of URLs allowed to make CORS requests. Requires CORS_ENABLED.")
 	clientsCreateCmd.Flags().String("subject-type", "public", "A URL string that references a logo for the client")
 	clientsCreateCmd.Flags().String("secret", "", "Provide the client's secret")
 	clientsCreateCmd.Flags().StringP("name", "n", "", "The client's name")


### PR DESCRIPTION
This allows the creation of clients permitted to make CORS requests from
specific domains.

Signed-off-by: Josh Giles <jgiles@paxos.com>

## Related issue

This  follows up on #957, which added the server feature but not a way to specify the CORS origins in the cli.

## Proposed changes

Add a flag for setting the allowed CORS origins.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
