### PR TITLE
Fix pagination headers

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -206,9 +206,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		return
 	}
 
-	if val := pagination.Header(r.URL, n, limit, offset); val != "" {
-		w.Header().Set("Link", val)
-	}
+	pagination.Header(w, r.URL, n, limit, offset)
 
 	h.r.Writer().Write(w, r, clients)
 }

--- a/client/handler.go
+++ b/client/handler.go
@@ -205,8 +205,12 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 		h.r.Writer().WriteError(w, r, err)
 		return
 	}
+
+	if val := pagination.Header(r.URL, n, limit, offset); val != "" {
+		w.Header().Set("Link", val)
+	}
+
 	h.r.Writer().Write(w, r, clients)
-	pagination.Header(r.URL, n, limit, offset).Write(w)
 }
 
 // swagger:route GET /clients/{id} admin getOAuth2Client

--- a/consent/handler.go
+++ b/consent/handler.go
@@ -192,9 +192,7 @@ func (h *Handler) GetConsentSessions(w http.ResponseWriter, r *http.Request, ps 
 		return
 	}
 
-	if val := pagination.Header(r.URL, n, limit, offset); val != "" {
-		w.Header().Set("Link", val)
-	}
+	pagination.Header(w, r.URL, n, limit, offset)
 
 	h.r.Writer().Write(w, r, a)
 }

--- a/consent/handler.go
+++ b/consent/handler.go
@@ -192,8 +192,11 @@ func (h *Handler) GetConsentSessions(w http.ResponseWriter, r *http.Request, ps 
 		return
 	}
 
+	if val := pagination.Header(r.URL, n, limit, offset); val != "" {
+		w.Header().Set("Link", val)
+	}
+
 	h.r.Writer().Write(w, r, a)
-	pagination.Header(r.URL, n, limit, offset).Write(w)
 }
 
 // swagger:route DELETE /oauth2/auth/sessions/login/{user} admin revokeAuthenticationSession

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/ory/go-convenience v0.1.0
 	github.com/ory/graceful v0.1.1
 	github.com/ory/herodot v0.6.0
-	github.com/ory/x v0.0.47
+	github.com/ory/x v0.0.49
 	github.com/pborman/uuid v1.2.0
 	github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/ory/graceful v0.1.1/go.mod h1:zqu70l95WrKHF4AZ6tXHvAqAvpY6M7g6ttaAVcM
 github.com/ory/herodot v0.5.1/go.mod h1:3BOneqcyBsVybCPAJoi92KN2BpJHcmDqAMcAAaJiJow=
 github.com/ory/herodot v0.6.0 h1:Dcs4yH1Qw1GIgGCvvvdafhT8xjwElTE//8xLmHtPEYA=
 github.com/ory/herodot v0.6.0/go.mod h1:3BOneqcyBsVybCPAJoi92KN2BpJHcmDqAMcAAaJiJow=
-github.com/ory/x v0.0.47 h1:cF0u521fXN3nZ1h7z5r6LfZVEaL6WBHrbiY4jR1HFog=
-github.com/ory/x v0.0.47/go.mod h1:LVQf17Z8SK/y0H0ewDuIqJLDCjQ2eOIfQT5l0LH53ls=
+github.com/ory/x v0.0.49 h1:ncw4dixaRl4AY2p5UZpEmpmnNaI8UyaS75Ubeat+YyI=
+github.com/ory/x v0.0.49/go.mod h1:LVQf17Z8SK/y0H0ewDuIqJLDCjQ2eOIfQT5l0LH53ls=
 github.com/parnurzeal/gorequest v0.2.15/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=


### PR DESCRIPTION
Signed-off-by: Kevin Minehart <kmineh0151@gmail.com>

## Related issue

#1361

This PR in ory/x: https://github.com/ory/x/pull/39

## Proposed changes

Instead of using `http.Header.Write(...)` in an attempt to write http headers, just use `http.ResponseWriter.Headers().Set(...)`.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)