### PR TITLE
docs: add hint for login different subject

### DIFF
--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -404,6 +404,20 @@ this value with your own obfuscated `sub` value by setting
 `force_subject_identifier` when accepting the login challenge in your user login
 app.
 
+### Using login_hint with Different Subject
+
+When a user already logged in with a subject(e.g. user-A), and she would like to
+login as another user using login_hint(e.g. login_hint=user-B), directly
+accepting the latter login request in your login provider will make hydra reply:
+`Subject from payload does not match subject from previous authentication`
+
+The suggested flow is:
+
+Check the response from [GET login request](https://www.ory.sh/hydra/docs/reference/api#get-a-login-request), if both the `subject` and `login_hint` are NOT empty and also NOT the same user, redirect UserAgent to `request_url` which is appended with '?prompt=login'. 
+This will make hydra ignore the existing authentication, and allow your login provider to login a different subject.
+
+For more information on `prompt=login` and other options, please check [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+
 ## CORS
 
 Both ORY Hydra's Admin and Public endpoints support CORS. For detailed


### PR DESCRIPTION
Add hint to allow login provider login different subject when there is already an authentication of another subject.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
