### PR TITLE
client: remove merge client during update

### DIFF
--- a/client/manager_memory.go
+++ b/client/manager_memory.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ory/hydra/x"
 
-	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 
 	"github.com/ory/fosite"
@@ -78,9 +77,6 @@ func (m *MemoryManager) UpdateClient(ctx context.Context, c *Client) error {
 			return errors.WithStack(err)
 		}
 		c.Secret = string(h)
-	}
-	if err := mergo.Merge(c, o); err != nil {
-		return errors.WithStack(err)
 	}
 
 	m.Lock()

--- a/client/manager_test.go
+++ b/client/manager_test.go
@@ -115,8 +115,8 @@ func TestManagers(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		t.Run("case=create-get-delete", func(t *testing.T) {
-			t.Run(fmt.Sprintf("db=%s", k), TestHelperCreateGetDeleteClient(k, m))
+		t.Run("case=create-get-update-delete", func(t *testing.T) {
+			t.Run(fmt.Sprintf("db=%s", k), TestHelperCreateGetUpdateDeleteClient(k, m))
 		})
 
 		t.Run("case=autogenerate-key", func(t *testing.T) {

--- a/client/manager_test_helpers.go
+++ b/client/manager_test_helpers.go
@@ -66,7 +66,7 @@ func TestHelperClientAuthenticate(k string, m Manager) func(t *testing.T) {
 	}
 }
 
-func TestHelperCreateGetDeleteClient(k string, m Storage) func(t *testing.T) {
+func TestHelperCreateGetUpdateDeleteClient(k string, m Storage) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.TODO()
 		_, err := m.GetClient(ctx, "4321")


### PR DESCRIPTION
## Proposed changes

Fix different behaviour between `memory client update manager` and `database client update manager`. 

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

If hydra runs with memory manager the update client operation only updates the forwarded values. If hydra runs with database manager the update client operation updates all fields of the client. If you don't forward a value for a given field the field is emptied in the database.
