### PR TITLE
Do not confirmLoginSession when skip is true to prevent remember reset to false

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -416,8 +416,10 @@ func (s *DefaultStrategy) verifyAuthentication(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	if err := s.r.ConsentManager().ConfirmLoginSession(r.Context(), sessionID, session.Subject, session.Remember); err != nil {
-		return nil, err
+	if !session.LoginRequest.Skip {
+		if err := s.r.ConsentManager().ConfirmLoginSession(r.Context(), sessionID, session.Subject, session.Remember); err != nil {
+			return nil, err
+		}
 	}
 
 	if !session.Remember {


### PR DESCRIPTION
## Related issue

#1409

## Proposed changes

"Remember" flag was reset to false after a 2nd login dance when the first login dance was "remembered.
I tried to follow instructions from @aeneasr on discord, but I am new to this project and oauth2...

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

I am still learning how the tests are structured, so I am still not sure how to add tests... I might need some guidance in order to add tests if you think tests need to be added.