### PR TITLE
cmd: Use commit hash instead of version for link to config

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,7 +32,7 @@ var serveControls = `## Configuration
 ORY Hydra can be configured using environment variables as well as a configuration file. For more information
 on configuration options, open the configuration documentation:
 
->> https://github.com/ory/hydra/blob/` + Version + `/docs/config.yaml <<
+>> https://github.com/ory/hydra/blob/` + Commit + `/docs/config.yaml <<
 `
 
 // serveCmd represents the host command


### PR DESCRIPTION
Closes #1486