### PR TITLE
fix: updated to golang 1.15.2 and consitant alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To compile this image manually run:
 #
 # $ GO111MODULE=on GOOS=linux GOARCH=amd64 go build && docker build -t oryd/hydra:v1.0.0-rc.7_oryOS.10 . && rm hydra
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk add -U --no-cache ca-certificates
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,7 +1,7 @@
 # To compile this image manually run:
 #
 # $ GO111MODULE=on GOOS=linux GOARCH=amd64 go build && docker build -t oryd/hydra:v1.0.0-rc.7_oryOS.10 . && rm hydra
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN addgroup -S ory; \
     adduser -S ory -G ory -D -H -s /bin/nologin

--- a/Dockerfile-e2e
+++ b/Dockerfile-e2e
@@ -1,4 +1,4 @@
-FROM golang:1.13.7-alpine
+FROM golang:1.15.2-alpine3.12
 
 ARG git_tag
 ARG git_commit


### PR DESCRIPTION
## Related issue


## Proposed changes

Updated dockerfile-e2e to use golang 1.15.2 now that 1.13 is EOL. Updated other dockerfiles to use Alpine 3.12 to make all dockerfile consitant.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ x] I have read the [security policy](../security/policy).
- [x ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
