### PR TITLE
Fix namespace in composer.json (again?)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "ext-mbstring": "*"
   },
   "autoload": {
-    "psr-4": { "Hydra\\SDK\\" : "sdk/php/swagger/lib/" }
+    "psr-4": { "HydraSDK\\" : "sdk/php/swagger/lib/" }
   }
 }


### PR DESCRIPTION
PR https://github.com/ory/hydra/pull/1468 changed the namespace within the PHP files from `Hydra\SDK` to `HydraSDK`, but it did not update the autoload section in the `composer.json` file.

This seems to happen quite often recently, I wonder if there should be a test in place to avoid having a mismatch there **ever**.