### PR TITLE
driver: don't log DSN

### DIFF
--- a/driver/registry.go
+++ b/driver/registry.go
@@ -1,8 +1,6 @@
 package driver
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -58,7 +56,6 @@ func MustNewRegistry(c configuration.Provider) Registry {
 }
 
 func NewRegistry(c configuration.Provider) (Registry, error) {
-	fmt.Print("Got dsn: ", c.DSN())
 	driver, err := dbal.GetDriverFor(c.DSN())
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
Removes an errant logging of the DSN. The DSN can include credentials which should not be logged.

related to https://github.com/ory/hydra/issues/1585 and https://github.com/ory/k8s/issues/55