### PR TITLE
docker: update docker-compose to v3 + docker-compose files refactor

### DIFF
--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,0 +1,29 @@
+###########################################################################
+#######             FOR DEMONSTRATION PURPOSES ONLY                 #######
+###########################################################################
+#                                                                         #
+# If you have not yet read the tutorial, do so now:                       #
+#  https://www.ory.sh/docs/hydra/5min-tutorial                            #
+#                                                                         #
+# This set up is only for demonstration purposes. The login               #
+# endpoint can only be used if you follow the steps in the tutorial.      #
+#                                                                         #
+###########################################################################
+
+version: '3'
+
+services:
+
+  hydra-migrate:
+    environment:
+      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
+
+  hydra:
+    environment:
+      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
+    restart: unless-stopped
+
+  mysqld:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=secret

--- a/docker-compose-tracing.yml
+++ b/docker-compose-tracing.yml
@@ -1,0 +1,36 @@
+###########################################################################
+#######             FOR DEMONSTRATION PURPOSES ONLY                 #######
+###########################################################################
+#                                                                         #
+# If you have not yet read the tutorial, do so now:                       #
+#  https://www.ory.sh/docs/hydra/5min-tutorial                            #
+#                                                                         #
+# This set up is only for demonstration purposes. The login               #
+# endpoint can only be used if you follow the steps in the tutorial.      #
+#                                                                         #
+###########################################################################
+
+version: '3'
+
+services:
+
+  hydra:
+    depends_on:
+      - jaeger
+    environment:
+      - TRACING_PROVIDER=jaeger
+      - TRACING_PROVIDER_JAEGER_SAMPLING_SERVER_URL=http://jaeger:5778/sampling
+      - TRACING_PROVIDER_JAEGER_LOCAL_AGENT_ADDRESS=jaeger:6831
+      - TRACING_PROVIDER_JAEGER_SAMPLING_TYPE=const
+      - TRACING_PROVIDER_JAEGER_SAMPLING_VALUE=1
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.7.0
+    ports:
+      - "5775:5775/udp"
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "5778:5778"
+      - "16686:16686"
+      - "14268:14268"
+      - "9411:9411"

--- a/docker-compose-twoc-mysql.yml
+++ b/docker-compose-twoc-mysql.yml
@@ -1,0 +1,32 @@
+###########################################################################
+#######             FOR DEMONSTRATION PURPOSES ONLY                 #######
+###########################################################################
+#                                                                         #
+# If you have not yet read the tutorial, do so now:                       #
+# https://www.ory.sh/docs/hydra/5min-tutorial                             #
+#                                                                         #
+# This set up is only for demonstration purposes. The login               #
+# endpoint can only be used if you follow the steps in the tutorial.      #
+#                                                                         #
+###########################################################################
+
+version: '3'
+
+services:
+
+  hydra-migrate:
+    environment:
+      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
+
+  hydra-admin:
+    environment:
+      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
+
+  hydra:
+    environment:
+      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
+
+  mysqld:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=secret

--- a/docker-compose-twoc.yml
+++ b/docker-compose-twoc.yml
@@ -41,8 +41,6 @@ services:
       - OAUTH2_CONSENT_URL=http://localhost:3000/consent
       - OAUTH2_LOGIN_URL=http://localhost:3000/login
       - DATABASE_URL=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable
-#     Uncomment the following line to use mysql instead.
-#      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
       - SYSTEM_SECRET=youReallyNeedToChangeThis
       - OAUTH2_SHARE_ERROR_DEBUG=1
 #      - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
@@ -64,8 +62,6 @@ services:
       - OAUTH2_CONSENT_URL=http://localhost:3000/consent
       - OAUTH2_LOGIN_URL=http://localhost:3000/login
       - DATABASE_URL=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable
-#     Uncomment the following line to use mysql instead.
-#      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
       - SYSTEM_SECRET=youReallyNeedToChangeThis
       - OAUTH2_SHARE_ERROR_DEBUG=1
 #      - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
