### PR TITLE
fix: force transaction isolation level to `LevelRepeatableRead`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/oleiade/reflections v1.0.0
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e
-	github.com/ory/fosite v0.30.5
+	github.com/ory/fosite v0.30.6
 	github.com/ory/go-acc v0.2.1
 	github.com/ory/graceful v0.1.1
 	github.com/ory/herodot v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -735,8 +735,8 @@ github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnh
 github.com/ory/dockertest/v3 v3.5.4 h1:rYijlJuraj8D4OgC1DpYpCV8SGXrkviT3RVrjFy7OFc=
 github.com/ory/dockertest/v3 v3.5.4/go.mod h1:J8ZUbNB2FOhm1cFZW9xBpDsODqsSWcyYgtJYVPcnF70=
 github.com/ory/fosite v0.29.0/go.mod h1:0atSZmXO7CAcs6NPMI/Qtot8tmZYj04Nddoold4S2h0=
-github.com/ory/fosite v0.30.5 h1:SbcS/qdmpnBzAoFBg9VLhzXpiG5VFIg9l+WjIbt5B6M=
-github.com/ory/fosite v0.30.5/go.mod h1:Lq9qQ9Sl6mcea2Tt8J7PU+wUeFYPZ+vg7N3zPVKGbN8=
+github.com/ory/fosite v0.30.6 h1:t1EQHkGv3gVODC9oBvoEi3nIyZ4kvC/ayCsvyswDvis=
+github.com/ory/fosite v0.30.6/go.mod h1:Lq9qQ9Sl6mcea2Tt8J7PU+wUeFYPZ+vg7N3zPVKGbN8=
 github.com/ory/go-acc v0.0.0-20181118080137-ddc355013f90 h1:Bpk3eqc3rbJT2mE+uS9ETzmi2cEL4RuIKz2iUeteh04=
 github.com/ory/go-acc v0.0.0-20181118080137-ddc355013f90/go.mod h1:sxnvPCxChFuSmTJGj8FdMupeq1BezCiEpDjTUXQ4hf4=
 github.com/ory/go-acc v0.2.1 h1:Pwcmwd/cSnwJsYN76+w3HU7oXeWFTkwj/KUj1qGDrVw=

