### PR TITLE
Additional claims

### DIFF
--- a/docs/api.swagger.json
+++ b/docs/api.swagger.json
@@ -2805,6 +2805,14 @@
           "type": "boolean",
           "x-go-name": "EmailVerified"
         },
+        "extra_vars": {
+          "description": "Addition claims (https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "ExtraVars"
+        },
         "family_name": {
           "description": "Surname(s) or last name(s) of the End-User. Note that in some cultures, people can have multiple family names or no family name; all can be present, with the names being separated by space characters.",
           "type": "string",

--- a/oauth2/doc.go
+++ b/oauth2/doc.go
@@ -250,6 +250,9 @@ type swaggeruserinfoResponsePayload struct {
 	// True if the End-User's phone number has been verified; otherwise false. When this Claim Value is true, this means that the OP took affirmative steps to ensure that this phone number was controlled by the End-User at the time the verification was performed. The means by which a phone number is verified is context-specific, and dependent upon the trust framework or contractual agreements within which the parties are operating. When true, the phone_number Claim MUST be in E.164 format and any extensions MUST be represented in RFC 3966 format.
 	PhoneNumberVerified bool `json:"phone_number_verified,omitempty"`
 
+	// Addition claims (https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims).
+	ExtraVars map[string]interface{} `json:"extra_vars,omitempty"`
+
 	// Time the End-User's information was last updated. Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time.
 	UpdatedAt int `json:"updated_at,omitempty"`
 }

--- a/sdk/go/hydra/models/swaggeruserinfo_response_payload.go
+++ b/sdk/go/hydra/models/swaggeruserinfo_response_payload.go
@@ -24,6 +24,9 @@ type SwaggeruserinfoResponsePayload struct {
 	// True if the End-User's e-mail address has been verified; otherwise false. When this Claim Value is true, this means that the OP took affirmative steps to ensure that this e-mail address was controlled by the End-User at the time the verification was performed. The means by which an e-mail address is verified is context-specific, and dependent upon the trust framework or contractual agreements within which the parties are operating.
 	EmailVerified bool `json:"email_verified,omitempty"`
 
+	// Addition claims (https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims).
+	ExtraVars map[string]interface{} `json:"extra_vars,omitempty"`
+
 	// Surname(s) or last name(s) of the End-User. Note that in some cultures, people can have multiple family names or no family name; all can be present, with the names being separated by space characters.
 	FamilyName string `json:"family_name,omitempty"`
 


### PR DESCRIPTION
Add ExtraVars into userInfo response.

## Related issue

https://github.com/ory/hydra/issues/1588

## Proposed changes

add ExtraVars (map [string] intreface {}) field to UserInfo response

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

