### PR TITLE
docs: Adding details about CSRF cookie problems

### DIFF
--- a/docs/versioned_docs/version-v1.5/debugging.mdx
+++ b/docs/versioned_docs/version-v1.5/debugging.mdx
@@ -47,6 +47,7 @@ reverse proxy supports path rewrites that might also cause issues!
 - You are trying to do two OAuth2 flows at the same time in the same Browser.
 - You have changed the Cookie SameSite behavior. If this is the default value (you did not change it), this should
 not be an issue.
+- You are using the `--dangerous-force-http` CLI flag to run via HTTP, but have not changed the Cookie SameSite behaviour. The default value for SameSite setting is `None`, which also requires the cookie be marked as `Secure` which won't be set whilst running Hydra over HTTP.
 
 :::warn
 You cannot call `/oauth2/auth` using an AJAX request. It is not allowed and not possible with OAuth2.


### PR DESCRIPTION
Issue I experienced today, running Hydra 1.4.10 in dangerous HTTP mode, the CSRF cookie defaulted to SameSite=None, but the cookie was not marked as secure (which makes sense, as Hydra is running over HTTP), so the cookie gets ignored (and was getting CSRF value not present errors).

I was able to get around it by either overriding the SameSite setting, or by switching to TLS termination.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Additional line in the docs about CSRF issues if SameSite=None and running over HTTP (the cookie won't be marked as Secure, and modern browsers such as Chrome will just ignore the cookie)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

