### PR TITLE
feat: support default jaeger environment variables

### DIFF
--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -1,11 +1,11 @@
 package tracing
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	jeagerConf "github.com/uber/jaeger-client-go/config"
 )
@@ -66,7 +66,7 @@ func (t *Tracer) Setup() error {
 	case "":
 		t.Logger.Infof("No tracer configured - skipping tracing setup")
 	default:
-		return fmt.Errorf("unknown tracer: %s", t.Provider)
+		return errors.Errorf("unknown tracer: %s", t.Provider)
 	}
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

Support default Jaeger environment variables as described in https://github.com/jaegertracing/jaeger-client-go#environment-variables
Those variables can then be overridden by Hydra config/env as before.

Motivation:


## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

This enables standard configuration of Jaeger helps in Kubernetes environment when those variables tend to be shared using configmap between different deployments.
Currently used environment variable `TRACING_PROVIDER_JAEGER_LOCAL_AGENT_ADDRESS` is not Kubernetes friendly - usually `JAEGER_AGENT_HOST` is populated instead with `status.hostIP`.
