### PR TITLE
fix(docker): Add nsswitch.conf into the dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ FROM scratch
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY hydra /usr/bin/hydra
 
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 USER 1000
 
 ENTRYPOINT ["hydra"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -9,6 +9,10 @@ RUN apk add -U --no-cache ca-certificates
 
 COPY hydra /usr/bin/hydra
 
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 USER ory
 
 ENTRYPOINT ["hydra"]


### PR DESCRIPTION
Go's netgo implementation currently does not respect hostname overrides
defined in /etc/hosts if the /etc/nsswitch.conf does not exists.

Made changes to the Dockerfiles to add a standard /etc/nsswitch.conf
to fix this issue.

## Related issue

No issue have been opened for this.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

When hydra is being used in a form of a docker image in an environment where hostname overrides are being used through /etc/hosts the overrides are not respected. This is not an issue with hydra all, but a well known one with golang and alpine, as the alpine base image a few years ago got rid of the nsswitch.conf saying that it is not needed anymore. Unfortunately golang depends on the presence of this file and when it is missing it just ignores whatever is in the /etc/hosts file.

This change adds the nsswitch.conf back to the docker image of hydra. 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
