### PR TITLE
Remove unnecessary paragraph in Hydra API docs

### DIFF
--- a/health/doc.go
+++ b/health/doc.go
@@ -103,9 +103,6 @@ func swaggerPublicIsInstanceReady() {}
 // If the service supports TLS Edge Termination, this endpoint does not require the
 // `X-Forwarded-Proto` header to be set.
 //
-// Be aware that if you are running multiple nodes of this service, the health status will never
-// refer to the cluster state, only to a single instance.
-//
 //     Produces:
 //     - application/json
 //


### PR DESCRIPTION
## Related issue

This resolves https://github.com/ory/docs/pull/214 as suggested by @aeneasr 

> The removed paragraph makes sense in the /health/alive and health/ready endpoints documentation but feels misplaced for documenting the /version endpoint.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)