### PR TITLE
Consent: deduplicate user authenticated clients during logout.

### DIFF
--- a/consent/manager_memory.go
+++ b/consent/manager_memory.go
@@ -477,10 +477,13 @@ func (m *MemoryManager) ListUserAuthenticatedClientsWithBackChannelLogout(ctx co
 	m.m["consentRequests"].RLock()
 	defer m.m["consentRequests"].RUnlock()
 
+	clientsMap := make(map[string]bool)
+
 	var rs []client.Client
 	for _, cr := range m.consentRequests {
-		if cr.Subject == subject && len(cr.Client.BackChannelLogoutURI) > 0 {
+		if cr.Subject == subject && len(cr.Client.BackChannelLogoutURI) > 0 && !clientsMap[cr.Client.GetID()] {
 			rs = append(rs, *cr.Client)
+			clientsMap[cr.Client.GetID()] = true
 		}
 	}
 

--- a/consent/manager_sql.go
+++ b/consent/manager_sql.go
@@ -528,7 +528,7 @@ func (m *SQLManager) ListUserAuthenticatedClientsWithBackChannelLogout(ctx conte
 
 func (m *SQLManager) listUserAuthenticatedClients(ctx context.Context, subject string, channel string) ([]client.Client, error) {
 	var ids []string
-	if err := m.DB.SelectContext(ctx, &ids, m.DB.Rebind(fmt.Sprintf(`SELECT c.id FROM hydra_client as c JOIN hydra_oauth2_consent_request as r ON (c.id = r.client_id) WHERE r.subject=? AND c.%schannel_logout_uri!='' and c.%schannel_logout_uri IS NOT NULL`, channel, channel)), subject); err != nil {
+	if err := m.DB.SelectContext(ctx, &ids, m.DB.Rebind(fmt.Sprintf(`SELECT DISTINCT(c.id) FROM hydra_client as c JOIN hydra_oauth2_consent_request as r ON (c.id = r.client_id) WHERE r.subject=? AND c.%schannel_logout_uri!='' and c.%schannel_logout_uri IS NOT NULL`, channel, channel)), subject); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, errors.WithStack(x.ErrNotFound)
 		}

--- a/consent/manager_test_helpers.go
+++ b/consent/manager_test_helpers.go
@@ -598,6 +598,39 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 				assert.EqualValues(t, "fk-client-LUACWFCL-5", clients[0].ClientID)
 			})
 
+			t.Run("case=ListUserAuthenticatedClientsWithFrontChannelLogout-duplicateLogin", func(t *testing.T) {
+				c, h := MockConsentRequest("LUACWFCL-DUPLICCATE", false, 0, false, false, false)
+				c.Client.BackChannelLogoutURI = "http://some-url.com/"
+
+				c.LoginSessionID = ""                                // otherwise we had to create the login session as well..
+				c.Subject = "subjectLUACWFCL-DUPLICCATE"             // otherwise we had to create the login session as well..
+				clientManager.CreateClient(context.TODO(), c.Client) // Ignore errors that are caused by duplication
+
+				for i := 0; i < 2; i++ {
+					lc, _ := MockAuthRequest("LUACWFCL-DUPLICCATE", true)
+					lc.Challenge = fmt.Sprintf("fk-login-challenge-LUACWFCL-DUPLICCATE-%d", i)
+					lc.Verifier = fmt.Sprintf("fk-login-verifier-LUACWFCL-DUPLICCATE-%d", i)
+					lc.SessionID = ""
+					require.NoError(t, m.CreateLoginRequest(context.TODO(), lc))
+
+					c.Challenge = fmt.Sprintf("challenge-LUACWFCL-DUPLICCATE-%d", i)
+					c.LoginChallenge = fmt.Sprintf("fk-login-challenge-LUACWFCL-DUPLICCATE-%d", i)
+					c.Verifier = fmt.Sprintf("verifiers-LUACWFCL-DUPLICCATE-%d", i)
+					require.NoError(t, m.CreateConsentRequest(context.TODO(), c))
+
+					h.Challenge = fmt.Sprintf("challenge-LUACWFCL-DUPLICCATE-%d", i)
+					_, err = m.HandleConsentRequest(context.TODO(), c.Challenge, h)
+					require.NoError(t, err)
+				}
+
+				clients, err := m.ListUserAuthenticatedClientsWithBackChannelLogout(context.TODO(), "subjectLUACWFCL-DUPLICCATE")
+				require.NoError(t, err)
+
+				require.Len(t, clients, 1)
+				assert.EqualValues(t, "http://some-url.com/", clients[0].BackChannelLogoutURI)
+				assert.EqualValues(t, "fk-client-LUACWFCL-DUPLICCATE", clients[0].ClientID)
+			})
+
 			t.Run("case=ListUserAuthenticatedClientsWithBackChannelLogout", func(t *testing.T) {
 				for i := 0; i <= 10; i++ {
 					c, h := MockConsentRequest(fmt.Sprintf("LUACWFBL-%d", i), false, 0, false, false, false)
@@ -624,6 +657,39 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 				require.Len(t, clients, 1)
 				assert.EqualValues(t, "http://some-url.com/", clients[0].BackChannelLogoutURI)
 				assert.EqualValues(t, "fk-client-LUACWFBL-5", clients[0].ClientID)
+			})
+
+			t.Run("case=ListUserAuthenticatedClientsWithBackChannelLogout-duplicateLogin", func(t *testing.T) {
+				c, h := MockConsentRequest("LUACWFBL-DUPLICCATE", false, 0, false, false, false)
+				c.Client.BackChannelLogoutURI = "http://some-url.com/"
+
+				c.LoginSessionID = ""                                // otherwise we had to create the login session as well..
+				c.Subject = "subjectLUACWFBL-DUPLICCATE"             // otherwise we had to create the login session as well..
+				clientManager.CreateClient(context.TODO(), c.Client) // Ignore errors that are caused by duplication
+
+				for i := 0; i < 2; i++ {
+					lc, _ := MockAuthRequest("LUACWFBL-DUPLICCATE", true)
+					lc.Challenge = fmt.Sprintf("fk-login-challenge-LUACWFBL-DUPLICCATE-%d", i)
+					lc.Verifier = fmt.Sprintf("fk-login-verifier-LUACWFBL-DUPLICCATE-%d", i)
+					lc.SessionID = ""
+					require.NoError(t, m.CreateLoginRequest(context.TODO(), lc))
+
+					c.Challenge = fmt.Sprintf("challenge-LUACWFBL-DUPLICCATE-%d", i)
+					c.LoginChallenge = fmt.Sprintf("fk-login-challenge-LUACWFBL-DUPLICCATE-%d", i)
+					c.Verifier = fmt.Sprintf("verifiers-LUACWFBL-DUPLICCATE-%d", i)
+					require.NoError(t, m.CreateConsentRequest(context.TODO(), c))
+
+					h.Challenge = fmt.Sprintf("challenge-LUACWFBL-DUPLICCATE-%d", i)
+					_, err = m.HandleConsentRequest(context.TODO(), c.Challenge, h)
+					require.NoError(t, err)
+				}
+
+				clients, err := m.ListUserAuthenticatedClientsWithBackChannelLogout(context.TODO(), "subjectLUACWFBL-DUPLICCATE")
+				require.NoError(t, err)
+
+				require.Len(t, clients, 1)
+				assert.EqualValues(t, "http://some-url.com/", clients[0].BackChannelLogoutURI)
+				assert.EqualValues(t, "fk-client-LUACWFBL-DUPLICCATE", clients[0].ClientID)
 			})
 
 			t.Run("case=LogoutRequest", func(t *testing.T) {


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

I adjust `ListUserAuthenticatedClientsWithFrontChannelLogout` & `ListUserAuthenticatedClientsWithBackChannelLogout`, make it return unduplicated clients.

If one user login client A 100 times, and then logout after the latest login, it would send 100 requests to the front/backchannel of client A with the logout token with the same sid. It's a waste of performance to both Hydra and client A.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
