### PR TITLE
strategies.access_token missing in configuration JSON schema

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -619,8 +619,7 @@
           "enum": [
             "opaque",
             "jwt"
-          ],
-          "default": "opaque"
+          ]
         }
       }
     },

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -612,6 +612,15 @@
             "DEPRECATED_HIERARCHICAL_SCOPE_STRATEGY"
           ],
           "default": "wildcard"
+        },
+        "access_token": {
+          "type": "string",
+          "description": "Defines access token type. jwt is a bad idea, see https://www.ory.sh/docs/hydra/advanced#json-web-tokens",
+          "enum": [
+            "opaque",
+            "jwt"
+          ],
+          "default": "opaque"
         }
       }
     },

--- a/driver/configuration/provider_viper_test.go
+++ b/driver/configuration/provider_viper_test.go
@@ -212,6 +212,7 @@ func TestViperProviderValidates(t *testing.T) {
 
 	// strategies
 	assert.Equal(t, "exact", c.ScopeStrategy())
+	assert.Equal(t, "opaque", c.AccessTokenStrategy())
 
 	// ttl
 	assert.Equal(t, 2*time.Hour, c.ConsentRequestMaxAge())

--- a/internal/.hydra.yaml
+++ b/internal/.hydra.yaml
@@ -88,6 +88,7 @@ urls:
 
 strategies:
   scope: exact
+  access_token: opaque
 
 ttl:
   login_consent_request: 2h


### PR DESCRIPTION
## Proposed changes
Configuration JSON schema did not include `strategies.access_token`.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

