### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ to our ecosystem. *If you think that your company deserves a spot here, reach ou
             <td>Adopter *</td>
             <td>Arduino</td>
             <td align="center"><img height="32px" src="./docs/adopters/arduino.svg" alt="Arduino"></td>
-            <td><a href="https://www.arduino.cc/">segment.com</a></td>
+            <td><a href="https://www.arduino.cc/">arduino.cc</a></td>
         </tr>
     </tdbody>
 </table>


### PR DESCRIPTION
Typo in README: `segment.com -> arduino.cc`