### PR TITLE
docs: Fix link to system secret rotation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -243,7 +243,7 @@ are loaded (see section after next).
 Rotating system secrets was fairly cumbersome in the past and required a restart of ORY Hydra. This changed. The
 system secret is now an array where the first element is used for encryption and all elements can be used for decryption.
 
-For more information on this topic, click [here](https://www.ory.sh/docs/hydra/advanced#system-secret-rotation).
+For more information on this topic, click [here](https://www.ory.sh/docs/hydra/advanced#rotation-of-hmac-token-signing-and-database-and-cookie-encryption-keys).
 
 To make this change work, environment variable `ROTATED_SYSTEM_SECRET` has been removed and can no longer be used. Command
 `hydra migrate secret` has also been removed without replacement as it is no longer required for rotating secrets.

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -359,7 +359,7 @@ oauth2:
 
 # The secrets section configures secrets used for encryption and signing of several systems. All secrets can be rotated,
 # for more information on this topic navigate to:
-# -> https://www.ory.sh/docs/hydra/advanced#system-secret-rotation
+# -> https://www.ory.sh/docs/hydra/advanced#rotation-of-hmac-token-signing-and-database-and-cookie-encryption-keys
 secrets:
   # The system secret must be at least 16 characters long. If none is provided, one will be generated. They key
   #	is used to encrypt sensitive data using AES-GCM (256 bit) and validate HMAC signatures.


### PR DESCRIPTION
## Proposed changes

The following link no longer exists
https://www.ory.sh/docs/hydra/advanced#system-secret-rotation

New link is here
https://www.ory.sh/docs/hydra/advanced#rotation-of-hmac-token-signing-and-database-and-cookie-encryption-keys

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
