### PR TITLE
fix: same site legacy workaround on iOS 12

### DIFF
--- a/consent/helper.go
+++ b/consent/helper.go
@@ -73,7 +73,7 @@ func createCsrfSession(w http.ResponseWriter, r *http.Request, store sessions.St
 		return errors.WithStack(err)
 	}
 	if sameSiteMode == http.SameSiteNoneMode && sameSiteLegacyWorkaround {
-		return createCsrfSession(w, r, store, legacyCsrfSessionName(name), csrf, secure, http.SameSiteDefaultMode, false)
+		return createCsrfSession(w, r, store, legacyCsrfSessionName(name), csrf, secure, 0, false)
 	}
 	return nil
 }

--- a/consent/helper_test.go
+++ b/consent/helper_test.go
@@ -322,7 +322,7 @@ func TestCreateCsrfSession(t *testing.T) {
 				"csrf_none_fallback_legacy": {
 					httpOnly: true,
 					secure:   true,
-					sameSite: http.SameSiteDefaultMode,
+					sameSite: 0,
 				},
 			},
 		},


### PR DESCRIPTION
## Related issue
Closes: #1907 

## Proposed changes
Enables legacy compatibility on iOS version < 13 and macOS version < 10.15

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

See #1907
