### PR TITLE
ci: Remove ARM binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,12 +22,12 @@ builds:
     goarch:
       - amd64
       - 386
-      - arm
-      - arm64
-    goarm:
-      - 5
-      - 6
-      - 7
+#      - arm
+#      - arm64
+#    goarm:
+#      - 5
+#      - 6
+#      - 7
     goos:
       - freebsd
       - linux


### PR DESCRIPTION
This is a workaround for #1576

ARM is still supported but must be built from source.
