### PR TITLE
fix: Improve Makefile dependency management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           keys:
             - hydra-v1-{{ checksum "go.sum" }}-{{ checksum "Makefile" }}
       - run: go mod download
-      - run: make deps
+      - run: make .bin/go-acc
       - save_cache:
           key: hydra-v1-{{ checksum "go.sum" }}-{{ checksum "Makefile" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,33 @@
 SHELL=/bin/bash -o pipefail
 
-EXECUTABLES = docker-compose docker node npm go
-K := $(foreach exec,$(EXECUTABLES),\
-        $(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH")))
-
 export GO111MODULE := on
 export PATH := .bin:${PATH}
 
-.PHONY: deps
-deps:
-ifneq ("$(shell base64 Makefile))","$(shell cat .bin/.lock)")
+GO_DEPENDENCIES = github.com/ory/go-acc \
+				  github.com/sqs/goreturns \
+				  github.com/ory/x/tools/listx \
+				  github.com/golang/mock/mockgen \
+				  github.com/go-swagger/go-swagger/cmd/swagger \
+				  golang.org/x/tools/cmd/goimports \
+				  github.com/ory/cli \
+				  github.com/gobuffalo/packr/v2/packr2 \
+				  github.com/go-bindata/go-bindata/go-bindata
+
+define make-go-dependency
+  # go install is responsible for not re-building when the code hasn't changed
+  .PHONY: .bin/$(notdir $1)
+  .bin/$(notdir $1):
+		GOBIN=$(PWD)/.bin/ go install $1
+endef
+
+$(foreach dep, $(GO_DEPENDENCIES), $(eval $(call make-go-dependency, $(dep))))
+
+node_modules: package.json
 		npm ci
-		go build -o .bin/go-acc github.com/ory/go-acc
-		go build -o .bin/goreturns github.com/sqs/goreturns
-		go build -o .bin/listx github.com/ory/x/tools/listx
-		go build -o .bin/mockgen github.com/golang/mock/mockgen
-		go build -o .bin/swagger github.com/go-swagger/go-swagger/cmd/swagger
-		go build -o .bin/goimports golang.org/x/tools/cmd/goimports
-		go build -o .bin/ory github.com/ory/cli
-		go build -o .bin/packr2 github.com/gobuffalo/packr/v2/packr2
-		go build -o .bin/go-bindata github.com/go-bindata/go-bindata/go-bindata
-		echo "v0" > .bin/.lock
-		echo "$$(base64 Makefile)" > .bin/.lock
-endif
 
 # Runs full test suite including tests where databases are enabled
 .PHONY: test-legacy-migrations
-test-legacy-migrations: deps
-		make test-resetdb
-		make sqlbin
+test-legacy-migrations: test-resetdb sqlbin
 		source scripts/test-env.sh && go test -tags legacy_migration_test -failfast -timeout=20m ./internal/fizzmigrate
 		docker rm -f hydra_test_database_mysql
 		docker rm -f hydra_test_database_postgres
@@ -36,7 +35,7 @@ test-legacy-migrations: deps
 
 # Runs full test suite including tests where databases are enabled
 .PHONY: test
-test: deps
+test: .bin/go-acc
 		make test-resetdb
 		source scripts/test-env.sh && go-acc ./... -- -failfast -timeout=20m
 		docker rm -f hydra_test_database_mysql
@@ -45,7 +44,7 @@ test: deps
 
 # Resets the test databases
 .PHONY: test-resetdb
-test-resetdb: deps
+test-resetdb: node_modules
 		docker kill hydra_test_database_mysql || true
 		docker kill hydra_test_database_postgres || true
 		docker kill hydra_test_database_cockroach || true
@@ -58,7 +57,7 @@ test-resetdb: deps
 
 # Runs tests in short mode, without database adapters
 .PHONY: docker
-docker: deps
+docker: .bin/packr2
 		packr2
 		CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build
 		packr2 clean
@@ -67,7 +66,7 @@ docker: deps
 		rm hydra
 
 .PHONY: e2e
-e2e: deps test-resetdb
+e2e: node_modules test-resetdb
 		source ./scripts/test-env.sh
 		./test/e2e/circle-ci.bash memory
 		./test/e2e/circle-ci.bash memory-jwt
@@ -87,32 +86,32 @@ quicktest:
 
 # Formats the code
 .PHONY: format
-format: deps
+format: .bin/goreturns node_modules
 		goreturns -w -local github.com/ory $$(listx .)
 		npm run format
 
 # Generates mocks
 .PHONY: mocks
-mocks: deps
+mocks: .bin/mockgen
 		mockgen -package oauth2_test -destination oauth2/oauth2_provider_mock_test.go github.com/ory/fosite OAuth2Provider
 
 # Adds sql files to the binary using go-bindata
 .PHONY: sqlbin
-sqlbin: deps
+sqlbin: .bin/go-bindata
 		cd internal/fizzmigrate/client; go-bindata -o sql_migration_files.go -pkg client ./migrations/sql/...
 		cd internal/fizzmigrate/consent; go-bindata -o sql_migration_files.go -pkg consent ./migrations/sql/...
 		cd internal/fizzmigrate/jwk; go-bindata -o sql_migration_files.go -pkg jwk ./migrations/sql/...
 		cd internal/fizzmigrate/oauth2; go-bindata -o sql_migration_files.go -pkg oauth2 ./migrations/sql/...
 
 # Runs all code generators
-.PHONY: gen deps
+.PHONY: gen
 gen: mocks sqlbin sdk
 
 # Generates the SDKs
 .PHONY: sdk
-sdk: deps
+sdk: .bin/cli
 		swagger generate spec -m -o ./.schema/api.swagger.json -x internal/httpclient,gopkg.in/square/go-jose.v2
-		ory dev swagger sanitize ./.schema/api.swagger.json
+		cli dev swagger sanitize ./.schema/api.swagger.json
 		swagger flatten --with-flatten=remove-unused -o ./.schema/api.swagger.json ./.schema/api.swagger.json
 		swagger validate ./.schema/api.swagger.json
 		rm -rf internal/httpclient
@@ -122,7 +121,7 @@ sdk: deps
 
 
 .PHONY: install-stable
-install-stable: deps
+install-stable: .bin/packr2
 		HYDRA_LATEST=$$(git describe --abbrev=0 --tags)
 		git checkout $$HYDRA_LATEST
 		packr2
@@ -133,7 +132,7 @@ install-stable: deps
 		git checkout master
 
 .PHONY: install
-install: deps
+install: .bin/packr2
 		packr2
 		GO111MODULE=on go install .
 		packr2 clean


### PR DESCRIPTION
This install dependencies only when you make a target that needs it.

This also removes the check that certain system dependencies (e.g. go)
are installed. Instead, we simply let the target fail. This ensures we
only test for the desired dependencies.

Fixes #1916 

Since I don't have the dependencies installed, I'm relying on CI to tell me if this is working properly...

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
