### PR TITLE
chore: fix linter due to deprecation notice on 'func (r Arguments) Exact(name string) bool'

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -553,7 +553,7 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if accessRequest.GetGrantTypes().Exact("client_credentials") {
+	if accessRequest.GetGrantTypes().ExactOne("client_credentials") {
 		var accessTokenKeyID string
 		if h.c.AccessTokenStrategy() == "jwt" {
 			accessTokenKeyID, err = h.r.AccessTokenJWTStrategy().GetPublicKeyID(r.Context())
@@ -659,12 +659,12 @@ func (h *Handler) AuthHandler(w http.ResponseWriter, r *http.Request, _ httprout
 	authorizeRequest.SetID(session.Challenge)
 
 	claims := &jwt.IDTokenClaims{
-		Subject:                             session.ConsentRequest.SubjectIdentifier,
-		Issuer:                              strings.TrimRight(h.c.IssuerURL().String(), "/") + "/",
-		IssuedAt:                            time.Now().UTC(),
-		AuthTime:                            time.Time(session.AuthenticatedAt),
-		RequestedAt:                         session.RequestedAt,
-		Extra:                               session.Session.IDToken,
+		Subject:     session.ConsentRequest.SubjectIdentifier,
+		Issuer:      strings.TrimRight(h.c.IssuerURL().String(), "/") + "/",
+		IssuedAt:    time.Now().UTC(),
+		AuthTime:    time.Time(session.AuthenticatedAt),
+		RequestedAt: session.RequestedAt,
+		Extra:       session.Session.IDToken,
 		AuthenticationContextClassReference: session.ConsentRequest.ACR,
 
 		// We do not need to pass the audience because it's included directly by ORY Fosite


### PR DESCRIPTION
In `fosite` release `v0.30.3` the following method [was deprecated](https://github.com/ory/fosite/compare/v0.30.2...v0.30.3):

```go
// Deprecated: Use ExactOne, Matches or MatchesExact
func (r Arguments) Exact(name string) bool {
	return name == strings.Join(r, " ")
}
```

Which caused the linter to fail.