### PR TITLE
feat: Allow modifying unix socket permissions

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -25,6 +25,30 @@
       "minimum": 1,
       "maximum": 65535
     },
+    "socket": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Sets the permissions of the unix socket",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Owner of unix socket. If empty, the owner will be the user running hydra.",
+          "default": ""
+        },
+        "group": {
+          "type": "string",
+          "description": "Group of unix socket. If empty, the group will be the primary group of the user running hydra.",
+          "default": ""
+        },
+        "mode": {
+          "type": "integer",
+          "description": "Mode of unix socket in numeric form",
+          "default": 493,
+          "minimum": 0,
+          "maximum": 511
+        }
+      }
+    },
     "cors": {
       "type": "object",
       "additionalProperties": false,
@@ -246,6 +270,9 @@
             "cors": {
               "$ref": "#/definitions/cors"
             },
+            "socket": {
+              "$ref": "#/definitions/socket"
+            },
             "access_log": {
               "type": "object",
               "additionalProperties": false,
@@ -282,6 +309,9 @@
             },
             "cors": {
               "$ref": "#/definitions/cors"
+            },
+            "socket": {
+              "$ref": "#/definitions/socket"
             },
             "access_log": {
               "type": "object",

--- a/docs/docs/production.md
+++ b/docs/docs/production.md
@@ -114,4 +114,14 @@ like:
 - `ADMIN_HOST="unix:/var/run/hydra/admin_socket"`
 
 ORY Hydra will try to create the socket file during startup and the socket will
-be writeable by the user running ORY Hydra.
+be writeable by the user running ORY Hydra. The owner, group and mode of the
+socket can be modified:
+```yaml
+serve:
+  admin:
+    host: unix:/var/run/hydra/admin_socket
+    socket:
+      owner: hydra
+      group: hydra-admin-api
+      mode: 770
+```

--- a/driver/configuration/helper.go
+++ b/driver/configuration/helper.go
@@ -1,0 +1,53 @@
+package configuration
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+)
+
+type UnixPermission struct {
+	Owner string
+	Group string
+	Mode  os.FileMode
+}
+
+func (p *UnixPermission) SetPermission(file string) error {
+	var e error
+	e = os.Chmod(file, p.Mode)
+	if e != nil {
+		return e
+	}
+
+	gid := -1
+	uid := -1
+
+	if p.Owner != "" {
+		var user_obj *user.User
+		user_obj, e = user.Lookup(p.Owner)
+		if e != nil {
+			return e
+		}
+		uid, e = strconv.Atoi(user_obj.Uid)
+		if e != nil {
+			return e
+		}
+	}
+	if p.Group != "" {
+		var group *user.Group
+		group, e := user.LookupGroup(p.Group)
+		if e != nil {
+			return e
+		}
+		gid, e = strconv.Atoi(group.Gid)
+		if e != nil {
+			return e
+		}
+	}
+
+	e = os.Chown(file, uid, gid)
+	if e != nil {
+		return e
+	}
+	return nil
+}

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -42,8 +42,10 @@ type Provider interface {
 	DataSourcePlugin() string
 	DefaultClientScope() []string
 	AdminListenOn() string
+	AdminSocketPermission() *UnixPermission
 	AdminDisableHealthAccessLog() bool
 	PublicListenOn() string
+	PublicSocketPermission() *UnixPermission
 	PublicDisableHealthAccessLog() bool
 	CookieSameSiteMode() http.SameSite
 	CookieSameSiteLegacyWorkaround() bool

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -47,9 +48,15 @@ const (
 	ViperKeyEncryptSessionData             = "oauth2.session.encrypt_at_rest"
 	ViperKeyAdminListenOnHost              = "serve.admin.host"
 	ViperKeyAdminListenOnPort              = "serve.admin.port"
+	ViperKeyAdminSocketOwner               = "serve.admin.socket.owner"
+	ViperKeyAdminSocketGroup               = "serve.admin.socket.group"
+	ViperKeyAdminSocketMode                = "serve.admin.socket.mode"
 	ViperKeyAdminDisableHealthAccessLog    = "serve.admin.access_log.disable_for_health"
 	ViperKeyPublicListenOnHost             = "serve.public.host"
 	ViperKeyPublicListenOnPort             = "serve.public.port"
+	ViperKeyPublicSocketOwner              = "serve.public.socket.owner"
+	ViperKeyPublicSocketGroup              = "serve.public.socket.group"
+	ViperKeyPublicSocketMode               = "serve.public.socket.mode"
 	ViperKeyPublicDisableHealthAccessLog   = "serve.public.access_log.disable_for_health"
 	ViperKeyCookieSameSiteMode             = "serve.cookies.same_site_mode"
 	ViperKeyCookieSameSiteLegacyWorkaround = "serve.cookies.same_site_legacy_workaround"
@@ -220,12 +227,28 @@ func (v *ViperProvider) publicPort() int {
 	return viperx.GetInt(v.l, ViperKeyPublicListenOnPort, 4444, "PUBLIC_PORT")
 }
 
+func (v *ViperProvider) PublicSocketPermission() *UnixPermission {
+	return &UnixPermission{
+		Owner: viperx.GetString(v.l, ViperKeyPublicSocketOwner, ""),
+		Group: viperx.GetString(v.l, ViperKeyPublicSocketGroup, ""),
+		Mode:  os.FileMode(viperx.GetInt(v.l, ViperKeyPublicSocketMode, 0755)),
+	}
+}
+
 func (v *ViperProvider) adminHost() string {
 	return viperx.GetString(v.l, ViperKeyAdminListenOnHost, "", "ADMIN_HOST")
 }
 
 func (v *ViperProvider) adminPort() int {
 	return viperx.GetInt(v.l, ViperKeyAdminListenOnPort, 4445, "ADMIN_PORT")
+}
+
+func (v *ViperProvider) AdminSocketPermission() *UnixPermission {
+	return &UnixPermission{
+		Owner: viperx.GetString(v.l, ViperKeyAdminSocketOwner, ""),
+		Group: viperx.GetString(v.l, ViperKeyAdminSocketGroup, ""),
+		Mode:  os.FileMode(viperx.GetInt(v.l, ViperKeyAdminSocketMode, 0755)),
+	}
 }
 
 func (v *ViperProvider) CookieSameSiteMode() http.SameSite {

--- a/internal/.hydra.yaml
+++ b/internal/.hydra.yaml
@@ -7,6 +7,10 @@ serve:
   public:
     port: 1
     host: localhost
+    socket:
+      owner: hydra
+      group: hydra-public-api
+      mode: 0775
     cors:
       enabled: false
       allowed_origins:
@@ -26,6 +30,11 @@ serve:
   admin:
     port: 2
     host: localhost
+    socket:
+      owner: hydra
+      group: hydra-admin-api
+      mode: 0770
+
     cors:
       enabled: false
       allowed_origins:

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -91,6 +91,10 @@ serve:
     # Leave empty to listen on all interfaces.
     host: localhost # leave this out or empty to listen on all devices which is the default
     # host: unix:/path/to/socket
+    # socket:
+    #   owner: hydra
+    #   group: hydra
+    #   mode: 0775
 
     # cors configures Cross Origin Resource Sharing for public endpoints.
     cors:
@@ -147,6 +151,10 @@ serve:
     # Leave empty to listen on all interfaces.
     host: localhost # leave this out or empty to listen on all devices which is the default
     # host: unix:/path/to/socket
+    # socket:
+    #   owner: hydra
+    #   group: hydra
+    #   mode: 0775
 
     # cors configures Cross Origin Resource Sharing for admin endpoints.
     cors:


### PR DESCRIPTION
This allows the reverse proxy to actually read the unix socket, since

 - The default permissions are 0755
 - Hydra is usually run as a user different than the reverse proxy
 - One needs read and write permissions to connect to the socket

With the commit, one can set the group to be a group that contains the
reverse proxy user and permissions to 0770

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
