### PR TITLE
fix: Revokes all consent sessions of a subject only if explicitly requested

### DIFF
--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -1410,9 +1410,10 @@
           },
           {
             "type": "string",
-            "description": "If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID",
+            "description": "Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID. If set `all`, delete all consent sessions of the Subject",
             "name": "client",
-            "in": "query"
+            "in": "query",
+            "required": true
           }
         ],
         "responses": {

--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -1416,7 +1416,7 @@
           },
           {
             "type": "boolean",
-            "description": "If set, deletes all consent sessions by the Subject that have been granted",
+            "description": "If set to `?all=true`, deletes all consent sessions by the Subject that have been granted.",
             "name": "all",
             "in": "query"
           }

--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -1410,10 +1410,15 @@
           },
           {
             "type": "string",
-            "description": "Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID. If set `all`, delete all consent sessions of the Subject",
+            "description": "Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID.",
             "name": "client",
-            "in": "query",
-            "required": true
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "Deletes all consent sessions by the Subject that have been granted.",
+            "name": "all",
+            "in": "query"
           }
         ],
         "responses": {

--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -1410,13 +1410,13 @@
           },
           {
             "type": "string",
-            "description": "Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID.",
+            "description": "If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID",
             "name": "client",
             "in": "query"
           },
           {
             "type": "boolean",
-            "description": "Deletes all consent sessions by the Subject that have been granted.",
+            "description": "If set, deletes all consent sessions by the Subject that have been granted",
             "name": "all",
             "in": "query"
           }

--- a/consent/doc.go
+++ b/consent/doc.go
@@ -49,16 +49,14 @@ type swaggerRevokeConsentSessions struct {
 	// required: true
 	Subject string `json:"subject"`
 
-	// Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID.
+	// If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID
 	//
 	// in: query
-	// required: false
 	Client string `json:"client"`
 
-	// Deletes all consent sessions by the Subject that have been granted.
+	// If set, deletes all consent sessions by the Subject that have been granted
 	//
 	// in: query
-	// required: false
 	All bool `json:"all"`
 }
 

