### PR TITLE
cmd: fix help text on migrate cmd

### DIFF
--- a/cmd/migrate_sql.go
+++ b/cmd/migrate_sql.go
@@ -46,5 +46,5 @@ Before running this command on an existing database, create a back up!
 func init() {
 	migrateCmd.AddCommand(migrateSqlCmd)
 
-	migrateSqlCmd.Flags().BoolP("read-from-env", "e", false, "If set, reads the database URL from the environment variable DATABASE_URL.")
+	migrateSqlCmd.Flags().BoolP("read-from-env", "e", false, "If set, reads the database connection string from the environment variable DSN.")
 }


### PR DESCRIPTION
## Proposed changes

Fixed help text to reference the correct environment variable which is now `DSN` instead of `DATABASE_URL`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)