### PR TITLE
docs: Adding details about auth creds in body

### DIFF
--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -58,7 +58,7 @@ or by setting in the HTTP API JSON body when POSTing to `/clients`:
 }
 ```
 
-Be aware that when making requests to `/oauth2/token` with a public OAuth 2.0
+Be aware that when making requests to `/oauth2/token` or `/oauth2/revoke` with a public OAuth 2.0
 Client, you can not authenticate with the HTTP Basic Authorization but must
 include the `client_id` in the POST body.
 


### PR DESCRIPTION
## Related issue
Documentation is missing informailtion about auth for /oauth2/revoke endpoint and it conused 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
