### PR TITLE
docs: minor text typo for limitations.md

### DIFF
--- a/docs/docs/limitations.md
+++ b/docs/docs/limitations.md
@@ -14,7 +14,7 @@ Our recommendation is to use MySQL 5.7+ or PostgreSQL.
 
 ## OAuth 2.0 Client Secret Length
 
-OAuth 2.0 Client Secrets are hashed using BCrypt. BCrypt has, by design, an
+OAuth 2.0 Client Secrets are hashed using BCrypt. BCrypt has, by design, a
 maximum password length. The Golang BCrypt library has a maximum password length
 of 73 bytes. Any password longer will be "truncated":
 


### PR DESCRIPTION
It said "an maximum" but I believe it should be "a maximum".

