### PR TITLE
Return the expiration time of the token, depending on its type, on the endpoint of introspection.

### DIFF
--- a/cmd/server/handler_oauth2_factory.go
+++ b/cmd/server/handler_oauth2_factory.go
@@ -219,6 +219,7 @@ func newOAuth2Handler(c *config.Config, frontend, backend *httprouter.Router, cm
 		ErrorURL:               *errorURL,
 		H:                      w,
 		AccessTokenLifespan:    c.GetAccessTokenLifespan(),
+		RefreshTokenLifespan:   c.GetRefreshTokenLifespan(),
 		CookieStore:            sessions.NewCookieStore(c.GetCookieSecret()),
 		IssuerURL:              c.Issuer,
 		ClientRegistrationURL:  c.ClientRegistrationURL,

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -430,9 +430,14 @@ func (h *Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request, _ ht
 		TokenType:       tt,
 	}
 
-	exp := resp.GetAccessRequester().GetSession().GetExpiresAt(fosite.AccessToken)
-	if exp.IsZero() {
-		exp = resp.GetAccessRequester().GetRequestedAt().Add(h.AccessTokenLifespan)
+	var exp time.Time
+	if tt == fosite.RefreshToken {
+		exp = resp.GetAccessRequester().GetRequestedAt().Add(h.RefreshTokenLifespan)
+	} else {
+		exp := resp.GetAccessRequester().GetSession().GetExpiresAt(fosite.AccessToken)
+		if exp.IsZero() {
+			exp = resp.GetAccessRequester().GetRequestedAt().Add(h.AccessTokenLifespan)
+		}
 	}
 
 	session, ok := resp.GetAccessRequester().GetSession().(*Session)

--- a/oauth2/handler_struct.go
+++ b/oauth2/handler_struct.go
@@ -44,7 +44,8 @@ type Handler struct {
 	ForcedHTTP bool
 	ErrorURL   url.URL
 
-	AccessTokenLifespan time.Duration
+	AccessTokenLifespan  time.Duration
+	RefreshTokenLifespan time.Duration
 	//IDTokenLifespan     time.Duration
 	CookieStore sessions.Store
 


### PR DESCRIPTION
## Related issue
https://github.com/ory/hydra/issues/1296
@aeneasr @aaslamin 

## Proposed changes
The change allows to get the correct expiration time of the token, depending on its type.

## Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [ ] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
