### PR TITLE
docs: Add a link to Identity Provider "Werther" to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Community:
 * [Consent App SDK for Go](https://github.com/janekolszak/idp)
 * [ORY Hydra middleware for Gin](https://github.com/janekolszak/gin-hydra)
 * [Kubernetes helm chart](https://github.com/kubernetes/charts/pull/1022)
+* [Werther - an Identity Provider over LDAP](https://github.com/i-core/werther)
 
 ## Blog posts & articles
 


### PR DESCRIPTION
Hello, ORY team!

We published project [Werther](https://github.com/i-core/werther) that is an Identity Provider for ORY Hydra. Werther authenticates users over LDAP.

We think it will be useful for the ORY Hydra community to have an Identity Provider that is ready to use. It would save the time needed to start working with the ORY Hydra.

If you are interested in it we will be glad to add the Werther link to the README page of the ORY Hydra.