### PR TITLE
feat: add and automate version schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,13 @@ workflows:
             tags:
               only: /.*/
       -
+        goreleaser/render-version-schema:
+          requires:
+            - goreleaser/release
+          filters:
+            tags:
+              only: /.*/
+      -
         goreleaser/newsletter-draft:
           chimp-list: f605a41b53
           chimp-segment: 6479481

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -971,6 +971,12 @@
           }
         }
       }
+    },
+    "version": {
+      "type": "string",
+      "title": "The Hydra version this config is written for.",
+      "description": "SemVer according to https://semver.org/ prefixed with `v` as in our releases.",
+      "pattern": "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     }
   }
 }

--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/ory/kratos/.schema/versions.config.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ory/cli/v0.0.21/.schema/version_meta.schema.json#",
+  "title": "All Versions of the ORY Hydra Configuration",
+  "type": "object",
+  "oneOf": [
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v1.7.0"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.7.0/.schema/config.schema.json"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Related issue

prepares #1986 

## Proposed changes

Analogously to kratos this adds:
- config top level version key
- ory/goreleaser/render-version-schema automation
- the version schema itself

## Further comments

When this is merged we can make a PR to schemastore.org