### PR TITLE
WIP: Downgrade log level for access rejections as a consequence of invalid credentials/expired token

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -551,10 +551,12 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	accessRequest, err := h.r.OAuth2Provider().NewAccessRequest(ctx, r, session)
 
 	if err != nil {
-		switch err.Error() {
-		case fosite.ErrServerError.Error():
-		case fosite.ErrTemporarilyUnavailable.Error():
-		case fosite.ErrMisconfiguration.Error():
+		switch errors.Cause(err) {
+		case fosite.ErrServerError:
+			fallthrough
+		case fosite.ErrTemporarilyUnavailable:
+			fallthrough
+		case fosite.ErrMisconfiguration:
 			x.LogError(r, err, h.r.Logger())
 		default:
 			x.LogAudit(r, err, h.r.Logger())
@@ -596,15 +598,16 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	accessResponse, err := h.r.OAuth2Provider().NewAccessResponse(ctx, accessRequest)
 
 	if err != nil {
-		switch err.Error() {
-		case fosite.ErrServerError.Error():
-		case fosite.ErrTemporarilyUnavailable.Error():
-		case fosite.ErrMisconfiguration.Error():
+		switch errors.Cause(err) {
+		case fosite.ErrServerError:
+			fallthrough
+		case fosite.ErrTemporarilyUnavailable:
+			fallthrough
+		case fosite.ErrMisconfiguration:
 			x.LogError(r, err, h.r.Logger())
 		default:
 			x.LogAudit(r, err, h.r.Logger())
 		}
-
 		h.r.OAuth2Provider().WriteAccessError(w, accessRequest, err)
 		return
 	}

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -549,8 +549,16 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	var ctx = r.Context()
 
 	accessRequest, err := h.r.OAuth2Provider().NewAccessRequest(ctx, r, session)
+
 	if err != nil {
-		x.LogError(r, err, h.r.Logger())
+		switch err.Error() {
+		case fosite.ErrServerError.Error():
+		case fosite.ErrTemporarilyUnavailable.Error():
+		case fosite.ErrMisconfiguration.Error():
+			x.LogError(r, err, h.r.Logger())
+		default:
+			x.LogAudit(r, err, h.r.Logger())
+		}
 		h.r.OAuth2Provider().WriteAccessError(w, accessRequest, err)
 		return
 	}
@@ -586,8 +594,17 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	accessResponse, err := h.r.OAuth2Provider().NewAccessResponse(ctx, accessRequest)
+
 	if err != nil {
-		x.LogAudit(r, err, h.r.Logger())
+		switch err.Error() {
+		case fosite.ErrServerError.Error():
+		case fosite.ErrTemporarilyUnavailable.Error():
+		case fosite.ErrMisconfiguration.Error():
+			x.LogError(r, err, h.r.Logger())
+		default:
+			x.LogAudit(r, err, h.r.Logger())
+		}
+
 		h.r.OAuth2Provider().WriteAccessError(w, accessRequest, err)
 		return
 	}

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -425,7 +425,7 @@ func (h *Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request, _ ht
 
 	tt, ar, err := h.r.OAuth2Provider().IntrospectToken(ctx, token, fosite.TokenType(tokenType), session, strings.Split(scope, " ")...)
 	if err != nil {
-		x.LogError(r, err, h.r.Logger())
+		x.LogAudit(r, err, h.r.Logger())
 		err := errors.WithStack(fosite.ErrInactiveToken.WithHint("An introspection strategy indicated that the token is inactive.").WithDebug(err.Error()))
 		h.r.OAuth2Provider().WriteIntrospectionError(w, err)
 		return
@@ -587,7 +587,7 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	accessResponse, err := h.r.OAuth2Provider().NewAccessResponse(ctx, accessRequest)
 	if err != nil {
-		x.LogError(r, err, h.r.Logger())
+		x.LogAudit(r, err, h.r.Logger())
 		h.r.OAuth2Provider().WriteAccessError(w, accessRequest, err)
 		return
 	}


### PR DESCRIPTION
## Related issue

[#2031](https://github.com/ory/hydra/issues/2031)

## Proposed changes

Invalid credentials or an expired token is a normal thing to happen and should be logged on "info" level, not on "error" level as is currently the case.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments


