### PR TITLE
fix: When importing a JWK, the algorithm should be set

### DIFF
--- a/cmd/cli/handler_jwk_test.go
+++ b/cmd/cli/handler_jwk_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"github.com/ory/x/josex"
+	"testing"
+)
+
+func Test_toSDKFriendlyJSONWebKey(t *testing.T) {
+	publicJWK := []byte(`{
+		"kty": "RSA",
+		"e": "AQAB",
+		"use": "sig",
+		"kid": "7a5ff76a-6766-11ea-bc55-0242ac130003",
+		"alg": "RS256",
+		"n": "l80jJJqcc1PpefIGVIjuPvA1D7NscnuF9aQqLa7I9rDUK4IaSOO3kL_EF13k-jTzcA5q4OZn5dR0kmqIMZT2gQ"
+	}`)
+
+	publicPEM := []byte(`
+		-----BEGIN PUBLIC KEY-----
+		MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAPf64dykufSkwnvUiBAwd5Si0K6t4m5i
+		qJD8TmLJCmFjKaOUa6nszcFt/FkAuORfdlrD9mEZLPrPx74RSluyTBMCAwEAAQ==
+		-----END PUBLIC KEY-----		
+	`)
+
+	type args struct {
+		key []byte
+		kid string
+		use string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "JWK with algorithm",
+			args: args{
+				key: publicJWK,
+				kid: "public:7a5ff76a-6766-11ea-bc55-0242ac130003",
+				use: "sig",
+			},
+			want: "RS256",
+		},
+		{
+			name: "PEM key without algorithm",
+			args: args{
+				key: publicPEM,
+				kid: "public:7a5ff76a-6766-11ea-bc55-0242ac130003",
+				use: "sig",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, _ := josex.LoadPublicKey(tt.args.key)
+			if got := toSDKFriendlyJSONWebKey(key, tt.args.kid, tt.args.use); got.Algorithm != tt.want {
+				t.Errorf("toSDKFriendlyJSONWebKey() = %v, want %v", got.Algorithm, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

When using the ```keys import cli``` feature to import a JWK the ```alg``` field get lost during import.

As far as I can see the ```crypto/ecdsa```, ```crypto/elliptic``` and ```crypto/rsa``` structs for private and public keys, used by the ```github.com/mendsley/gojwk```, doesn't support a ```alg``` field. All my tests, trying to importing a non JWK, the ```alg``` field was empty.

I removed the ```github.com/mendsley/gojwk``` package and changed the ```toSDKFriendlyJSONWebKey``` function.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)