--- a/consent/doc.go
+++ b/consent/doc.go
@@ -54,7 +54,7 @@ type swaggerRevokeConsentSessions struct {
 	// in: query
 	Client string `json:"client"`
 
-	// If set, deletes all consent sessions by the Subject that have been granted
+	// If set to `?all=true`, deletes all consent sessions by the Subject that have been granted.
 	//
 	// in: query
 	All bool `json:"all"`

--- a/consent/doc.go
+++ b/consent/doc.go
@@ -49,11 +49,17 @@ type swaggerRevokeConsentSessions struct {
 	// required: true
 	Subject string `json:"subject"`
 
-	// Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID. If set `all`, delete all consent sessions of the Subject
+	// Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID.
 	//
 	// in: query
-	// required: true
+	// required: false
 	Client string `json:"client"`
+
+	// Deletes all consent sessions by the Subject that have been granted.
+	//
+	// in: query
+	// required: false
+	All bool `json:"all"`
 }
 
 // swagger:parameters listSubjectConsentSessions

--- a/consent/doc.go
+++ b/consent/doc.go
@@ -49,9 +49,10 @@ type swaggerRevokeConsentSessions struct {
 	// required: true
 	Subject string `json:"subject"`
 
-	// If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID
+	// Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID. If set `all`, delete all consent sessions of the Subject
 	//
 	// in: query
+	// required: true
 	Client string `json:"client"`
 }
 

--- a/consent/handler.go
+++ b/consent/handler.go
@@ -108,13 +108,18 @@ func (h *Handler) DeleteConsentSession(w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
-	if len(client) > 0 {
-		if err := h.r.ConsentManager().RevokeSubjectClientConsentSession(r.Context(), subject, client); err != nil {
+	if client == "" {
+		h.r.Writer().WriteError(w, r, errors.WithStack(fosite.ErrInvalidRequest.WithHint(`Query parameter "client" is not defined but should have been.`)))
+		return
+	}
+
+	if client == "all" {
+		if err := h.r.ConsentManager().RevokeSubjectConsentSession(r.Context(), subject); err != nil {
 			h.r.Writer().WriteError(w, r, err)
 			return
 		}
 	} else {
-		if err := h.r.ConsentManager().RevokeSubjectConsentSession(r.Context(), subject); err != nil {
+		if err := h.r.ConsentManager().RevokeSubjectClientConsentSession(r.Context(), subject, client); err != nil {
 			h.r.Writer().WriteError(w, r, err)
 			return
 		}

--- a/consent/handler.go
+++ b/consent/handler.go
@@ -103,26 +103,26 @@ func (h *Handler) SetRoutes(admin *x.RouterAdmin) {
 func (h *Handler) DeleteConsentSession(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	subject := r.URL.Query().Get("subject")
 	client := r.URL.Query().Get("client")
+	allClients := r.URL.Query().Get("all") == "true"
 	if subject == "" {
 		h.r.Writer().WriteError(w, r, errors.WithStack(fosite.ErrInvalidRequest.WithHint(`Query parameter "subject" is not defined but should have been.`)))
 		return
 	}
 
-	if client == "" {
-		h.r.Writer().WriteError(w, r, errors.WithStack(fosite.ErrInvalidRequest.WithHint(`Query parameter "client" is not defined but should have been.`)))
-		return
-	}
-
-	if client == "all" {
-		if err := h.r.ConsentManager().RevokeSubjectConsentSession(r.Context(), subject); err != nil {
-			h.r.Writer().WriteError(w, r, err)
-			return
-		}
-	} else {
+	switch {
+	case len(client) > 0:
 		if err := h.r.ConsentManager().RevokeSubjectClientConsentSession(r.Context(), subject, client); err != nil {
 			h.r.Writer().WriteError(w, r, err)
 			return
 		}
+	case allClients:
+		if err := h.r.ConsentManager().RevokeSubjectConsentSession(r.Context(), subject); err != nil {
+			h.r.Writer().WriteError(w, r, err)
+			return
+		}
+	default:
+		h.r.Writer().WriteError(w, r, errors.WithStack(fosite.ErrInvalidRequest.WithHint(`Query parameter both "client" and "all" is not defined but one of them should have been.`)))
+		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/consent/sdk_test.go
+++ b/consent/sdk_test.go
@@ -75,14 +75,18 @@ func TestSDK(t *testing.T) {
 	cr1, hcr1 := MockConsentRequest("1", false, 0, false, false, false)
 	cr2, hcr2 := MockConsentRequest("2", false, 0, false, false, false)
 	cr3, hcr3 := MockConsentRequest("3", true, 3600, false, false, false)
+	cr4, hcr4 := MockConsentRequest("4", true, 3600, false, false, false)
 	require.NoError(t, m.CreateConsentRequest(context.TODO(), cr1))
 	require.NoError(t, m.CreateConsentRequest(context.TODO(), cr2))
 	require.NoError(t, m.CreateConsentRequest(context.TODO(), cr3))
+	require.NoError(t, m.CreateConsentRequest(context.TODO(), cr4))
 	_, err := m.HandleConsentRequest(context.TODO(), "challenge1", hcr1)
 	require.NoError(t, err)
 	_, err = m.HandleConsentRequest(context.TODO(), "challenge2", hcr2)
 	require.NoError(t, err)
 	_, err = m.HandleConsentRequest(context.TODO(), "challenge3", hcr3)
+	require.NoError(t, err)
+	_, err = m.HandleConsentRequest(context.TODO(), "challenge4", hcr4)
 	require.NoError(t, err)
 
 	lur1 := MockLogoutRequest("testsdk-1", true)
@@ -113,7 +117,10 @@ func TestSDK(t *testing.T) {
 	_, err = sdk.Admin.RevokeConsentSessions(admin.NewRevokeConsentSessionsParams().WithSubject("subject1"))
 	require.Error(t, err)
 
-	_, err = sdk.Admin.RevokeConsentSessions(admin.NewRevokeConsentSessionsParams().WithSubject("subject1").WithClient("client1"))
+	_, err = sdk.Admin.RevokeConsentSessions(admin.NewRevokeConsentSessionsParams().WithSubject(cr4.Subject).WithClient(&cr4.Client.ID))
+	require.NoError(t, err)
+
+	_, err = sdk.Admin.RevokeConsentSessions(admin.NewRevokeConsentSessionsParams().WithSubject("subject1").WithAll(pointerx.Bool(true)))
 	require.NoError(t, err)
 
 	_, err = sdk.Admin.GetConsentRequest(admin.NewGetConsentRequestParams().WithConsentChallenge("challenge1"))

--- a/consent/sdk_test.go
+++ b/consent/sdk_test.go
@@ -111,6 +111,9 @@ func TestSDK(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = sdk.Admin.RevokeConsentSessions(admin.NewRevokeConsentSessionsParams().WithSubject("subject1"))
+	require.Error(t, err)
+
+	_, err = sdk.Admin.RevokeConsentSessions(admin.NewRevokeConsentSessionsParams().WithSubject("subject1").WithClient("client1"))
 	require.NoError(t, err)
 
 	_, err = sdk.Admin.GetConsentRequest(admin.NewGetConsentRequestParams().WithConsentChallenge("challenge1"))

--- a/cypress/integration/oauth2/consent.js
+++ b/cypress/integration/oauth2/consent.js
@@ -48,7 +48,7 @@ describe('OAuth 2.0 End-User Authorization', () => {
     cy.request(
       'DELETE',
       Cypress.env('admin_url') +
-        '/oauth2/auth/sessions/consent?subject=foo@bar.com'
+        '/oauth2/auth/sessions/consent?subject=foo@bar.com&all=true'
     );
 
     cy.request(

--- a/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
+++ b/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewRevokeConsentSessionsParams creates a new RevokeConsentSessionsParams object
@@ -60,8 +61,13 @@ for the revoke consent sessions operation typically these are written to a http.
 */
 type RevokeConsentSessionsParams struct {
 
+	/*All
+	  Deletes all consent sessions by the Subject that have been granted.
+
+	*/
+	All *bool
 	/*Client
-	  If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID
+	  Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID.
 
 	*/
 	Client *string
@@ -109,6 +115,17 @@ func (o *RevokeConsentSessionsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithAll adds the all to the revoke consent sessions params
+func (o *RevokeConsentSessionsParams) WithAll(all *bool) *RevokeConsentSessionsParams {
+	o.SetAll(all)
+	return o
+}
+
+// SetAll adds the all to the revoke consent sessions params
+func (o *RevokeConsentSessionsParams) SetAll(all *bool) {
+	o.All = all
+}
+
 // WithClient adds the client to the revoke consent sessions params
 func (o *RevokeConsentSessionsParams) WithClient(client *string) *RevokeConsentSessionsParams {
 	o.SetClient(client)
@@ -138,6 +155,22 @@ func (o *RevokeConsentSessionsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
+
+	if o.All != nil {
+
+		// query param all
+		var qrAll bool
+		if o.All != nil {
+			qrAll = *o.All
+		}
+		qAll := swag.FormatBool(qrAll)
+		if qAll != "" {
+			if err := r.SetQueryParam("all", qAll); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	if o.Client != nil {
 

--- a/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
+++ b/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
@@ -62,7 +62,7 @@ for the revoke consent sessions operation typically these are written to a http.
 type RevokeConsentSessionsParams struct {
 
 	/*All
-	  If set, deletes all consent sessions by the Subject that have been granted
+	  If set to `?all=true`, deletes all consent sessions by the Subject that have been granted.
 
 	*/
 	All *bool

--- a/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
+++ b/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
@@ -62,12 +62,12 @@ for the revoke consent sessions operation typically these are written to a http.
 type RevokeConsentSessionsParams struct {
 
 	/*All
-	  Deletes all consent sessions by the Subject that have been granted.
+	  If set, deletes all consent sessions by the Subject that have been granted
 
 	*/
 	All *bool
 	/*Client
-	  Deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID.
+	  If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID
 
 	*/
 	Client *string


### PR DESCRIPTION
## Related issue

close #1951

## Proposed changes

Revokes all consent sessions of a subject only if `client` URL parameter is set `all` value.
An error returns if it's called without `client` URL parameter.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
