### PR TITLE
consent: Update documentation

### DIFF
--- a/consent/handler.go
+++ b/consent/handler.go
@@ -221,7 +221,7 @@ func (h *Handler) DeleteLoginSession(w http.ResponseWriter, r *http.Request, ps 
 
 // swagger:route GET /oauth2/auth/requests/login admin getLoginRequest
 //
-// Get an login request
+// Get a login request
 //
 // When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider
 // (sometimes called "identity provider") to authenticate the subject and then tell ORY Hydra now about it. The login
@@ -274,7 +274,7 @@ func (h *Handler) GetLoginRequest(w http.ResponseWriter, r *http.Request, ps htt
 
 // swagger:route PUT /oauth2/auth/requests/login/accept admin acceptLoginRequest
 //
-// Accept an login request
+// Accept a login request
 //
 // When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider
 // (sometimes called "identity provider") to authenticate the subject and then tell ORY Hydra now about it. The login
@@ -496,7 +496,7 @@ func (h *Handler) GetConsentRequest(w http.ResponseWriter, r *http.Request, ps h
 
 // swagger:route PUT /oauth2/auth/requests/consent/accept admin acceptConsentRequest
 //
-// Accept an consent request
+// Accept a consent request
 //
 // When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider
 // to authenticate the subject and then tell ORY Hydra now about it. If the subject authenticated, he/she must now be asked if
@@ -575,7 +575,7 @@ func (h *Handler) AcceptConsentRequest(w http.ResponseWriter, r *http.Request, p
 
 // swagger:route PUT /oauth2/auth/requests/consent/reject admin rejectConsentRequest
 //
-// Reject an consent request
+// Reject a consent request
 //
 // When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider
 // to authenticate the subject and then tell ORY Hydra now about it. If the subject authenticated, he/she must now be asked if


### PR DESCRIPTION
fix spelling

## Proposed changes

Fix usage of "an" and "a" for correct spelling

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

no tests because no functional change, just documentation
