### PR TITLE
ci: Make test independent from Nancy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,7 @@ workflows:
               only: /.*/
       - changelog/generate:
           requires:
+            - nancy/test
             - test
             - golangci/lint
             - test-e2e-memory
@@ -213,6 +214,7 @@ workflows:
           appname: Ory_Hydra
           specignorepgks: internal/httpclient -x gopkg.in/square/go-jose.v2
           requires:
+            - nancy/test
             - test
             - golangci/lint
             - test-e2e-memory
@@ -231,6 +233,7 @@ workflows:
       - sdk/release:
           specignorepgks: internal/httpclient -x gopkg.in/square/go-jose.v2
           requires:
+            - nancy/test
             - test
             - golangci/lint
             - sdk/generate
@@ -242,6 +245,7 @@ workflows:
               ignore: /.*/
       - docs/build:
           requires:
+            - nancy/test
             - test
             - golangci/lint
           filters:
@@ -259,6 +263,7 @@ workflows:
         goreleaser/release:
           requires:
             - goreleaser/test
+            - nancy/test
             - test
             - golangci/lint
             - test-e2e-memory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,8 +159,6 @@ workflows:
           tags:
             only: /.*/
       - test:
-          requires:
-            - nancy/test
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
## Proposed changes

CI job `nancy/test` fails if hydra has vulnerable dependencies.
Developers should fix it if it's possible but it's not always possible.
Then I changed workflow to start `test` regardless of `nancy/test` result.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
