### PR TITLE
fix: consent cockroachdb perfomance issue with zigzag join query 

### DIFF
--- a/persistence/sql/migrations/20200521071434_consent.cockroach.down.sql
+++ b/persistence/sql/migrations/20200521071434_consent.cockroach.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX hydra_oauth2_consent_request@hydra_oauth2_consent_request_client_id_subject_idx;

--- a/persistence/sql/migrations/20200521071434_consent.cockroach.up.sql
+++ b/persistence/sql/migrations/20200521071434_consent.cockroach.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX hydra_oauth2_consent_request_client_id_subject_idx ON hydra_oauth2_consent_request (client_id, subject);

--- a/persistence/sql/migrations/20200521071434_consent.mysql.down.sql
+++ b/persistence/sql/migrations/20200521071434_consent.mysql.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX hydra_oauth2_consent_request ON hydra_oauth2_consent_request_client_id_subject_idx;

--- a/persistence/sql/migrations/20200521071434_consent.mysql.up.sql
+++ b/persistence/sql/migrations/20200521071434_consent.mysql.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX hydra_oauth2_consent_request_client_id_subject_idx ON hydra_oauth2_consent_request (client_id, subject);

--- a/persistence/sql/migrations/20200521071434_consent.postgres.down.sql
+++ b/persistence/sql/migrations/20200521071434_consent.postgres.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX hydra_oauth2_consent_request_client_id_subject_idx;

--- a/persistence/sql/migrations/20200521071434_consent.postgres.up.sql
+++ b/persistence/sql/migrations/20200521071434_consent.postgres.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX hydra_oauth2_consent_request_client_id_subject_idx ON hydra_oauth2_consent_request (client_id, subject);


### PR DESCRIPTION
Add an index over subject and client_id in order to avoid the
(sometimes) underperformant zigzag join query.

Closes #1789
Related to #1755 https://github.com/cockroachdb/cockroach/issues/47179

After applying the proposed index, the query plan now avoids the zigzag join query, reducing the query times from 50s to 2s in worst cases in my tests.

```
	distributed	true
	vectorized	false
sort		
 │	order	-requested_at
 └── render		
      └── lookup-join		
           │	table	hydra_oauth2_consent_request_handled@primary
           │	type	inner
           │	equality	(challenge) = (challenge)
           │	equality cols are key	
           │	parallel	
           │	pred	"(@9 = '{}') AND (@7 = true)"
           └── filter		
                │	filter	skip = false
                └── index-join		
                     │	table	hydra_oauth2_consent_request@primary
                     └── scan		
	table	hydra_oauth2_consent_request@hydra_oauth2_consent_request_client_id_subject_idx
	spans	"/""myclient""/""my@subject.com""-/""my-client""/""my@subject.com""/PrefixEnd"
```