### PR TITLE
cmd: allow to set the client's post-logout URIs

### DIFF
--- a/cmd/cli/handler_client.go
+++ b/cmd/cli/handler_client.go
@@ -119,6 +119,7 @@ func (h *ClientHandler) CreateClient(cmd *cobra.Command, args []string) {
 		AllowedCORSOrigins:      flagx.MustGetStringSlice(cmd, "allowed-cors-origins"),
 		SubjectType:             flagx.MustGetString(cmd, "subject-type"),
 		Audience:                flagx.MustGetStringSlice(cmd, "audience"),
+		PostLogoutRedirectUris:  flagx.MustGetStringSlice(cmd, "post-logout-callbacks"),
 	}
 
 	response, err := m.Admin.CreateOAuth2Client(admin.NewCreateOAuth2ClientParams().WithBody(&cc))

--- a/cmd/clients_create.go
+++ b/cmd/clients_create.go
@@ -61,6 +61,7 @@ func init() {
 	clientsCreateCmd.Flags().String("subject-type", "public", "A identifier algorithm. Valid values are \"public\" and \"pairwise\"")
 	clientsCreateCmd.Flags().String("secret", "", "Provide the client's secret")
 	clientsCreateCmd.Flags().StringP("name", "n", "", "The client's name")
+	clientsCreateCmd.Flags().StringSlice("post-logout-callbacks", []string{}, "List of allowed URLs to be redirected to after a logout")
 
 	// encrypt client secret options
 	clientsCreateCmd.Flags().String("pgp-key", "", "Base64 encoded PGP encryption key for encrypting client secret")


### PR DESCRIPTION
## Related issue
Closes #1426 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
