### PR TITLE
feat: Error log with request information

### DIFF
--- a/x/errors_test.go
+++ b/x/errors_test.go
@@ -22,6 +22,7 @@ package x
 
 import (
 	"bytes"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -42,18 +43,27 @@ func (s *errStackTracer) Error() string {
 }
 
 func TestLogError(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "https://hydra/some/endpoint", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	buf := bytes.NewBuffer([]byte{})
 	l := logrusx.New("", "", logrusx.ForceLevel(logrus.TraceLevel))
 	l.Logger.Out = buf
-	LogError(errors.New("asdf"), l)
+	LogError(r, errors.New("asdf"), l)
 
 	t.Logf("%s", string(buf.Bytes()))
 
 	assert.True(t, strings.Contains(string(buf.Bytes()), "trace"))
 
-	LogError(errors.Wrap(new(errStackTracer), ""), l)
+	LogError(r, errors.Wrap(new(errStackTracer), ""), l)
 }
 
 func TestLogErrorDoesNotPanic(t *testing.T) {
-	LogError(errors.New("asdf"), nil)
+	r, err := http.NewRequest(http.MethodGet, "https://hydra/some/endpoint", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	LogError(r, errors.New("asdf"), nil)
 }


### PR DESCRIPTION
## Proposed changes

Log errors with request information.

```
$ DSN=memory LOG_LEVEL=info go run main.go serve all
```

Currently, error log doesn't include request information.

```
$ curl -k -X POST "https://localhost:4444/oauth2/token?bar=foo" -H 'Traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'

ERRO[2020-06-05T15:13:43+09:00] An error occurred                             audience=application error=map[message:invalid_request reason:The POST body can not be empty. status:Bad Request status_code:400] service_name= service_version=
```

By this PR, error log includes request information

```
$ curl -k -X POST "https://localhost:4444/oauth2/token?bar=foo" -H 'Traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'

ERRO[2020-06-05T11:51:16+09:00] An error occurred                             audience=application error=map[message:invalid_request reason:The POST body can not be empty. status:Bad Request status_code:400] http_request=map[headers:map[accept:*/* user-agent:curl/7.64.1] host:localhost:4444 method:POST path:/oauth2/token query:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true". remote:[::1]:61568 scheme:https] service_name= service_version= span_id=00f067aa0ba902b7 trace_id=4bf92f3577b34da6a3ce929d0e0e4736
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