--- a/oauth2/fosite_store_sql.go
+++ b/oauth2/fosite_store_sql.go
@@ -447,7 +447,10 @@ func (s *FositeSQLStore) FlushInactiveAccessTokens(ctx context.Context, notAfter
 }
 
 func (s *FositeSQLStore) BeginTX(ctx context.Context) (context.Context, error) {
-	if tx, err := s.DB.BeginTxx(ctx, nil); err != nil {
+	if tx, err := s.DB.BeginTxx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  false,
+	}); err != nil {
 		return ctx, err
 	} else {
 		return context.WithValue(ctx, txKey, tx), nil

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -38,20 +38,8 @@ import (
 	djwt "github.com/dgrijalva/jwt-go"
 	"github.com/jmoiron/sqlx"
 	"github.com/julienschmidt/httprouter"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/clientcredentials"
-
-	"github.com/ory/viper"
-
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/token/jwt"
-	"github.com/ory/x/pointerx"
-	"github.com/ory/x/sqlcon/dockertest"
-	"github.com/ory/x/urlx"
-
 	hc "github.com/ory/hydra/client"
 	"github.com/ory/hydra/driver"
 	"github.com/ory/hydra/driver/configuration"
@@ -60,6 +48,15 @@ import (
 	"github.com/ory/hydra/internal/httpclient/client/admin"
 	"github.com/ory/hydra/internal/httpclient/models"
 	"github.com/ory/hydra/x"
+	"github.com/ory/viper"
+	"github.com/ory/x/pointerx"
+	"github.com/ory/x/sqlcon/dockertest"
+	"github.com/ory/x/urlx"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 func newCookieJar() http.CookieJar {

--- a/oauth2/oauth2_refresh_token_test.go
+++ b/oauth2/oauth2_refresh_token_test.go
@@ -1,0 +1,155 @@
+package oauth2_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ory/fosite"
+	hc "github.com/ory/hydra/client"
+	"github.com/ory/hydra/internal"
+	"github.com/ory/hydra/oauth2"
+	"github.com/ory/hydra/x"
+	"github.com/pborman/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateRefreshTokenSessionStress is a sanity test to verify the fix for https://github.com/ory/hydra/issues/1719 &
+// https://github.com/ory/hydra/issues/1735.
+// It currently only deals with Postgres as that was what the issue was based on due to the default isolation level used
+// by the storage engine.
+func TestCreateRefreshTokenSessionStress(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	// number of iterations this test will make to ensure everything is working as expected. This test is aiming to
+	// prove correct behaviour when the handler is getting hit with the same refresh token in concurrent requests. Given
+	// that problems that may occur in this scenario are "racey" in nature, it is important to run this test several times
+	// so to minimize the probability were we pass due to sheer luck.
+	testRuns := 5
+	// number of workers that will concurrently hit the 'CreateRefreshTokenSession' method using the same refresh token.
+	// don't set this value to be too high as it will result in connection failures to the DB instance. The test is designed such that
+	// it will retry in the event we get unlucky and a transaction completes successfully prior to other requests getting past the
+	// first read.
+	workers := 10
+	postgresRegistry := internal.NewRegistrySQL(internal.NewConfigurationWithDefaults(), connectToPG(t))
+	x.CleanSQL(t, postgresRegistry.DB())
+	_, err := postgresRegistry.CreateSchemas("postgres")
+	require.NoError(t, err)
+
+	token := "234c678fed33c1d2025537ae464a1ebf7d23fc4a"
+	tokenSignature := "4c7c7e8b3a77ad0c3ec846a21653c48b45dbfa31"
+	testClient := hc.Client{
+		ClientID:      uuid.New(),
+		Secret:        "secret",
+		ResponseTypes: []string{"id_token", "code", "token"},
+		GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
+		Scope:         "hydra offline openid",
+		Audience:      []string{"https://api.ory.sh/"},
+	}
+
+	request := &fosite.AccessRequest{
+		GrantTypes: []string{
+			"refresh_token",
+		},
+		Request: fosite.Request{
+			ID: uuid.New(),
+			Client: &hc.Client{
+				ClientID: testClient.ClientID,
+			},
+			RequestedScope: []string{"offline"},
+			GrantedScope:   []string{"offline"},
+			Session:        oauth2.NewSession(""),
+			Form: url.Values{
+				"refresh_token": []string{fmt.Sprintf("%s.%s", token, tokenSignature)},
+			},
+		},
+	}
+
+	ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	require.NoError(t, postgresRegistry.OAuth2Storage().(clientCreator).CreateClient(ctx, &testClient))
+	assert.NoError(t, postgresRegistry.OAuth2Storage().CreateRefreshTokenSession(ctx, tokenSignature, request))
+	_, err = postgresRegistry.OAuth2Storage().GetRefreshTokenSession(ctx, tokenSignature, nil)
+	assert.NoError(t, err)
+	provider := postgresRegistry.OAuth2Provider()
+
+	var wg sync.WaitGroup
+	for run := 0; run < testRuns; run++ {
+		barrier := make(chan struct{})
+		errorsCh := make(chan error, workers)
+
+		go func() {
+			for w := 0; w < workers; w++ {
+				wg.Add(1)
+				go func(run, worker int) {
+					defer wg.Done()
+					ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+					// all workers will block here until the for loop above has launched all the worker go-routines
+					// this is to ensure we fire all the workers off at the same
+					<-barrier
+					_, err := provider.NewAccessResponse(ctx, request)
+					errorsCh <- err
+				}(run, w)
+			}
+
+			// wait until all workers have completed their work
+			wg.Wait()
+			close(errorsCh)
+		}()
+
+		// let the race begin!
+		// all worker go-routines will now attempt to hit the "NewAccessResponse" method
+		close(barrier)
+
+		// process worker results
+
+		// successCount is the number of workers that were able to call "NewAccessResponse" without receiving an error.
+		// if the successCount at the end of a test run is bigger than one, it means that multiple access/refresh tokens
+		// were issued using the same refresh token! - https://knowyourmeme.com/memes/scared-hamster
+		var successCount int
+		for err := range errorsCh {
+			if err != nil {
+				switch err := errors.Cause(err).(type) {
+				case *fosite.RFC6749Error:
+
+					// TODO: ok this is the tricky part, we need to add error handling logic somewhere such that we are
+					// able to catch the following transaction error(s):
+					//
+					//   • ERROR: could not serialize access due to concurrent update (SQLSTATE 40001)
+					//
+					// this logic likely belongs somewhere in fosite as the refresh flow is currently wrapping any error
+					// it gets back into a `fosite.ErrServerError`.
+
+					// TODO: add assertions that will deal with errors to ensure the returned 'fosite.RFC6749Error'
+					// error is hydrated as expected
+
+					// TODO: amir - remove debug prints
+					fmt.Printf("RFC6749 error debug: %s\n", err.Debug)
+				default:
+					t.Errorf("expected underlying error type be '*fosite.RFC6749Error', but it was "+
+						"actually of type %T: %+v", err, err)
+				}
+			} else {
+				successCount++
+			}
+		}
+
+		if successCount != 1 {
+			t.Errorf("CRITICAL: in test iteration %d, %d out of %d workers were able to use the refresh token "+
+				"to obtain a new access/refresh token where exactly ONE was expected to be have been successfull.",
+				run,
+				successCount,
+				workers)
+		}
+
+		// reset state for the next test iteration
+		_ = postgresRegistry.OAuth2Storage().RevokeRefreshToken(ctx, request.ID)
+		_ = postgresRegistry.OAuth2Storage().CreateRefreshTokenSession(ctx, tokenSignature, request)
+	}
+}

--- a/oauth2/oauth2_refresh_token_test.go
+++ b/oauth2/oauth2_refresh_token_test.go
@@ -3,17 +3,22 @@ package oauth2_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/ory/fosite"
 	hc "github.com/ory/hydra/client"
+	"github.com/ory/hydra/driver"
 	"github.com/ory/hydra/internal"
 	"github.com/ory/hydra/oauth2"
-	"github.com/ory/hydra/x"
+	"github.com/ory/x/dbal"
 	"github.com/ory/x/errorsx"
+	"github.com/ory/x/sqlcon/dockertest"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,10 +43,6 @@ func TestCreateRefreshTokenSessionStress(t *testing.T) {
 	// it will retry in the event we get unlucky and a transaction completes successfully prior to other requests getting past the
 	// first read.
 	workers := 10
-	postgresRegistry := internal.NewRegistrySQL(internal.NewConfigurationWithDefaults(), connectToPG(t))
-	x.CleanSQL(t, postgresRegistry.DB())
-	_, err := postgresRegistry.CreateSchemas("postgres")
-	require.NoError(t, err)
 
 	token := "234c678fed33c1d2025537ae464a1ebf7d23fc4a"
 	tokenSignature := "4c7c7e8b3a77ad0c3ec846a21653c48b45dbfa31"
@@ -73,86 +74,177 @@ func TestCreateRefreshTokenSessionStress(t *testing.T) {
 		},
 	}
 
-	ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
-	require.NoError(t, postgresRegistry.OAuth2Storage().(clientCreator).CreateClient(ctx, &testClient))
-	require.NoError(t, postgresRegistry.OAuth2Storage().CreateRefreshTokenSession(ctx, tokenSignature, request))
-	_, err = postgresRegistry.OAuth2Storage().GetRefreshTokenSession(ctx, tokenSignature, nil)
-	require.NoError(t, err)
-	provider := postgresRegistry.OAuth2Provider()
+	config := internal.NewConfigurationWithDefaults()
+	registries := make(map[string]driver.Registry)
+	var pg, msql, cdb *sqlx.DB
+	dockertest.Parallel([]func(){
+		func() {
+			pg = connectToPG(t)
+		},
+		func() {
+			msql = connectToMySQL(t)
+		},
+		func() {
+			cdb = connectToCRDB(t)
+		},
+	})
 
-	var wg sync.WaitGroup
-	for run := 0; run < testRuns; run++ {
-		barrier := make(chan struct{})
-		errorsCh := make(chan error, workers)
+	registries[dbal.DriverPostgreSQL] = connectSQL(t, config, dbal.DriverPostgreSQL, pg)
+	registries[dbal.DriverCockroachDB] = connectSQL(t, config, dbal.DriverCockroachDB, cdb)
+	registries[dbal.DriverMySQL] = connectSQL(t, config, dbal.DriverMySQL, msql)
 
-		go func() {
-			for w := 0; w < workers; w++ {
-				wg.Add(1)
-				go func(run, worker int) {
-					defer wg.Done()
-					ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
-					// all workers will block here until the for loop above has launched all the worker go-routines
-					// this is to ensure we fire all the workers off at the same
-					<-barrier
-					_, err := provider.NewAccessResponse(ctx, request)
-					errorsCh <- err
-				}(run, w)
-			}
+	for dbName, dbRegistry := range registries {
+		ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+		require.NoError(t, dbRegistry.OAuth2Storage().(clientCreator).CreateClient(ctx, &testClient))
+		require.NoError(t, dbRegistry.OAuth2Storage().CreateRefreshTokenSession(ctx, tokenSignature, request))
+		_, err := dbRegistry.OAuth2Storage().GetRefreshTokenSession(ctx, tokenSignature, nil)
+		require.NoError(t, err)
+		provider := dbRegistry.OAuth2Provider()
+		storageVersion := dbVersion(ctx, dbRegistry)
 
-			// wait until all workers have completed their work
-			wg.Wait()
-			close(errorsCh)
-		}()
+		var wg sync.WaitGroup
+		for run := 0; run < testRuns; run++ {
+			barrier := make(chan struct{})
+			errorsCh := make(chan error, workers)
 
-		// let the race begin!
-		// all worker go-routines will now attempt to hit the "NewAccessResponse" method
-		close(barrier)
-
-		// process worker results
-
-		// successCount is the number of workers that were able to call "NewAccessResponse" without receiving an error.
-		// if the successCount at the end of a test run is bigger than one, it means that multiple access/refresh tokens
-		// were issued using the same refresh token! - https://knowyourmeme.com/memes/scared-hamster
-		var successCount int
-		for err := range errorsCh {
-			if err != nil {
-				switch cause := errorsx.Cause(err).(type) {
-				case *fosite.RFC6749Error:
-					switch cause.Name {
-					case fosite.ErrInvalidRequest.Name:
-						assert.Equal(t, fosite.ErrInvalidRequest.Description, cause.Description)
-						assert.Contains(t, cause.Debug, "could not serialize access due to concurrent update (SQLSTATE 40001)")
-					default:
-						t.Errorf("an unexpected RFC6749 error with the name %q was returned.\n"+
-							"Hint: has the refresh token error handling changed in fosite? If so, you need to add further "+
-							"assertions here to cover the additional errors that are being returned by the handler.\n\n"+
-							"Error description: %s\n"+
-							"Error debug: %s\n"+
-							"Error hint: %s\n"+
-							"Raw error: %+v",
-							cause.Name,
-							cause.Description,
-							cause.Debug,
-							cause.Hint,
-							err)
-					}
-				default:
-					t.Errorf("expected underlying error to be of type '*fosite.RFC6749Error', but it was "+
-						"actually of type %T: %+v", err, err)
+			go func() {
+				for w := 0; w < workers; w++ {
+					wg.Add(1)
+					go func(run, worker int) {
+						defer wg.Done()
+						ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+						time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+						// all workers will block here until the for loop above has launched all the worker go-routines
+						// this is to ensure we fire all the workers off at the same
+						<-barrier
+						_, err := provider.NewAccessResponse(ctx, request)
+						errorsCh <- err
+					}(run, w)
 				}
-			} else {
-				successCount++
+
+				// wait until all workers have completed their work
+				wg.Wait()
+				close(errorsCh)
+			}()
+
+			// let the race begin!
+			// all worker go-routines will now attempt to hit the "NewAccessResponse" method
+			close(barrier)
+
+			// process worker results
+
+			// successCount is the number of workers that were able to call "NewAccessResponse" without receiving an error.
+			// if the successCount at the end of a test run is bigger than one, it means that multiple access/refresh tokens
+			// were issued using the same refresh token! - https://knowyourmeme.com/memes/scared-hamster
+			var successCount int
+			for err := range errorsCh {
+				if err != nil {
+					switch cause := errorsx.Cause(err).(type) {
+					case *fosite.RFC6749Error:
+						switch cause.Name {
+
+						// change logic below when the refresh handler starts returning 'fosite.ErrInvalidRequest' for other reasons.
+						// as of now, this error is only returned due to concurrent transactions competing to refresh using the same token.
+
+						case fosite.ErrInvalidRequest.Name:
+							// the error description copy is defined by RFC 6749 and should not be different regardless of
+							// the underlying transactional aware storage backend used by hydra
+							assert.Equal(t, fosite.ErrInvalidRequest.Description, cause.Description)
+							// the database error debug copy will be different depending on the underlying database used
+							switch dbName {
+							case dbal.DriverMySQL:
+							case dbal.DriverPostgreSQL, dbal.DriverCockroachDB:
+								var matched bool
+								for _, errSubstr := range []string{
+									// both postgreSQL & cockroachDB return error code 40001 for consistency errors as a result of
+									// using the REPEATABLE_READ isolation level
+									"SQLSTATE 40001",
+									// possible if one worker starts the transaction AFTER another worker has successfully
+									// refreshed the token and committed the transaction
+									"not_found",
+								} {
+									if strings.Contains(cause.Debug, errSubstr) {
+										matched = true
+										break
+									}
+								}
+
+								assert.True(t, matched, "received an unexpected kind of `fosite.ErrInvalidRequest`\n"+
+									"DB version: %s\n"+
+									"Error description: %s\n"+
+									"Error debug: %s\n"+
+									"Error hint: %s\n"+
+									"Raw error: %+v",
+									storageVersion,
+									cause.Description,
+									cause.Debug,
+									cause.Hint,
+									err)
+							}
+						default:
+							// unfortunately, MySQL does not offer the same behaviour under the "REPEATABLE_READ" isolation
+							// level so we have to relax this assertion just for MySQL for the time being as server_errors
+							// resembling the following can be returned:
+							//
+							//    Error 1213: Deadlock found when trying to get lock; try restarting transaction
+							if dbName != dbal.DriverMySQL {
+								t.Errorf("an unexpected RFC6749 error with the name %q was returned.\n"+
+									"Hint: has the refresh token error handling changed in fosite? If so, you need to add further "+
+									"assertions here to cover the additional errors that are being returned by the handler.\n"+
+									"DB version: %s\n"+
+									"Error description: %s\n"+
+									"Error debug: %s\n"+
+									"Error hint: %s\n"+
+									"Raw error: %+v",
+									cause.Name,
+									storageVersion,
+									cause.Description,
+									cause.Debug,
+									cause.Hint,
+									err)
+							}
+						}
+					default:
+						t.Errorf("expected underlying error to be of type '*fosite.RFC6749Error', but it was "+
+							"actually of type %T: %+v - DB version: %s", err, err, storageVersion)
+					}
+				} else {
+					successCount++
+				}
 			}
+
+			// IMPORTANT - skip consistency check for MySQL :(
+			//
+			// different DBMS's provide different consistency guarantees when using the "REPEATABLE_READ" isolation level
+			// Currently, MySQL's implementation of "REPEATABLE_READ" makes it possible for multiple concurrent requests
+			// to successfully utilize the same refresh token. Therefore, we skip the assertion below.
+			//
+			// TODO: this needs to be addressed by making it possible to use different isolation levels for various authorization
+			//       flows depending on the underlying hydra storage backend. For example, if using MySQL, hydra should force
+			//       the transaction isolation level to be "Serializable" when a request to the token handler is received.
+
+			switch dbName {
+			case dbal.DriverMySQL:
+			case dbal.DriverPostgreSQL, dbal.DriverCockroachDB:
+				require.Equal(t, 1, successCount, "CRITICAL: in test iteration %d, %d out of %d workers "+
+					"were able to use the refresh token. Exactly ONE was expected to be have been successful.",
+					run,
+					successCount,
+					workers)
+			}
+
+			// reset state for the next test iteration
+			assert.NoError(t, dbRegistry.OAuth2Storage().RevokeRefreshToken(ctx, request.ID))
+			assert.NoError(t, dbRegistry.OAuth2Storage().CreateRefreshTokenSession(ctx, tokenSignature, request))
 		}
-
-		assert.Equal(t, 1, successCount, "CRITICAL: in test iteration %d, %d out of %d workers "+
-			"were able to use the refresh token. Exactly ONE was expected to be have been successful.",
-			run,
-			successCount,
-			workers)
-
-		// reset state for the next test iteration
-		_ = postgresRegistry.OAuth2Storage().RevokeRefreshToken(ctx, request.ID)
-		_ = postgresRegistry.OAuth2Storage().CreateRefreshTokenSession(ctx, tokenSignature, request)
 	}
+}
+
+func dbVersion(ctx context.Context, registry driver.Registry) string {
+	var version string
+	if sqlRegistry, ok := registry.(*driver.RegistrySQL); ok {
+		_ = sqlRegistry.DB().QueryRowxContext(ctx, "select version()").Scan(&version)
+		version = fmt.Sprintf("%s-%s", sqlRegistry.DB().DriverName(), version)
+	}
+	return version
 }


### PR DESCRIPTION
## Related issues

- https://github.com/ory/hydra/issues/1719
- https://github.com/ory/hydra/issues/1735

## ⚠️ Dependent PRs

- [x] https://github.com/ory/fosite/pull/402
- [x] https://github.com/ory/x/pull/129

_(Each of the packages above will need a new tag release once/if the PRs have been merged)_ 🙏 

## Proposed changes

To improve consistency in certain authorization flows that utilize transactions, this PR forces the SQL storage transaction isolation level to `LevelRepeatableRead`. This will ensure that we avoid the phenomena of non-repeatable reads which occur when a transaction re-reads data it has previously read and then finds out that another transaction has since modified that data and committed. As a result, setting this isolation level fixes a flaw where one could use a given refresh token more than once. See the test added.

In the event that multiple concurrent transactions are competing under a given refresh token workflow, the underlying database engine will eventually return an error when one of the transactions successfully commits. For example, in such a scenario, postgres will rollback the transaction with:

```
could not serialize access due to concurrent update (SQLSTATE 40001)
```


## TODO 

- [x] This PR needs to accompany changes in `fosite` and likely `x` for error handling logic in the event the underlying database engine returns an error due to concurrent transaction activity on the same rows
- The error types and codes returned under this condition will likely be different for each database driver implementation

I am thinking the best way to do this is to add a new error type to represent a "transaction (serialization) error" which can be caught & returned by the [`HandleError`](https://github.com/ory/x/blob/master/sqlcon/error.go#L33) API exposed by the `sqlcon` package. This API is already consumed by relevant methods of Hydra's SQL based implementation of the `fosite` storage interfaces.

Finally, inside `fosite`'s [refresh token grant handler](https://github.com/ory/fosite/blob/master/handler/oauth2/flow_refresh.go#L118) we could check for this new transaction error type and return an appropriate `RFC6749Error` error. I am thinking this particular error should result in a 503 based on the [postgres documentation](https://www.postgresql.org/docs/9.1/transaction-iso.html#MVCC-ISOLEVEL-TABLE
):

> When an application receives this error message, it should abort the current transaction and retry the whole transaction from the beginning.

In our case, we will not be retrying the transaction because it will be unfruitful. The next time the user tries to call the token endpoint with the same refresh token, it will result in an invalid request as expected. It seems strange to deduce an error as a result of transaction concurrency with a concrete 4xx error, no?

```
To summarize: 

(multiple txn's competing to use the same refresh token)

• fosite refresh handler calls out to storage after initing txn earlier w/ new iso level
• storage calls out to actual database to modify some row
• db returns an error due to concurrent access, eg:
   • `could not serialize access due to concurrent update (SQLSTATE 40001)`
• we use the `sqlcon` package to capture this error and wrap it in some generic "txn serialization error" type and return it up the callstack
• eventually back into fosite code which can check for this error and create a RFC6749Error
```

@aeneasr what do you think of this approach?

- [x] Expand test coverage for all SQL backed stores, currently I am only dealing with postgres

- [x] Investigate how `MySQL` & `CockroachDB` behave under this isolation level (_the test I added should hopefully make this straightforward 🤞_)


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
