### PR TITLE
handler: use generate secrets function as used in cmd 

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ory/x/pagination"
-	"github.com/ory/x/randx"
 )
 
 type Handler struct {
@@ -87,12 +86,12 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	}
 
 	if len(c.Secret) == 0 {
-		secret, err := randx.RuneSequence(12, []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.~"))
+		secretb, err := x.GenerateSecret(26)
 		if err != nil {
 			h.r.Writer().WriteError(w, r, errors.WithStack(err))
 			return
 		}
-		c.Secret = string(secret)
+		c.Secret = string(secretb)
 	}
 
 	if err := h.r.ClientValidator().Validate(&c); err != nil {

--- a/cypress/integration/admin/client_create.js
+++ b/cypress/integration/admin/client_create.js
@@ -1,0 +1,18 @@
+import { prng } from '../../helpers';
+
+describe('The Clients Admin Interface', function() {
+    const nc = () => ({
+        client_id: prng(),
+        scope: 'foo openid offline_access',
+        grant_types: ['client_credentials']
+    });
+
+    it('should return client_secret with length 26 for newly created clients without client_secret specified', function() {
+        const client = nc();
+
+        cy.request('POST', Cypress.env('admin_url') + '/clients', JSON.stringify(client))
+            .then((response) => {
+                expect(response.body.client_secret.length).to.equal(26)
+            })
+    });
+});


### PR DESCRIPTION
## Proposed changes

When a client is created the client secret generation should be the same for api and cli

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments
While trying to test the admin interface we recognized there are no tests for the handler. With the client_create.js admin cypress test this done. Did we miss a better part to test the admin handler?
