### PR TITLE
cmd: Fix no-open inverted flag check

### DIFF
--- a/cmd/token_user.go
+++ b/cmd/token_user.go
@@ -123,7 +123,7 @@ var tokenUserCmd = &cobra.Command{
 			oauth2.SetAuthURLParam("max_age", strconv.Itoa(maxAge)),
 		)
 
-		if flagx.MustGetBool(cmd, "no-open") {
+		if !flagx.MustGetBool(cmd, "no-open") {
 			webbrowser.Open(serverLocation)
 		}
 


### PR DESCRIPTION
## Related issue

Command `hydra token user --no-open` does not open up the browser since the `--no-open` flag check is inverted, similar to ory/hydra#1258 and https://github.com/ory/keto/pull/85

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
