### PR TITLE
feat: metrics prometheus endpoint should not require x-forwarded-proto header

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -39,25 +39,24 @@ import (
 	"github.com/ory/x/logrusx"
 	"github.com/ory/x/reqlog"
 
-	"github.com/ory/hydra/driver"
-	"github.com/ory/hydra/driver/configuration"
-	"github.com/ory/hydra/x"
-
 	"github.com/julienschmidt/httprouter"
 	"github.com/rs/cors"
 	"github.com/spf13/cobra"
 	"github.com/urfave/negroni"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/ory/graceful"
 	"github.com/ory/x/healthx"
 	"github.com/ory/x/metricsx"
 
-	"go.uber.org/automaxprocs/maxprocs"
-
 	"github.com/ory/hydra/client"
 	"github.com/ory/hydra/consent"
+	"github.com/ory/hydra/driver"
+	"github.com/ory/hydra/driver/configuration"
 	"github.com/ory/hydra/jwk"
+	"github.com/ory/hydra/metrics/prometheus"
 	"github.com/ory/hydra/oauth2"
+	"github.com/ory/hydra/x"
 )
 
 var _ = &consent.Handler{}
@@ -272,7 +271,7 @@ func setup(d driver.Driver, cmd *cobra.Command) (admin *x.RouterAdmin, public *x
 				healthx.AliveCheckPath,
 				healthx.ReadyCheckPath,
 				healthx.VersionPath,
-				driver.MetricsPrometheusPath,
+				prometheus.MetricsPrometheusPath,
 				"/",
 			},
 			BuildVersion: d.Registry().BuildVersion(),

--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -35,10 +35,6 @@ import (
 	"github.com/ory/hydra/x"
 )
 
