### PR TITLE
possible #1615 solution: partial wildcard allowed-origins, with just …

### DIFF
--- a/driver/cors_test.go
+++ b/driver/cors_test.go
@@ -28,12 +28,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ory/viper"
-
 	"github.com/ory/fosite"
 	. "github.com/ory/hydra/driver"
 	"github.com/ory/hydra/internal"
 	"github.com/ory/hydra/oauth2"
+	"github.com/ory/viper"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -156,6 +155,17 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Bearer " + token}},
 			expectHeader: http.Header{"Access-Control-Allow-Credentials": []string{"true"}, "Access-Control-Allow-Origin": []string{"http://foobar.com"}, "Access-Control-Expose-Headers": []string{"Content-Type"}, "Vary": []string{"Origin"}},
+		},
+		{
+			d: "should accept any allowed specified origin protocol",
+			prep: func() {
+				r.ClientManager().CreateClient(context.Background(), &client.Client{ClientID: "foo-11", Secret: "bar", AllowedCORSOrigins: []string{"*"}})
+				viper.Set("serve.public.cors.enabled", true)
+				viper.Set("serve.public.cors.allowed_origins", []string{"http://*", "https://*"})
+			},
+			code:         http.StatusNotImplemented,
+			header:       http.Header{"Origin": {"http://foo.foobar.com"}, "Authorization": {"Basic Zm9vLTQ6YmFy"}},
+			expectHeader: http.Header{"Access-Control-Allow-Credentials": []string{"true"}, "Access-Control-Allow-Origin": []string{"http://foo.foobar.com"}, "Access-Control-Expose-Headers": []string{"Content-Type"}, "Vary": []string{"Origin"}},
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {


### PR DESCRIPTION
…protocol specified (for example "http://*") could use glob ** pattern in order to match any sequence of characters (even the separator).

Signed-off-by: Aterocana <dominicimaurizio<at>gmail.com>

## Related issue
`@aeneasr` as discussed in #1615 I'm proposing this fix.

## Proposed changes

Basically I think the issue here is the protocol is specified, but no domain is: for example https://*.
Internally glob.Glob is compiled (with glob.Compile) with the provided string and `'.'` rune separator. Since `g:=glob.Compile("https://*", '.')` doesn't match `g.Match("http://foobar.com")` due to `.` separator, we could use `g:=glob.Compile("https://**", '.') to ignore `.` separator in this specific case.
In order to do so I simply tried to match if "://" substring is into an allowed-origin string.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments
