### PR TITLE
hydra config: logout url env var in viper provider

### DIFF
--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -346,7 +346,7 @@ func (v *ViperProvider) LoginURL() *url.URL {
 }
 
 func (v *ViperProvider) LogoutURL() *url.URL {
-	return urlRoot(urlx.ParseOrFatal(v.l, viperx.GetString(v.l, ViperKeyLogoutURL, v.publicFallbackURL("oauth2/fallbacks/logout"))))
+	return urlRoot(urlx.ParseOrFatal(v.l, viperx.GetString(v.l, ViperKeyLogoutURL, v.publicFallbackURL("oauth2/fallbacks/logout"), "OAUTH2_LOGOUT_URL")))
 }
 
 func (v *ViperProvider) ConsentURL() *url.URL {


### PR DESCRIPTION
## Related issue

-/-

## Proposed changes

We're currently working on implementing logouts for our hydra. In our environment we use environment variables to configure most of hydra. We've had sporadic success by setting the `ViperKeyLogoutRedirectURL` with `OAUTH2_LOGOUT_REDIRECT_URL`, but still get the default (error) page, that `urls.logout` is not set. 

This change should add the missing ability to configure `ViperKeyLogoutURL` by setting the environment variable `OAUTH2_LOGOUT_URL`, similar to how we can configure the login / consent / post lougout redirect urls in the viper configuration provider.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

-/-
