### PR TITLE
docs: fixed broken link to config docs displayed on hydra serve help

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,7 +32,7 @@ var serveControls = `## Configuration
 ORY Hydra can be configured using environment variables as well as a configuration file. For more information
 on configuration options, open the configuration documentation:
 
->> https://github.com/ory/hydra/blob/` + Commit + `/docs/config.yaml <<
+>> https://github.com/ory/hydra/blob/` + Commit + `/docs/docs/reference/configuration.md <<
 `
 
 // serveCmd represents the host command


### PR DESCRIPTION
## Related issue

#2065 

## Proposed changes

Fixed broken link to config docs displayed on `hydra serve` help following the recommendations from @tacurran.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
