### PR TITLE
Allow localhost to skip consent for public clients

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -416,11 +416,12 @@ func (s *DefaultStrategy) requestConsent(w http.ResponseWriter, r *http.Request,
 	// accepted, as appropriate.
 	if ar.GetClient().IsPublic() {
 		// The OpenID Connect Test Tool fails if this returns `consent_required` when `prompt=none` is used.
-		// According to the quote above, it should be ok to allow https to skip consent.
+		// According to the quote above, it should be ok to allow https to skip consent. Additionally any localhost
+		// hostname is allowed to skip consent.
 		//
 		// This is tracked as issue: https://github.com/ory/hydra/issues/866
 		// This is also tracked as upstream issue: https://github.com/openid-certification/oidctest/issues/97
-		if ar.GetRedirectURI().Scheme != "https" {
+		if ar.GetRedirectURI().Scheme != "https" && !(fosite.IsLocalhost(ar.GetRedirectURI() && ar.GetRedirectURI().Scheme == "http")) {
 			return s.forwardConsentRequest(w, r, ar, authenticationSession, nil)
 		}
 	}

--- a/consent/strategy_default_test.go
+++ b/consent/strategy_default_test.go
@@ -480,13 +480,34 @@ func TestStrategy(t *testing.T) {
 		},
 		{
 			d:                     "This should fail because prompt=none, client is public, and redirection scheme is not HTTPS but a custom scheme",
-			req:                   fosite.AuthorizeRequest{RedirectURI: mustParseURL(t, "custom://redirection-scheme/path"), Request: fosite.Request{Client: &client.Client{TokenEndpointAuthMethod: "none", ClientID: "client-id"}, RequestedScope: []string{"scope-a"}}},
+			req:                   fosite.AuthorizeRequest{RedirectURI: mustParseURL(t, "custom://localhost/path"), Request: fosite.Request{Client: &client.Client{TokenEndpointAuthMethod: "none", ClientID: "client-id"}, RequestedScope: []string{"scope-a"}}},
 			prompt:                "none",
 			jar:                   persistentCJ,
 			lph:                   passAuthentication(apiClient, false),
 			expectFinalStatusCode: fosite.ErrConsentRequired.StatusCode(),
 			expectErrType:         []error{ErrAbortOAuth2Request, fosite.ErrConsentRequired},
 			expectErr:             []bool{true, true},
+		},
+		{
+			d:                     "This should pass because prompt=none, client is public, redirection scheme is HTTP and host is localhost",
+			req:                   fosite.AuthorizeRequest{RedirectURI: mustParseURL(t, "http://localhost/path"), Request: fosite.Request{Client: &client.Client{TokenEndpointAuthMethod: "none", ClientID: "client-id"}, RequestedScope: []string{"scope-a"}}},
+			prompt:                "none",
+			jar:                   persistentCJ,
+			lph:                   passAuthentication(apiClient, true),
+			cph:                   passAuthorization(apiClient, true),
+			expectFinalStatusCode: http.StatusOK,
+			expectErrType:         []error{ErrAbortOAuth2Request, ErrAbortOAuth2Request, nil},
+			expectErr:             []bool{true, true, false},
+			expectSession: &HandledConsentRequest{
+				ConsentRequest: &ConsentRequest{Subject: "user", SubjectIdentifier: "user"},
+				GrantedScope:   []string{"scope-a"},
+				Remember:       true,
+				RememberFor:    0,
+				Session: &ConsentRequestSessionData{
+					AccessToken: map[string]interface{}{"foo": "bar"},
+					IDToken:     map[string]interface{}{"bar": "baz"},
+				},
+			},
 		},
 		// This test is disabled because it breaks OIDC Conformity Tests
 		//{


### PR DESCRIPTION
This PR **should** fix #1364.

I'm not a go developer, and I didn't manage to get the tests working (unrelated to this code change). Basically I was getting the following error during testing, which did not result from my code changes:

```
client/handler.go:209: not enough arguments in call to pagination.Header
	have (*url.URL, int, int, int)
	want (http.ResponseWriter, *url.URL, int, int, int)
```