### PR TITLE
config: Add IsCookieSecure() to allow secure cookie without https

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -273,7 +273,7 @@ func (s *DefaultStrategy) forwardAuthenticationRequest(w http.ResponseWriter, r 
 		return errors.WithStack(err)
 	}
 
-	if err := createCsrfSession(w, r, s.r.CookieStore(), cookieAuthenticationCSRFName, csrf, s.c.ServesHTTPS()); err != nil {
+	if err := createCsrfSession(w, r, s.r.CookieStore(), cookieAuthenticationCSRFName, csrf, s.c.IsCookieSecure()); err != nil {
 		return errors.WithStack(err)
 	}
 
@@ -445,7 +445,7 @@ func (s *DefaultStrategy) verifyAuthentication(w http.ResponseWriter, r *http.Re
 	}
 	cookie.Options.HttpOnly = true
 
-	if s.c.ServesHTTPS() {
+	if s.c.IsCookieSecure() {
 		cookie.Options.Secure = true
 	}
 
@@ -548,7 +548,7 @@ func (s *DefaultStrategy) forwardConsentRequest(w http.ResponseWriter, r *http.R
 		return errors.WithStack(err)
 	}
 
-	if err := createCsrfSession(w, r, s.r.CookieStore(), cookieConsentCSRFName, csrf, s.c.ServesHTTPS()); err != nil {
+	if err := createCsrfSession(w, r, s.r.CookieStore(), cookieConsentCSRFName, csrf, s.c.IsCookieSecure()); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -53,6 +53,7 @@ type Provider interface {
 	TracingProvider() string
 	TracingJaegerConfig() *tracing.JaegerConfig
 	GetCookieSecrets() [][]byte
+	IsCookieSecure() bool
 	GetRotatedSystemSecrets() [][]byte
 	GetSystemSecret() []byte
 	LogoutRedirectURL() *url.URL

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -54,6 +54,7 @@ const (
 	ViperKeyIDTokenLifespan                = "ttl.id_token"
 	ViperKeyAuthCodeLifespan               = "ttl.auth_code"
 	ViperKeyScopeStrategy                  = "strategies.scope"
+	ViperKeyCookieForceSecure              = "cookie.force_secure"
 	ViperKeyGetCookieSecrets               = "secrets.cookie"
 	ViperKeyGetSystemSecret                = "secrets.system"
 	ViperKeyLogoutRedirectURL              = "urls.post_logout_redirect"
@@ -265,6 +266,10 @@ func (v *ViperProvider) GetCookieSecrets() [][]byte {
 	return [][]byte{
 		[]byte(viperx.GetString(v.l, ViperKeyGetCookieSecrets, string(v.GetSystemSecret()), "COOKIE_SECRET")),
 	}
+}
+
+func (v *ViperProvider) IsCookieSecure() bool {
+	return v.ServesHTTPS() || viperx.GetBool(v.l, ViperKeyCookieForceSecure, false, "COOKIE_FORCE_SECURE")
 }
 
 func (v *ViperProvider) GetRotatedSystemSecrets() [][]byte {

--- a/driver/configuration/provider_viper_test.go
+++ b/driver/configuration/provider_viper_test.go
@@ -119,3 +119,20 @@ func TestViperProvider_IssuerURL(t *testing.T) {
 	p2 := NewViperProvider(l, false, nil)
 	assert.Equal(t, "http://hydra.localhost/", p2.IssuerURL().String())
 }
+
+func TestViperProvider_IsCookieSecure(t *testing.T) {
+	l := logrusx.New()
+	l.SetOutput(ioutil.Discard)
+
+	p := NewViperProvider(l, false, nil)
+	value := p.IsCookieSecure()
+	assert.Equal(t, true, value)
+
+	p = NewViperProvider(l, true, nil)
+	value = p.IsCookieSecure()
+	assert.Equal(t, false, value)
+
+	os.Setenv("COOKIE_FORCE_SECURE", "true")
+	value = p.IsCookieSecure()
+	assert.Equal(t, true, value)
+}


### PR DESCRIPTION
## Proposed changes

The aim is to allow usage of secure cookies when `--dangerous-force-http` is used.
When hydra is used behind a load balancer managing TLS, I still want to use secure cookies.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation within the code base (if appropriate)
- [X] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate) Commit pushed: waiting for this PR review before creating a PR on the docs: https://github.com/GuillaumeSmaha/docs/commit/49d6c51c78fabf42a5be53643ff97017aacf8b1b
