### PR TITLE
driver: Fix RP-Initiated Logout trailing slash bug

### DIFF
--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -360,7 +360,7 @@ func (v *ViperProvider) PublicURL() *url.URL {
 }
 
 func (v *ViperProvider) IssuerURL() *url.URL {
-	return urlRoot(urlx.ParseOrFatal(v.l, viperx.GetString(v.l, ViperKeyIssuerURL, v.fallbackURL("/", v.publicHost(), v.publicPort()), "OAUTH2_ISSUER_URL", "ISSUER", "ISSUER_URL")))
+	return urlRoot(urlx.ParseOrFatal(v.l, strings.TrimRight(viperx.GetString(v.l, ViperKeyIssuerURL, v.fallbackURL("/", v.publicHost(), v.publicPort()), "OAUTH2_ISSUER_URL", "ISSUER", "ISSUER_URL"), "/")+"/"))
 }
 
 func (v *ViperProvider) OAuth2AuthURL() string {

--- a/driver/configuration/provider_viper_test.go
+++ b/driver/configuration/provider_viper_test.go
@@ -107,3 +107,15 @@ func TestViperProvider_PublicDisableHealthAccessLog(t *testing.T) {
 	value = p.PublicDisableHealthAccessLog()
 	assert.Equal(t, true, value)
 }
+
+func TestViperProvider_IssuerURL(t *testing.T) {
+	l := logrusx.New()
+	l.SetOutput(ioutil.Discard)
+	viper.Set(ViperKeyIssuerURL, "http://hydra.localhost")
+	p := NewViperProvider(l, false, nil)
+	assert.Equal(t, "http://hydra.localhost/", p.IssuerURL().String())
+
+	viper.Set(ViperKeyIssuerURL, "http://hydra.localhost/")
+	p2 := NewViperProvider(l, false, nil)
+	assert.Equal(t, "http://hydra.localhost/", p2.IssuerURL().String())
+}


### PR DESCRIPTION
## Related issue

https://github.com/ory/hydra/issues/1546

## Proposed changes

use TrimRight.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments
