### PR TITLE
Prevent errors when calling HandleConsentRequest a second time

### DIFF
--- a/consent/manager_test_helpers.go
+++ b/consent/manager_test_helpers.go
@@ -295,6 +295,9 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager pkg.Fos
 					require.NoError(t, err)
 					compareConsentRequest(t, c, got1)
 
+					_, err = m.HandleConsentRequest(context.TODO(), "challenge"+tc.key, h)
+					require.NoError(t, err)
+
 					got2, err := m.VerifyAndInvalidateConsentRequest(context.TODO(), "verifier"+tc.key)
 					require.NoError(t, err)
 					compareConsentRequest(t, c, got2.ConsentRequest)

--- a/consent/sql_helper.go
+++ b/consent/sql_helper.go
@@ -23,6 +23,7 @@ package consent
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -89,6 +90,13 @@ var sqlParamsConsentRequestHandled = []string{
 	"session_id_token",
 	"was_used",
 }
+var sqlParamsConsentRequestHandledUpdate = func() []string {
+	p := make([]string, len(sqlParamsConsentRequestHandled))
+	for i, v := range sqlParamsConsentRequestHandled {
+		p[i] = fmt.Sprintf("%s=:%s", v, v)
+	}
+	return p
+}()
 
 var sqlParamsAuthSession = []string{
 	"id",


### PR DESCRIPTION
Signed-off-by: Kevin Minehart <kmineh0151@gmail.com>

## Related issue

#1256 

Previous PR: https://github.com/ory/hydra/pull/1301

## Proposed changes

If HandleConsentRequest is called a second time, then:
* If the request was not used (`was_used = false`), then the old ConsentRequest is replaced with the newly provided data.
* If the request was used (`was_used = true`), then the old ConsentRequest is returned, whereas previously a SQL error would be returned.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ x I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

Sorry about messing up the old PR!  I tried something new with squashing commits but that backfired when I forgot to sign an older commit. 🤷‍♂️
