### PR TITLE
docs: fix typo "pariwise" on advanced flows page

### DIFF
--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -111,7 +111,7 @@ reasons:
    token was revoked, which however defeats the purpose of using JSON Web Tokens
    in the first place.
 4. **Certain OpenID Connect features will not work** when using JSON Web Tokens
-   as Access Tokens, such as the pariwise subject identifier algorithm.
+   as Access Tokens, such as the pairwise subject identifier algorithm.
 5. **There is a better solution: Use
    [ORY Oathkeeper](https://github.com/ory/oathkeeper)!** ORY Oathkeeper is a
    proxy you deploy in front of your services. It will "convert" ORY Hydra's

--- a/docs/versioned_docs/version-v1.4/advanced.md
+++ b/docs/versioned_docs/version-v1.4/advanced.md
@@ -235,7 +235,7 @@ reasons:
    token was revoked, which however defeats the purpose of using JSON Web Tokens
    in the first place.
 4. **Certain OpenID Connect features will not work** when using JSON Web Tokens
-   as Access Tokens, such as the pariwise subject identifier algorithm.
+   as Access Tokens, such as the pairwise subject identifier algorithm.
 5. **There is a better solution: Use
    [ORY Oathkeeper](https://github.com/ory/oathkeeper)!** ORY Oathkeeper is a
    proxy you deploy in front of your services. It will "convert" ORY Hydra's

--- a/docs/versioned_docs/version-v1.5/advanced.md
+++ b/docs/versioned_docs/version-v1.5/advanced.md
@@ -235,7 +235,7 @@ reasons:
    token was revoked, which however defeats the purpose of using JSON Web Tokens
    in the first place.
 4. **Certain OpenID Connect features will not work** when using JSON Web Tokens
-   as Access Tokens, such as the pariwise subject identifier algorithm.
+   as Access Tokens, such as the pairwise subject identifier algorithm.
 5. **There is a better solution: Use
    [ORY Oathkeeper](https://github.com/ory/oathkeeper)!** ORY Oathkeeper is a
    proxy you deploy in front of your services. It will "convert" ORY Hydra's

--- a/docs/versioned_docs/version-v1.6/advanced.md
+++ b/docs/versioned_docs/version-v1.6/advanced.md
@@ -111,7 +111,7 @@ reasons:
    token was revoked, which however defeats the purpose of using JSON Web Tokens
    in the first place.
 4. **Certain OpenID Connect features will not work** when using JSON Web Tokens
-   as Access Tokens, such as the pariwise subject identifier algorithm.
+   as Access Tokens, such as the pairwise subject identifier algorithm.
 5. **There is a better solution: Use
    [ORY Oathkeeper](https://github.com/ory/oathkeeper)!** ORY Oathkeeper is a
    proxy you deploy in front of your services. It will "convert" ORY Hydra's

--- a/docs/versioned_docs/version-v1.7/advanced.md
+++ b/docs/versioned_docs/version-v1.7/advanced.md
@@ -111,7 +111,7 @@ reasons:
    token was revoked, which however defeats the purpose of using JSON Web Tokens
    in the first place.
 4. **Certain OpenID Connect features will not work** when using JSON Web Tokens
-   as Access Tokens, such as the pariwise subject identifier algorithm.
+   as Access Tokens, such as the pairwise subject identifier algorithm.
 5. **There is a better solution: Use
    [ORY Oathkeeper](https://github.com/ory/oathkeeper)!** ORY Oathkeeper is a
    proxy you deploy in front of your services. It will "convert" ORY Hydra's


### PR DESCRIPTION
## Related issue

If necessary I can file a new issue for this work but I felt it was not necessary given how simple the fix is.

## Proposed changes

Fixed a typo on the "Advanced OAuth2 and OpenID Connect Flows" (`s/pariwise/pairwise/`).

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added or changed [the documentation](docs/docs).