### PR TITLE
fix: allow -1 as ttl.refresh_token value

### DIFF
--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -1821,10 +1821,10 @@
       "description": "It is important that this model object is named JSONWebKey for\n\"swagger generate spec\" to generate only on definition of a\nJSONWebKey.",
       "type": "object",
       "required": [
-        "use",
-        "kty",
+        "alg",
         "kid",
-        "alg"
+        "kty",
+        "use"
       ],
       "properties": {
         "alg": {
@@ -1926,20 +1926,30 @@
       "title": "NullTime implements sql.NullTime functionality."
     },
     "PreviousConsentSession": {
-      "description": "The response used to return used consent requests\nsame as HandledLoginRequest, just with consent_request exposed as json",
+      "description": "PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession The response used to return used consent requests\nsame as HandledLoginRequest, just with consent_request exposed as json",
       "type": "object",
       "properties": {
         "consent_request": {
           "$ref": "#/definitions/consentRequest"
         },
         "grant_access_token_audience": {
-          "$ref": "#/definitions/StringSlicePipeDelimiter"
+          "description": "GrantedAudience sets the audience the user authorized the client to use. Should be a subset of `requested_access_token_audience`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "grant_scope": {
-          "$ref": "#/definitions/StringSlicePipeDelimiter"
+          "description": "GrantScope sets the scope the user authorized the client to use. Should be a subset of `requested_scope`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "handled_at": {
-          "$ref": "#/definitions/NullTime"
+          "description": "handled at\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time\nFormat: date-time",
+          "type": "string",
+          "format": "date-time"
         },
         "remember": {
           "description": "Remember, if set to true, tells ORY Hydra to remember this consent authorization and reuse it if the same\nclient asks the same user for the same, or a subset of, scope.",
@@ -1967,9 +1977,19 @@
       "title": "The request payload used to accept a consent request.",
       "properties": {
         "grant_access_token_audience": {
+          "description": "grant access token audience",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "$ref": "#/definitions/StringSlicePipeDelimiter"
         },
         "grant_scope": {
+          "description": "grant scope",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "$ref": "#/definitions/StringSlicePipeDelimiter"
         },
         "handled_at": {
@@ -2034,7 +2054,7 @@
     },
     "consentRequest": {
       "type": "object",
-      "title": "Contains information on an ongoing consent request.",
+      "title": "ConsentRequest Contains information on an ongoing consent request.",
       "properties": {
         "acr": {
           "description": "ACR represents the Authentication AuthorizationContext Class Reference value for this authentication session. You can use it\nto express that, for example, a user authenticated using two factor authentication.",
@@ -2066,9 +2086,17 @@
           "type": "string"
         },
         "requested_access_token_audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "$ref": "#/definitions/StringSlicePipeDelimiter"
         },
         "requested_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "$ref": "#/definitions/StringSlicePipeDelimiter"
         },
         "skip": {
@@ -2143,6 +2171,7 @@
       }
     },
     "healthNotReadyStatus": {
+      "description": "HealthNotReadyStatus health not ready status",
       "type": "object",
       "properties": {
         "errors": {
@@ -2164,6 +2193,7 @@
       }
     },
     "jsonWebKeySetGeneratorRequest": {
+      "description": "JSONWebKeySetGeneratorRequest json web key set generator request",
       "type": "object",
       "required": [
         "alg",
@@ -2204,9 +2234,19 @@
           "type": "string"
         },
         "requested_access_token_audience": {
+          "description": "requested access token audience",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "$ref": "#/definitions/StringSlicePipeDelimiter"
         },
         "requested_scope": {
+          "description": "requested scope",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "$ref": "#/definitions/StringSlicePipeDelimiter"
         },
         "session_id": {
@@ -2225,7 +2265,7 @@
     },
     "logoutRequest": {
       "type": "object",
-      "title": "Contains information about an ongoing logout request.",
+      "title": "LogoutRequest Contains information about an ongoing logout request.",
       "properties": {
         "request_url": {
           "description": "RequestURL is the original Logout URL requested.",
@@ -2247,7 +2287,7 @@
     },
     "oAuth2Client": {
       "type": "object",
-      "title": "Client represents an OAuth 2.0 Client.",
+      "title": "OAuth2Client OAuth2Client Client represents an OAuth 2.0 Client.",
       "properties": {
         "allowed_cors_origins": {
           "$ref": "#/definitions/StringSlicePipeDelimiter"
@@ -2288,7 +2328,7 @@
           "$ref": "#/definitions/StringSlicePipeDelimiter"
         },
         "created_at": {
-          "description": "CreatedAt returns the timestamp of the client's creation.",
+          "description": "CreatedAt returns the timestamp of the client's creation.\nFormat: date-time\nFormat: date-time",
           "type": "string",
           "format": "date-time"
         },
@@ -2363,7 +2403,7 @@
           "type": "string"
         },
         "updated_at": {
-          "description": "UpdatedAt returns the timestamp of the last update.",
+          "description": "UpdatedAt returns the timestamp of the last update.\nFormat: date-time\nFormat: date-time",
           "type": "string",
           "format": "date-time"
         },
@@ -2445,26 +2485,32 @@
       }
     },
     "oauth2TokenResponse": {
-      "description": "The Access Token Response",
+      "description": "Oauth2TokenResponse Oauth2TokenResponse Oauth2TokenResponse The Access Token Response",
       "type": "object",
       "properties": {
         "access_token": {
+          "description": "access token",
           "type": "string"
         },
         "expires_in": {
+          "description": "expires in",
           "type": "integer",
           "format": "int64"
         },
         "id_token": {
+          "description": "id token",
           "type": "string"
         },
         "refresh_token": {
+          "description": "refresh token",
           "type": "string"
         },
         "scope": {
+          "description": "scope",
           "type": "string"
         },
         "token_type": {
+          "description": "token type",
           "type": "string"
         }
       }
@@ -2506,21 +2552,26 @@
     },
     "rejectRequest": {
       "type": "object",
-      "title": "The request payload used to accept a login or consent request.",
+      "title": "RejectRequest The request payload used to accept a login or consent request.",
       "properties": {
         "error": {
+          "description": "error",
           "type": "string"
         },
         "error_debug": {
+          "description": "error debug",
           "type": "string"
         },
         "error_description": {
+          "description": "error description",
           "type": "string"
         },
         "error_hint": {
+          "description": "error hint",
           "type": "string"
         },
         "status_code": {
+          "description": "status code",
           "type": "integer",
           "format": "int64"
         }
@@ -2610,6 +2661,7 @@
       }
     },
     "version": {
+      "description": "Version version",
       "type": "object",
       "properties": {
         "version": {
@@ -2623,13 +2675,13 @@
       "type": "object",
       "title": "WellKnown represents important OpenID Connect discovery metadata",
       "required": [
-        "issuer",
         "authorization_endpoint",
-        "token_endpoint",
+        "id_token_signing_alg_values_supported",
+        "issuer",
         "jwks_uri",
-        "subject_types_supported",
         "response_types_supported",
-        "id_token_signing_alg_values_supported"
+        "subject_types_supported",
+        "token_endpoint"
       ],
       "properties": {
         "authorization_endpoint": {

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -150,7 +150,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["path"]
+          "required": [
+            "path"
+          ]
         },
         {
           "properties": {
@@ -165,7 +167,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["base64"]
+          "required": [
+            "base64"
+          ]
         }
       ]
     },
@@ -472,7 +476,9 @@
             }
           },
           "then": {
-            "required": ["pairwise"]
+            "required": [
+              "pairwise"
+            ]
           },
           "else": {
             "properties": {
@@ -627,9 +633,15 @@
         "refresh_token": {
           "description": "Configures how long refresh tokens are valid. Set to -1 for refresh tokens to never expire.",
           "default": "720h",
-          "allOf": [
+          "oneOf": [
             {
               "$ref": "#/definitions/duration"
+            },
+            {
+              "enum": [
+                "-1",
+                -1
+              ]
             }
           ]
         },

--- a/internal/httpclient/models/accept_consent_request.go
+++ b/internal/httpclient/models/accept_consent_request.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// AcceptConsentRequest AcceptConsentRequest AcceptConsentRequest AcceptConsentRequest AcceptConsentRequest AcceptConsentRequest AcceptConsentRequest AcceptConsentRequest AcceptConsentRequest The request payload used to accept a consent request.
+// AcceptConsentRequest The request payload used to accept a consent request.
 //
 // swagger:model acceptConsentRequest
 type AcceptConsentRequest struct {

--- a/internal/httpclient/models/accept_login_request.go
+++ b/internal/httpclient/models/accept_login_request.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// AcceptLoginRequest AcceptLoginRequest AcceptLoginRequest HandledLoginRequest is the request payload used to accept a login request.
+// AcceptLoginRequest HandledLoginRequest is the request payload used to accept a login request.
 //
 // swagger:model acceptLoginRequest
 type AcceptLoginRequest struct {

--- a/internal/httpclient/models/consent_request.go
+++ b/internal/httpclient/models/consent_request.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// ConsentRequest Contains information on an ongoing consent request.
+// ConsentRequest ConsentRequest Contains information on an ongoing consent request.
 //
 // swagger:model consentRequest
 type ConsentRequest struct {

--- a/internal/httpclient/models/consent_request_session.go
+++ b/internal/httpclient/models/consent_request_session.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// ConsentRequestSession ConsentRequestSession ConsentRequestSession ConsentRequestSession ConsentRequestSession Used to pass session data to a consent request.
+// ConsentRequestSession Used to pass session data to a consent request.
 //
 // swagger:model consentRequestSession
 type ConsentRequestSession struct {

--- a/internal/httpclient/models/flush_inactive_o_auth2_tokens_request.go
+++ b/internal/httpclient/models/flush_inactive_o_auth2_tokens_request.go
@@ -12,15 +12,13 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// FlushInactiveOAuth2TokensRequest FlushInactiveOAuth2TokensRequest FlushInactiveOAuth2TokensRequest flush inactive o auth2 tokens request
+// FlushInactiveOAuth2TokensRequest flush inactive o auth2 tokens request
 //
 // swagger:model flushInactiveOAuth2TokensRequest
 type FlushInactiveOAuth2TokensRequest struct {
 
 	// NotAfter sets after which point tokens should not be flushed. This is useful when you want to keep a history
 	// of recently issued tokens for auditing.
-	// Format: date-time
-	// Format: date-time
 	// Format: date-time
 	NotAfter strfmt.DateTime `json:"notAfter,omitempty"`
 }

--- a/internal/httpclient/models/generic_error.go
+++ b/internal/httpclient/models/generic_error.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// GenericError GenericError Error response
+// GenericError Error response
 //
 // Error responses are sent when an error (e.g. unauthorized, bad request, ...) occurred.
 //

--- a/internal/httpclient/models/health_not_ready_status.go
+++ b/internal/httpclient/models/health_not_ready_status.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// HealthNotReadyStatus health not ready status
+// HealthNotReadyStatus HealthNotReadyStatus health not ready status
 //
 // swagger:model healthNotReadyStatus
 type HealthNotReadyStatus struct {

--- a/internal/httpclient/models/health_status.go
+++ b/internal/httpclient/models/health_status.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// HealthStatus HealthStatus HealthStatus HealthStatus HealthStatus health status
+// HealthStatus health status
 //
 // swagger:model healthStatus
 type HealthStatus struct {

--- a/internal/httpclient/models/json_web_key.go
+++ b/internal/httpclient/models/json_web_key.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// JSONWebKey JSONWebKey It is important that this model object is named JSONWebKey for
+// JSONWebKey It is important that this model object is named JSONWebKey for
 // "swagger generate spec" to generate only on definition of a
 // JSONWebKey.
 //

--- a/internal/httpclient/models/json_web_key_set.go
+++ b/internal/httpclient/models/json_web_key_set.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// JSONWebKeySet JSONWebKeySet JSONWebKeySet It is important that this model object is named JSONWebKeySet for
+// JSONWebKeySet It is important that this model object is named JSONWebKeySet for
 // "swagger generate spec" to generate only on definition of a
 // JSONWebKeySet. Since one with the same name is previously defined as
 // client.Client.JSONWebKeys and this one is last, this one will be

--- a/internal/httpclient/models/json_web_key_set_generator_request.go
+++ b/internal/httpclient/models/json_web_key_set_generator_request.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// JSONWebKeySetGeneratorRequest json web key set generator request
+// JSONWebKeySetGeneratorRequest JSONWebKeySetGeneratorRequest json web key set generator request
 //
 // swagger:model jsonWebKeySetGeneratorRequest
 type JSONWebKeySetGeneratorRequest struct {

--- a/internal/httpclient/models/login_request.go
+++ b/internal/httpclient/models/login_request.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// LoginRequest LoginRequest Contains information on an ongoing login request.
+// LoginRequest Contains information on an ongoing login request.
 //
 // swagger:model loginRequest
 type LoginRequest struct {

--- a/internal/httpclient/models/logout_request.go
+++ b/internal/httpclient/models/logout_request.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// LogoutRequest Contains information about an ongoing logout request.
+// LogoutRequest LogoutRequest Contains information about an ongoing logout request.
 //
 // swagger:model logoutRequest
 type LogoutRequest struct {

--- a/internal/httpclient/models/o_auth2_client.go
+++ b/internal/httpclient/models/o_auth2_client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// OAuth2Client OAuth2Client Client represents an OAuth 2.0 Client.
+// OAuth2Client OAuth2Client OAuth2Client Client represents an OAuth 2.0 Client.
 //
 // swagger:model oAuth2Client
 type OAuth2Client struct {
@@ -61,6 +61,7 @@ type OAuth2Client struct {
 	Contacts StringSlicePipeDelimiter `json:"contacts,omitempty"`
 
 	// CreatedAt returns the timestamp of the client's creation.
+	// Format: date-time
 	// Format: date-time
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
@@ -147,6 +148,7 @@ type OAuth2Client struct {
 	TosURI string `json:"tos_uri,omitempty"`
 
 	// UpdatedAt returns the timestamp of the last update.
+	// Format: date-time
 	// Format: date-time
 	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`

--- a/internal/httpclient/models/o_auth2_token_introspection.go
+++ b/internal/httpclient/models/o_auth2_token_introspection.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// OAuth2TokenIntrospection OAuth2TokenIntrospection OAuth2TokenIntrospection Introspection contains an access token's session data as specified by IETF RFC 7662, see:
+// OAuth2TokenIntrospection Introspection contains an access token's session data as specified by IETF RFC 7662, see:
 //
 // https://tools.ietf.org/html/rfc7662
 //

--- a/internal/httpclient/models/oauth2_token_response.go
+++ b/internal/httpclient/models/oauth2_token_response.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// Oauth2TokenResponse Oauth2TokenResponse Oauth2TokenResponse The Access Token Response
+// Oauth2TokenResponse Oauth2TokenResponse Oauth2TokenResponse Oauth2TokenResponse The Access Token Response
 //
 // swagger:model oauth2TokenResponse
 type Oauth2TokenResponse struct {

--- a/internal/httpclient/models/open_id_connect_context.go
+++ b/internal/httpclient/models/open_id_connect_context.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// OpenIDConnectContext OpenIDConnectContext OpenIDConnectContext Contains optional information about the OpenID Connect request.
+// OpenIDConnectContext Contains optional information about the OpenID Connect request.
 //
 // swagger:model openIDConnectContext
 type OpenIDConnectContext struct {

--- a/internal/httpclient/models/previous_consent_session.go
+++ b/internal/httpclient/models/previous_consent_session.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession The response used to return used consent requests
+// PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession PreviousConsentSession The response used to return used consent requests
 // same as HandledLoginRequest, just with consent_request exposed as json
 //
 // swagger:model PreviousConsentSession
@@ -28,6 +28,7 @@ type PreviousConsentSession struct {
 	GrantScope []string `json:"grant_scope"`
 
 	// handled at
+	// Format: date-time
 	// Format: date-time
 	// Format: date-time
 	// Format: date-time

--- a/internal/httpclient/models/reject_request.go
+++ b/internal/httpclient/models/reject_request.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// RejectRequest The request payload used to accept a login or consent request.
+// RejectRequest RejectRequest The request payload used to accept a login or consent request.
 //
 // swagger:model rejectRequest
 type RejectRequest struct {

--- a/internal/httpclient/models/userinfo_response.go
+++ b/internal/httpclient/models/userinfo_response.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse UserinfoResponse The userinfo response
+// UserinfoResponse The userinfo response
 //
 // swagger:model userinfoResponse
 type UserinfoResponse struct {

--- a/internal/httpclient/models/version.go
+++ b/internal/httpclient/models/version.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// Version version
+// Version Version version
 //
 // swagger:model version
 type Version struct {

--- a/internal/httpclient/models/well_known.go
+++ b/internal/httpclient/models/well_known.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// WellKnown WellKnown WellKnown represents important OpenID Connect discovery metadata
+// WellKnown WellKnown represents important OpenID Connect discovery metadata
 //
 // It includes links to several endpoints (e.g. /oauth2/token) and exposes information on supported signature algorithms
 // among others.


### PR DESCRIPTION
Because viper converts the type from both string and number to time.Duration we can allow both types.
closes #1811