### PR TITLE
autogen: add v1.7.4 to version.schema.json

### DIFF
--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -1,22 +1,36 @@
 {
-  "$id": "https://github.com/ory/kratos/.schema/versions.config.schema.json",
-  "$schema": "https://raw.githubusercontent.com/ory/cli/v0.0.21/.schema/version_meta.schema.json#",
-  "title": "All Versions of the ORY Hydra Configuration",
-  "type": "object",
-  "oneOf": [
-    {
-      "allOf": [
+    "$id": "https://github.com/ory/kratos/.schema/versions.config.schema.json",
+    "$schema": "https://raw.githubusercontent.com/ory/cli/v0.0.21/.schema/version_meta.schema.json#",
+    "title": "All Versions of the ORY Hydra Configuration",
+    "type": "object",
+    "oneOf": [
         {
-          "properties": {
-            "version": {
-              "const": "v1.7.0"
-            }
-          }
+            "allOf": [
+                {
+                    "properties": {
+                        "version": {
+                            "const": "v1.7.0"
+                        }
+                    }
+                },
+                {
+                    "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.7.0/.schema/config.schema.json"
+                }
+            ]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.7.0/.schema/config.schema.json"
+            "allOf": [
+                {
+                    "properties": {
+                        "version": {
+                            "const": "v1.7.4"
+                        }
+                    }
+                },
+                {
+                    "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.7.4/.schema/config.schema.json"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
## Related issue

Rendering the version schema and pushing it failed during the release in CCI. This is the commit that was not pushed. The automation is updated independently.

## Proposed changes

Add the latest release to the version schema.

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

This commit comes from CCI.