### PR TITLE
 #1369 Fix well known keys when AccessTokenStrategy is JWT

### DIFF
--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -92,7 +92,7 @@ func (v *ViperProvider) InsecureRedirects() []string {
 
 func (v *ViperProvider) WellKnownKeys(include ...string) []string {
 	if v.AccessTokenStrategy() == "jwt" {
-		include = append(include, x.OpenIDConnectKeyName)
+		include = append(include, x.OAuth2JWTKeyName)
 	}
 
 	include = append(include, x.OpenIDConnectKeyName)


### PR DESCRIPTION
## Related issue

Resolves #1369 

## Proposed changes

Correct constant in `func WellKnownKeys(...)` when access token strategy is JWT

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ x I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [ ] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
