### PR TITLE
cmd: Add option to disable access log for health endpoints

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -133,6 +133,11 @@ serve:
       # If set to true, adds additional log output to debug server side CORS issues. Defaults to false.
       debug: true
 
+    # Access Log configuration for public server.
+    access_log:
+      # Disable access log for health endpoints.
+      disable_for_health: false
+
   # admin controls the admin daemon serving admin API endpoints like /jwk, /client, ...
   admin:
     # The port to listen on. Defaults to 4445
@@ -184,6 +189,10 @@ serve:
       # If set to true, adds additional log output to debug server side CORS issues. Defaults to false.
       debug: true
 
+    # Access Log configuration for admin server.
+    access_log:
+      # Disable access log for health endpoints.
+      disable_for_health: false
 
   # tls configures HTTPS (HTTP over TLS). If configured, the server automatically supports HTTP/2.
   tls:

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -40,7 +40,9 @@ type Provider interface {
 	DataSourcePlugin() string
 	DefaultClientScope() []string
 	AdminListenOn() string
+	AdminDisableHealthAccessLog() bool
 	PublicListenOn() string
+	PublicDisableHealthAccessLog() bool
 	ConsentRequestMaxAge() time.Duration
 	AccessTokenLifespan() time.Duration
 	RefreshTokenLifespan() time.Duration

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -42,8 +42,10 @@ const (
 	ViperKeyBCryptCost                     = "oauth2.hashers.bcrypt.cost"
 	ViperKeyAdminListenOnHost              = "serve.admin.host"
 	ViperKeyAdminListenOnPort              = "serve.admin.port"
+	ViperKeyAdminDisableHealthAccessLog    = "serve.admin.access_log.disable_for_health"
 	ViperKeyPublicListenOnHost             = "serve.public.host"
 	ViperKeyPublicListenOnPort             = "serve.public.port"
+	ViperKeyPublicDisableHealthAccessLog   = "serve.public.access_log.disable_for_health"
 	ViperKeyConsentRequestMaxAge           = "ttl.login_consent_request"
 	ViperKeyAccessTokenLifespan            = "ttl.access_token"
 	ViperKeyRefreshTokenLifespan           = "ttl.refresh_token"
@@ -183,8 +185,16 @@ func (v *ViperProvider) AdminListenOn() string {
 	return v.getAddress(host, port)
 }
 
+func (v *ViperProvider) AdminDisableHealthAccessLog() bool {
+	return viperx.GetBool(v.l, ViperKeyAdminDisableHealthAccessLog, false)
+}
+
 func (v *ViperProvider) PublicListenOn() string {
 	return v.getAddress(v.publicHost(), v.publicPort())
+}
+
+func (v *ViperProvider) PublicDisableHealthAccessLog() bool {
+	return viperx.GetBool(v.l, ViperKeyPublicDisableHealthAccessLog, false)
 }
 
 func (v *ViperProvider) publicHost() string {

--- a/driver/configuration/provider_viper_test.go
+++ b/driver/configuration/provider_viper_test.go
@@ -2,19 +2,19 @@ package configuration
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/rs/cors"
-
-	"github.com/ory/hydra/x"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/ory/hydra/x"
+	"github.com/ory/x/logrusx"
 )
 
 func setEnv(key, value string) func(t *testing.T) {
@@ -75,4 +75,34 @@ func TestCORSOptions(t *testing.T) {
 		MaxAge:             0,
 		Debug:              false,
 	}, p.CORSOptions("public"))
+}
+
+func TestViperProvider_AdminDisableHealthAccessLog(t *testing.T) {
+	l := logrusx.New()
+	l.SetOutput(ioutil.Discard)
+
+	p := NewViperProvider(l, false, nil)
+
+	value := p.AdminDisableHealthAccessLog()
+	assert.Equal(t, false, value)
+
+	os.Setenv("SERVE_ADMIN_ACCESS_LOG_DISABLE_FOR_HEALTH", "true")
+
+	value = p.AdminDisableHealthAccessLog()
+	assert.Equal(t, true, value)
+}
+
+func TestViperProvider_PublicDisableHealthAccessLog(t *testing.T) {
+	l := logrusx.New()
+	l.SetOutput(ioutil.Discard)
+
+	p := NewViperProvider(l, false, nil)
+
+	value := p.PublicDisableHealthAccessLog()
+	assert.Equal(t, false, value)
+
+	os.Setenv("SERVE_PUBLIC_ACCESS_LOG_DISABLE_FOR_HEALTH", "true")
+
+	value = p.PublicDisableHealthAccessLog()
+	assert.Equal(t, true, value)
 }


### PR DESCRIPTION
## Related issue

#1278

## Proposed changes

This commit adds an option to disable access log for health endpoints.
This is especially helpful in environments like Kubernetes, where
special preprocessing filters would be required otherwise.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