-const (
-	MetricsPrometheusPath = "/metrics/prometheus"
-)
-
 type RegistryBase struct {
 	l            *logrusx.Logger
 	al           *logrusx.Logger
@@ -104,7 +100,7 @@ func (m *RegistryBase) RegisterRoutes(admin *x.RouterAdmin, public *x.RouterPubl
 	public.GET(healthx.AliveCheckPath, m.HealthHandler().Alive)
 	public.GET(healthx.ReadyCheckPath, m.HealthHandler().Ready(false))
 
-	admin.Handler("GET", MetricsPrometheusPath, promhttp.Handler())
+	admin.Handler("GET", prometheus.MetricsPrometheusPath, promhttp.Handler())
 
 	m.ConsentHandler().SetRoutes(admin)
 	m.KeyHandler().SetRoutes(admin, public, m.OAuth2AwareMiddleware())

--- a/metrics/prometheus/doc.go
+++ b/metrics/prometheus/doc.go
@@ -14,6 +14,9 @@ package prometheus
 //      prometheus.io/path: "/metrics/prometheus"
 // ```
 //
+// If the service supports TLS Edge Termination, this endpoint does not require the
+// `X-Forwarded-Proto` header to be set.
+//
 //     Produces:
 //     - plain/text
 //

--- a/metrics/prometheus/metrics.go
+++ b/metrics/prometheus/metrics.go
@@ -1,5 +1,9 @@
 package prometheus
 
+const (
+	MetricsPrometheusPath = "/metrics/prometheus"
+)
+
 // Metrics prototypes
 // Example:
 // 	Counter      *prometheus.CounterVec

--- a/x/tls_termination.go
+++ b/x/tls_termination.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/negroni"
 
+	"github.com/ory/hydra/metrics/prometheus"
 	"github.com/ory/x/healthx"
 	"github.com/ory/x/stringsx"
 )
@@ -51,7 +52,11 @@ type tlsConfig interface {
 
 func RejectInsecureRequests(reg tlsRegistry, c tlsConfig) negroni.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-		if r.TLS != nil || !c.ServesHTTPS() || r.URL.Path == healthx.AliveCheckPath || r.URL.Path == healthx.ReadyCheckPath {
+		if r.TLS != nil ||
+			!c.ServesHTTPS() ||
+			r.URL.Path == healthx.AliveCheckPath ||
+			r.URL.Path == healthx.ReadyCheckPath ||
+			r.URL.Path == prometheus.MetricsPrometheusPath {
 			next.ServeHTTP(rw, r)
 			return
 		}

--- a/x/tls_termination_test.go
+++ b/x/tls_termination_test.go
@@ -35,18 +35,40 @@ func TestDoesRequestSatisfyTermination(t *testing.T) {
 		assert.EqualValues(t, http.StatusBadGateway, res.Code)
 	})
 
-	t.Run("case=forced-http", func(t *testing.T) {
-		c := internal.NewConfigurationWithDefaults()
+	// change: x-forwarded-proto is checked after cidr, therefor it will never actually test header
+	t.Run("case=missing-x-forwarded-proto", func(t *testing.T) {
+		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
+
 		res := httptest.NewRecorder()
-		RejectInsecureRequests(r, c)(res, &http.Request{Header: http.Header{}, URL: new(url.URL)}, noopHandler)
-		assert.EqualValues(t, http.StatusNoContent, res.Code)
+		RejectInsecureRequests(r, c)(res, &http.Request{
+			RemoteAddr: "127.0.0.1:123",
+			Header:     http.Header{},
+			URL:        new(url.URL)},
+			panicHandler,
+		)
+		assert.EqualValues(t, http.StatusBadGateway, res.Code)
+	})
+
+	// change: x-forwarded-proto is checked after cidr, therefor it will never actually test header with "http"
+	t.Run("case=x-forwarded-proto-is-http", func(t *testing.T) {
+		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
+
+		res := httptest.NewRecorder()
+		RejectInsecureRequests(r, c)(res, &http.Request{
+			RemoteAddr: "127.0.0.1:123",
+			Header: http.Header{
+				"X-Forwarded-Proto": []string{"http"},
+			}, URL: new(url.URL)},
+			panicHandler,
+		)
+		assert.EqualValues(t, http.StatusBadGateway, res.Code)
 	})
 
 	t.Run("case=missing-x-forwarded-for", func(t *testing.T) {
 		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
 
 		res := httptest.NewRecorder()
-		RejectInsecureRequests(r, c)(res, &http.Request{Header: http.Header{}, URL: new(url.URL)}, panicHandler)
+		RejectInsecureRequests(r, c)(res, &http.Request{Header: http.Header{"X-Forwarded-Proto": []string{"https"}}, URL: new(url.URL)}, panicHandler)
 		assert.EqualValues(t, http.StatusBadGateway, res.Code)
 	})
 
@@ -91,47 +113,7 @@ func TestDoesRequestSatisfyTermination(t *testing.T) {
 		assert.EqualValues(t, http.StatusNoContent, res.Code)
 	})
 
-	t.Run("case=missing-x-forwarded-proto", func(t *testing.T) {
-		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
-
-		res := httptest.NewRecorder()
-		RejectInsecureRequests(r, c)(res, &http.Request{
-			RemoteAddr: "127.0.0.1:123",
-			Header:     http.Header{},
-			URL:        new(url.URL)},
-			panicHandler,
-		)
-		assert.EqualValues(t, http.StatusBadGateway, res.Code)
-	})
-
-	t.Run("case=x-forwarded-proto-is-http", func(t *testing.T) {
-		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
-
-		res := httptest.NewRecorder()
-		RejectInsecureRequests(r, c)(res, &http.Request{
-			RemoteAddr: "127.0.0.1:123",
-			Header: http.Header{
-				"X-Forwarded-Proto": []string{"http"},
-			}, URL: new(url.URL)},
-			panicHandler,
-		)
-		assert.EqualValues(t, http.StatusBadGateway, res.Code)
-	})
-
-	t.Run("case=remote-matches-cidr", func(t *testing.T) {
-		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
-
-		res := httptest.NewRecorder()
-		RejectInsecureRequests(r, c)(res, &http.Request{
-			RemoteAddr: "127.0.0.1:123",
-			Header: http.Header{
-				"X-Forwarded-Proto": []string{"https"},
-			}, URL: new(url.URL)},
-			noopHandler,
-		)
-		assert.EqualValues(t, http.StatusNoContent, res.Code)
-	})
-
+	// change: cidr and x-forwarded-proto headers are irrelevant for this test
 	t.Run("case=passes-because-health-alive-endpoint", func(t *testing.T) {
 		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
 
@@ -146,6 +128,7 @@ func TestDoesRequestSatisfyTermination(t *testing.T) {
 		assert.EqualValues(t, http.StatusNoContent, res.Code)
 	})
 
+	// change: cidr and x-forwarded-proto headers are irrelevant for this test
 	t.Run("case=passes-because-health-ready-endpoint", func(t *testing.T) {
 		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
 
@@ -154,20 +137,6 @@ func TestDoesRequestSatisfyTermination(t *testing.T) {
 			RemoteAddr: "227.0.0.1:123",
 			Header:     http.Header{},
 			URL:        &url.URL{Path: "/health/alive"},
-		},
-			noopHandler,
-		)
-		assert.EqualValues(t, http.StatusNoContent, res.Code)
-	})
-
-	t.Run("case=passes-because-metrics-prometheus-endpoint", func(t *testing.T) {
-		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
-
-		res := httptest.NewRecorder()
-		RejectInsecureRequests(r, c)(res, &http.Request{
-			RemoteAddr: "227.0.0.1:123",
-			Header:     http.Header{},
-			URL:        &url.URL{Path: "/metrics/prometheus"},
 		},
 			noopHandler,
 		)
@@ -199,6 +168,29 @@ func TestDoesRequestSatisfyTermination(t *testing.T) {
 				"X-Forwarded-For":   []string{"227.0.0.1,127.0.0.1,227.0.0.2"},
 				"X-Forwarded-Proto": []string{"https"},
 			}, URL: new(url.URL)},
+			noopHandler,
+		)
+		assert.EqualValues(t, http.StatusNoContent, res.Code)
+	})
+
+	// test: in case http is forced request should be accepted
+	t.Run("case=forced-http", func(t *testing.T) {
+		c := internal.NewConfigurationWithDefaults()
+		res := httptest.NewRecorder()
+		RejectInsecureRequests(r, c)(res, &http.Request{Header: http.Header{}, URL: new(url.URL)}, noopHandler)
+		assert.EqualValues(t, http.StatusNoContent, res.Code)
+	})
+
+	// test: prometheus endpoint should accept request
+	t.Run("case=passes-because-metrics-prometheus-endpoint", func(t *testing.T) {
+		viper.Set(configuration.ViperKeyAllowTLSTerminationFrom, "126.0.0.1/24,127.0.0.1/24")
+
+		res := httptest.NewRecorder()
+		RejectInsecureRequests(r, c)(res, &http.Request{
+			RemoteAddr: "227.0.0.1:123",
+			Header:     http.Header{},
+			URL:        &url.URL{Path: "/metrics/prometheus"},
+		},
 			noopHandler,
 		)
 		assert.EqualValues(t, http.StatusNoContent, res.Code)


### PR DESCRIPTION
The purpose of this PR is to allow /metrics/prometheus endpoint to be invoked without https or x-forwarded-proto: https header.
In some cases prometheus is already in cluster behind LBS and (without a lot of hassle) it does not set this header.

changes:

- moved MetricsPrometheusPath constant to metrics/prometheus/metrics.go
- added rule to allow insecure requests for MetricsPrometheusPath endpoint (the same as for health routes)
- arranged tls_termination_test.go test to cover all cases in RejectInsecureRequests function

relates to issue #2072
@aeneasr , please take a look at this PR

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

