### PR TITLE
Support session data encryption

### DIFF
--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -37,6 +37,7 @@ type Provider interface {
 	OIDCDiscoveryUserinfoEndpoint() string
 	ShareOAuth2Debug() bool
 	DSN() string
+	EncryptSessionData() bool
 	BCryptCost() int
 	DataSourcePlugin() string
 	DefaultClientScope() []string

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -42,6 +42,7 @@ const (
 	ViperKeySubjectTypesSupported          = "oidc.subject_identifiers.supported_types"
 	ViperKeyDefaultClientScope             = "oidc.dynamic_client_registration.default_scope"
 	ViperKeyDSN                            = "dsn"
+	ViperKeyEncryptSessionData             = "db.encrypt_session_data"
 	ViperKeyBCryptCost                     = "oauth2.hashers.bcrypt.cost"
 	ViperKeyAdminListenOnHost              = "serve.admin.host"
 	ViperKeyAdminListenOnPort              = "serve.admin.port"
@@ -175,6 +176,10 @@ func (v *ViperProvider) CORSOptions(iface string) cors.Options {
 
 func (v *ViperProvider) DSN() string {
 	return viperx.GetString(v.l, ViperKeyDSN, "", "DATABASE_URL")
+}
+
+func (v *ViperProvider) EncryptSessionData() bool {
+	return viperx.GetBool(v.l, ViperKeyEncryptSessionData, false)
 }
 
 func (v *ViperProvider) DataSourcePlugin() string {

--- a/driver/registry_sql.go
+++ b/driver/registry_sql.go
@@ -181,7 +181,7 @@ func (m *RegistrySQL) ConsentManager() consent.Manager {
 
 func (m *RegistrySQL) OAuth2Storage() x.FositeStorer {
 	if m.fs == nil {
-		m.fs = oauth2.NewFositeSQLStore(m.DB(), m.r, m.c)
+		m.fs = oauth2.NewFositeSQLStore(m.DB(), m.r, m.c, m.KeyCipher())
 	}
 	return m.fs
 }

--- a/internal/driver.go
+++ b/internal/driver.go
@@ -18,6 +18,7 @@ func resetConfig() {
 	viper.Set(configuration.ViperKeySubjectTypesSupported, nil)
 	viper.Set(configuration.ViperKeyDefaultClientScope, nil)
 	viper.Set(configuration.ViperKeyDSN, nil)
+	viper.Set(configuration.ViperKeyEncryptSessionData, false)
 	viper.Set(configuration.ViperKeyBCryptCost, nil)
 	viper.Set(configuration.ViperKeyAdminListenOnHost, nil)
 	viper.Set(configuration.ViperKeyAdminListenOnPort, nil)

--- a/oauth2/fosite_store_sql.go
+++ b/oauth2/fosite_store_sql.go
@@ -35,6 +35,8 @@ import (
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/sirupsen/logrus"
 
+	"github.com/ory/hydra/jwk"
+
 	"github.com/ory/fosite"
 	"github.com/ory/hydra/client"
 	"github.com/ory/x/dbal"
@@ -45,8 +47,9 @@ import (
 type FositeSQLStore struct {
 	DB *sqlx.DB
 
-	r InternalRegistry
-	c Configuration
+	r  InternalRegistry
+	c  Configuration
+	kc *jwk.AEAD
 
 	HashSignature bool
 }
@@ -58,8 +61,8 @@ type sqlxDB interface {
 	GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
 }
 
-func NewFositeSQLStore(db *sqlx.DB, r InternalRegistry, c Configuration) *FositeSQLStore {
-	return &FositeSQLStore{r: r, c: c, DB: db}
+func NewFositeSQLStore(db *sqlx.DB, r InternalRegistry, c Configuration, kc *jwk.AEAD) *FositeSQLStore {
+	return &FositeSQLStore{r: r, c: c, kc: kc, DB: db}
 }
 
 type tableName string
@@ -123,7 +126,7 @@ type sqlData struct {
 	Session           []byte         `db:"session_data"`
 }
 
-func sqlSchemaFromRequest(signature string, r fosite.Requester, logger logrus.FieldLogger) (*sqlData, error) {
+func sqlSchemaFromRequest(signature string, r fosite.Requester, c Configuration, kc *jwk.AEAD, logger logrus.FieldLogger) (*sqlData, error) {
 	subject := ""
 	if r.GetSession() == nil {
 		logger.Debugf("Got an empty session in sqlSchemaFromRequest")
@@ -134,6 +137,14 @@ func sqlSchemaFromRequest(signature string, r fosite.Requester, logger logrus.Fi
 	session, err := json.Marshal(r.GetSession())
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	if c.EncryptSessionData() {
+		ciphertext, err := kc.Encrypt(session)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		session = []byte(ciphertext)
 	}
 
 	var challenge sql.NullString
@@ -163,9 +174,17 @@ func sqlSchemaFromRequest(signature string, r fosite.Requester, logger logrus.Fi
 	}, nil
 }
 
-func (s *sqlData) toRequest(session fosite.Session, cm client.Manager, logger logrus.FieldLogger) (*fosite.Request, error) {
+func (s *sqlData) toRequest(session fosite.Session, cm client.Manager, conf Configuration, kc *jwk.AEAD, logger logrus.FieldLogger) (*fosite.Request, error) {
+	sess := s.Session
+	if conf.EncryptSessionData() {
+		var err error
+		sess, err = kc.Decrypt(string(sess))
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
 	if session != nil {
-		if err := json.Unmarshal(s.Session, session); err != nil {
+		if err := json.Unmarshal(sess, session); err != nil {
 			return nil, errors.WithStack(err)
 		}
 	} else {
@@ -256,7 +275,7 @@ func (s *FositeSQLStore) createSession(ctx context.Context, signature string, re
 	db := s.db(ctx)
 	signature = s.hashSignature(signature, table)
 
-	data, err := sqlSchemaFromRequest(signature, requester, s.r.Logger())
+	data, err := sqlSchemaFromRequest(signature, requester, s.c, s.kc, s.r.Logger())
 	if err != nil {
 		return err
 	}
@@ -293,7 +312,7 @@ func (s *FositeSQLStore) findSessionBySignature(ctx context.Context, signature s
 	} else if err != nil {
 		return nil, sqlcon.HandleError(err)
 	} else if !d.Active && table == sqlTableCode {
-		if r, err := d.toRequest(session, s.r.ClientManager(), s.r.Logger()); err != nil {
+		if r, err := d.toRequest(session, s.r.ClientManager(), s.c, s.kc, s.r.Logger()); err != nil {
 			return nil, err
 		} else {
 			return r, errors.WithStack(fosite.ErrInvalidatedAuthorizeCode)
@@ -302,7 +321,7 @@ func (s *FositeSQLStore) findSessionBySignature(ctx context.Context, signature s
 		return nil, errors.WithStack(fosite.ErrInactiveToken)
 	}
 
-	return d.toRequest(session, s.r.ClientManager(), s.r.Logger())
+	return d.toRequest(session, s.r.ClientManager(), s.c, s.kc, s.r.Logger())
 }
 
 func (s *FositeSQLStore) deleteSession(ctx context.Context, signature string, table tableName) error {


### PR DESCRIPTION
## Related issue

#1649 
@aeneasr 

Currently, Hydra stores claims from consent application as json in database. In our case, we will have a field in /userinfo endpoint stores JWT. Similar to [Aggregated Claims](https://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims).

This can be supported by adding claims to id token session in hydra consent application. But hydra will save claims in plain text. Attacker can use the JWT if they grant the database access.

## Proposed changes

1. Add a config flag`db.encrypt_session_data` to hydra
2. If flag is true, encrypt data before writing in database and decrypt after reading from database.
The encryption is using AES via `KeyCipher` in `RegistryBase`.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