@@ -87,9 +83,3 @@ services:
       - POSTGRES_USER=hydra
       - POSTGRES_PASSWORD=secret
       - POSTGRES_DB=hydra
-
-#  Uncomment the following section to use mysql instead.
-#  mysqld:
-#    image: mysql:5.7
-#    environment:
-#      - MYSQL_ROOT_PASSWORD=secret

--- a/docker-compose-twoc.yml
+++ b/docker-compose-twoc.yml
@@ -10,7 +10,7 @@
 #                                                                         #
 ###########################################################################
 
-version: '2'
+version: '3'
 
 services:
 
@@ -18,8 +18,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    links:
-      - postgresd:postgresd
     environment:
 #      - LOG_LEVEL=debug
       - DATABASE_URL=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable
@@ -31,10 +29,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    links:
-      - postgresd:postgresd
-#     Uncomment the following line to use mysql instead.
-#      - mysqld:mysqld
     depends_on:
       - hydra-migrate
     ports:
@@ -58,10 +52,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    links:
-      - postgresd:postgresd
-#     Uncomment the following line to use mysql instead.
-#      - mysqld:mysqld
     depends_on:
       - hydra-migrate
     ports:
@@ -85,8 +75,6 @@ services:
     environment:
       - HYDRA_ADMIN_URL=http://hydra-admin:4445
     image: oryd/hydra-login-consent-node:v1.0.0-rc.5
-    links:
-      - hydra-admin
     ports:
       - "3000:3000"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@
 #                                                                         #
 ###########################################################################
 
-version: '2'
+version: '3'
 
 services:
 
@@ -18,10 +18,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    links:
-      - postgresd:postgresd
-#     Uncomment the following section to use mysql instead.
-#      - mysqld:mysqld
     environment:
 #      - LOG_LEVEL=debug
       - DATABASE_URL=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable
@@ -35,10 +31,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    links:
-      - postgresd:postgresd
-#     Uncomment the following line to use mysql instead.
-#      - mysqld:mysqld
     depends_on:
       - hydra-migrate
 #     Uncomment the following when configuring tracing
@@ -71,17 +63,15 @@ services:
 #      - TRACING_PROVIDER_JAEGER_LOCAL_AGENT_ADDRESS=jaeger:6831
 #      - TRACING_PROVIDER_JAEGER_SAMPLING_TYPE=const
 #      - TRACING_PROVIDER_JAEGER_SAMPLING_VALUE=1
-    restart: on-failure
+    restart: unless-stopped
 
   consent:
     environment:
       - HYDRA_ADMIN_URL=http://hydra:4445
     image: oryd/hydra-login-consent-node:v1.0.0-rc.5
-    links:
-      - hydra
     ports:
       - "3000:3000"
-    restart: on-failure
+    restart: unless-stopped
 
 # Uncomment the following when configuring tracing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     environment:
 #      - LOG_LEVEL=debug
       - DATABASE_URL=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable
-#     Uncomment the following section to use mysql instead.
-#      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
     command:
       migrate sql -e
     restart: on-failure
@@ -33,15 +31,10 @@ services:
       dockerfile: Dockerfile
     depends_on:
       - hydra-migrate
-#     Uncomment the following when configuring tracing
-#      - jaeger
     ports:
-      # Public port
-      - "4444:4444"
-      # Admin port
-      - "4445:4445"
-      # Port for hydra token user
-      - "5555:5555"
+      - "4444:4444" # Public port
+      - "4445:4445" # Admin port
+      - "5555:5555" # Port for hydra token user
     command:
       serve all --dangerous-force-http
     environment:
@@ -50,19 +43,11 @@ services:
       - OAUTH2_CONSENT_URL=http://localhost:3000/consent
       - OAUTH2_LOGIN_URL=http://localhost:3000/login
       - DATABASE_URL=postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable
-#     Uncomment the following line to use mysql instead.
-#      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
       - SYSTEM_SECRET=youReallyNeedToChangeThis
       - OAUTH2_SHARE_ERROR_DEBUG=1
       - OIDC_SUBJECT_TYPES_SUPPORTED=public,pairwise
       - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
