### PR TITLE
jwk: Add keep pairs option for keys deletion

### DIFF
--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -68,4 +69,67 @@ func TestHandlerWellKnown(t *testing.T) {
 	resp := known.Key("public:test-id")
 	require.NotNil(t, resp, "Could not find key public")
 	assert.Equal(t, resp, IDKS.Key("public:test-id"))
+}
+
+func TestHandlerKeySet(t *testing.T) {
+	conf := internal.NewConfigurationWithDefaults()
+	reg := internal.NewRegistry(conf)
+
+	viper.Set(configuration.ViperKeyWellKnownKeys, []string{x.OpenIDConnectKeyName, x.OpenIDConnectKeyName})
+
+	router := x.NewRouterAdmin()
+
+	h := reg.KeyHandler()
+
+	h.SetRoutes(router, router.RouterPublic(), func(h http.Handler) http.Handler {
+		return h
+	})
+	testServer := httptest.NewServer(router)
+
+	t.Run("CreateJSONWebKeySet", func(t *testing.T) {
+		createJWKSetPath := "/keys/test-key"
+		createJWKSetReqBody := strings.NewReader(`{"alg": "RS256", "kid": "test-01", "use": "sig"}`)
+		createRes, err := http.Post(testServer.URL+createJWKSetPath, "application/json", createJWKSetReqBody)
+		require.NoError(t, err, "problem in http request")
+		defer createRes.Body.Close()
+
+		var createdJWKSet jose.JSONWebKeySet
+		err = json.NewDecoder(createRes.Body).Decode(&createdJWKSet)
+		require.NoError(t, err, "problem in decoding response")
+
+		assert.EqualValues(t, createRes.StatusCode, http.StatusCreated)
+		assert.Len(t, createdJWKSet.Key("public:test-01"), 1)
+		assert.Len(t, createdJWKSet.Key("private:test-01"), 1)
+	})
+
+	t.Run("GetJSONWebKeySet", func(t *testing.T) {
+		getJWKSetPath := "/keys/test-key"
+		getRes, err := http.Get(testServer.URL + getJWKSetPath)
+		require.NoError(t, err, "problem in http request")
+		defer getRes.Body.Close()
+
+		var getJWKSet jose.JSONWebKeySet
+		err = json.NewDecoder(getRes.Body).Decode(&getJWKSet)
+		require.NoError(t, err, "problem in decoding response")
+
+		require.Len(t, getJWKSet.Keys, 2)
+	})
+
+	t.Run("DeleteJSONWebKeySet", func(t *testing.T) {
+		deleteJWKSetPath := "/keys/test-key"
+		deleteReq, err := http.NewRequest(http.MethodDelete, testServer.URL+deleteJWKSetPath, nil)
+		deleteRes, err := http.DefaultClient.Do(deleteReq)
+		deleteReq.Header.Add("Content-Type", "application/json")
+		require.NoError(t, err, "problem in http request")
+		defer deleteRes.Body.Close()
+
+		assert.Equal(t, http.StatusNoContent, deleteRes.StatusCode)
+
+		getJWKSetPath := "/keys/test-key"
+		getRes, err := http.Get(testServer.URL + getJWKSetPath)
+		require.NoError(t, err, "problem in http request")
+		defer getRes.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, getRes.StatusCode)
+	})
 }

--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -193,22 +193,23 @@ func TestHandlerKeySet(t *testing.T) {
 				deleteRes, err := http.DefaultClient.Do(deleteReq)
 				deleteReq.Header.Add("Content-Type", "application/json")
 				require.NoError(t, err, "problem in http request")
-				defer deleteRes.Body.Close()
-
-				getResAfter, err := http.Get(testServer.URL + getJWKSetPath)
 
 				if c.expectedError {
-					require.Error(t, err, "no problem in http request but expected error")
+					assert.NotEqual(t, http.StatusNoContent, deleteRes.StatusCode)
 					return
 				}
+				assert.Equal(t, http.StatusNoContent, deleteRes.StatusCode)
 
+				getResAfter, err := http.Get(testServer.URL + getJWKSetPath)
 				require.NoError(t, err, "problem in http request")
+
 				defer getResAfter.Body.Close()
 
 				var getJWKSetAfter jose.JSONWebKeySet
 				err = json.NewDecoder(getResAfter.Body).Decode(&getJWKSetAfter)
 				require.NoError(t, err, "problem in decoding response")
 
+				assert.Len(t, getJWKSetAfter.Keys, len(c.expectedKeyIDs))
 				for _, keyID := range c.expectedKeyIDs {
 					assert.Len(t, getJWKSetAfter.Key(keyID), 1)
 				}


### PR DESCRIPTION
## Related issue

This PR will closes #1474 

## Proposed changes

- [x] Add tests for JWK API
- [x] Add keep pairs option for keys deletion API
- [ ] Generate SDK 
- [ ] Add keep pairs option for keys deletion CLI

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
