### PR TITLE
cmd: Fix logging Span ID

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -167,7 +167,7 @@ func setTracingLogger(logger *reqlog.Middleware) {
 			fields = fields.WithField("trace_id", spanCtx.TraceIDString())
 		}
 		if spanCtx.HasSpanID() {
-			fields = fields.WithField("trace_id", spanCtx.SpanIDString())
+			fields = fields.WithField("span_id", spanCtx.SpanIDString())
 		}
 
 		return fields


### PR DESCRIPTION
## Related issue

#1680
#1685

## Proposed changes

Fix logging Span ID.
#1685 has mistake that `span_id` overwrites `trace_id`.
Now both `span_id` and `trace_id` are logged.

```
INFO[0030] started handling request                      method=GET remote="[::1]:59642" request=/health/alive span_id=00f067aa0ba902b7 trace_id=4bf92f3577b34da6a3ce929d0e0e4736
INFO[0030] completed handling request                    measure#hydra/admin: https://localhost:4444/.latency=77569 method=GET remote="[::1]:59642" request=/health/alive span_id=00f067aa0ba902b7 status=200 text_status=OK took="77.569µs" trace_id=4bf92f3577b34da6a3ce929d0e0e4736
```

## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

I'm sorry...