-#     - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
-#     Uncomment the following lines when configuring tracing
-#      - TRACING_PROVIDER=jaeger
-#      - TRACING_PROVIDER_JAEGER_SAMPLING_SERVER_URL=http://jaeger:5778/sampling
-#      - TRACING_PROVIDER_JAEGER_LOCAL_AGENT_ADDRESS=jaeger:6831
-#      - TRACING_PROVIDER_JAEGER_SAMPLING_TYPE=const
-#      - TRACING_PROVIDER_JAEGER_SAMPLING_VALUE=1
+#      - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
     restart: unless-stopped
 
   consent:
@@ -73,19 +58,6 @@ services:
       - "3000:3000"
     restart: unless-stopped
 
-# Uncomment the following when configuring tracing
-
-#  jaeger:
-#    image: jaegertracing/all-in-one:1.7.0
-#    ports:
-#    - "5775:5775/udp"
-#    - "6831:6831/udp"
-#    - "6832:6832/udp"
-#    - "5778:5778"
-#    - "16686:16686"
-#    - "14268:14268"
-#    - "9411:9411"
-
   postgresd:
     image: postgres:9.6
     ports:
@@ -94,9 +66,3 @@ services:
       - POSTGRES_USER=hydra
       - POSTGRES_PASSWORD=secret
       - POSTGRES_DB=hydra
-
-#  Uncomment the following section to use mysql instead.
-#  mysqld:
-#    image: mysql:5.7
-#    environment:
-#      - MYSQL_ROOT_PASSWORD=secret

--- a/scripts/5min-tutorial.sh
+++ b/scripts/5min-tutorial.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+DB=${DB:-postgres}
+TRACING=${TRACING:-false}
+TWOC=${TWOC:-false}
+
+DC="docker-compose -f docker-compose.yml"
+if [[ $DB == "mysql" ]]; then
+    DC+=" -f docker-compose-mysql.yml"
+fi
+if [[ $TRACING == true ]]; then
+    DC+=" -f docker-compose-tracing.yml"
+fi
+if [[ $TWOC == true ]]; then
+    DC+=" -f docker-compose-twoc.yml"
+fi
+DC+=" up --build"
+
+$DC
+


### PR DESCRIPTION
## Related issues

#1321 #1196

## Proposed changes

* Update docker-compose to v3.
* Reorganize/refactor docker-compose config into multiple files for cleanness and readability.

## About the second commit, reorganize/refactor...

I've detected six usecases of the docker-compose files.

1. postgres 
2. mysql
3. postgres + tracing
4. mysql + tracing
5. twoc-postgres
6. twoc-mysql

Instead of forcing the user to edit the `docker-compose.yml` and `docker-compose-twoc.yml` files by hand, the usage now would be:

1. docker-compose up --build
2. docker-compose -f docker-compose.yml -f docker-compose-mysql.yml up --build
3. docker-compose -f docker-compose.yml -f docker-compose-tracing.yml up --build
4. docker-compose -f docker-compose.yml -f docker-compose-mysql.yml -f docker-compose-tracing.yml up --build
5. docker-compose -f docker-compose-twoc.yml up --build
6. docker-compose -f docker-compose-twoc.yml -f docker-compose-twoc-mysql.yml up --build

## How does it work:

docker-compose does a merge between the files you pass  in via `-f`. So idea is to just override/modify the config as needed from base `docker-compose.yml`.

## Summary

#### Advantages

* Cleaner to read.
* User doesn't have to touch files by hand to change the database or add tracing.

#### Disadvantages

* Commands are longer to type if you are not on standard configuration.
* Requires better docker-compose understanding if you want to tweak the files.

## Notes

* An edit of the docs would be required if this gets approved.
* I've tested all the described scenarios using `docker-compose config` and diff-ing the files with the produced output by the original config to ensure the behavior is the same on both scenarios.

CC \ @aeneasr 
