### PR TITLE
driver: memoize OAuth2Provider in base registry

### DIFF
--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -268,7 +268,7 @@ func (m *RegistryBase) OAuth2Provider() fosite.OAuth2Provider {
 			m.Logger().Fatalf(`Environment variable OAUTH2_ACCESS_TOKEN_STRATEGY is set to "%s" but only "opaque" and "jwt" are valid values.`, ats)
 		}
 
-		return compose.Compose(
+		m.fop = compose.Compose(
 			fc,
 			m.r.OAuth2Storage(),
 			&compose.CommonStrategy{


### PR DESCRIPTION
## Proposed changes

This appears to be a bug which prevents memoization of the OAuth2Provider in the registry.

This impacts our use of Hydra because we use a custom ClientHasher in Hydra. This works inside Hydra, but the OAuth2 Provider is configured using the Hasher on the BaseRegistry, which cannot be overridden from outside of Hydra. It therefore passes the default Hasher into fosite.OAuth2Provider. We should be able to override this by getting the OAuth2Provider from the registry and setting the Hasher on the fosite instance, however, this memoization bug means that the OAuth2Provider is recreated each time it is requested. Therefore, we cannot override any fosite settings.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)