### PR TITLE
fix: logout error hint

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -738,7 +738,7 @@ func (s *DefaultStrategy) issueLogoutVerifier(w http.ResponseWriter, r *http.Req
 
 		if len(state) > 0 {
 			// state can only be set if it's an RP-initiated logout flow. If not, we should throw an error.
-			return nil, errors.WithStack(fosite.ErrInvalidRequest.WithHint("Logout failed because query parameter post_logout_redirect_uri is set but id_token_hint is missing"))
+			return nil, errors.WithStack(fosite.ErrInvalidRequest.WithHint("Logout failed because query parameter state is set but id_token_hint is missing"))
 		}
 
 		if len(requestedRedir) > 0 {

--- a/consent/strategy_default_test.go
+++ b/consent/strategy_default_test.go
@@ -253,7 +253,7 @@ func TestStrategyLogout(t *testing.T) {
 			d:                "should fail if non-rp initiated logout is initiated with state (indicating rp-flow)",
 			params:           url.Values{"state": {"foobar"}},
 			lph:              noopHandler,
-			expectBody:       `{"error":"invalid_request","error_description":"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed","error_hint":"Logout failed because query parameter post_logout_redirect_uri is set but id_token_hint is missing","status_code":400,"request_id":""}`,
+			expectBody:       `{"error":"invalid_request","error_description":"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed","error_hint":"Logout failed because query parameter state is set but id_token_hint is missing","status_code":400,"request_id":""}`,
 			expectStatusCode: http.StatusBadRequest,
 		},
 		{


### PR DESCRIPTION
Simple nitpick to correct a copy/paste error in the error_hint during a failed logout flow (now, with a corrected test case, too ;-) )