### PR TITLE
test: fix confusing expected/got

### DIFF
--- a/consent/strategy_default_test.go
+++ b/consent/strategy_default_test.go
@@ -1766,12 +1766,12 @@ func TestStrategyLoginConsent(t *testing.T) {
 				tc.req.Form = r.Form
 
 				c, err := strategy.HandleOAuth2AuthorizationRequest(w, r, &tc.req)
-				t.Logf("DefaultStrategy returned at call %d:\n\tgot: %+v\n\texpected: %s", calls, c, err)
+				t.Logf("DefaultStrategy returned at call %d:\n\tresult: %+v\n\terr: %s", calls, c, err)
 
 				if tc.expectErr[calls] {
 					assert.Error(t, err)
 					if tc.expectErrType[calls] != nil {
-						assert.EqualError(t, tc.expectErrType[calls], err.Error(), "%+v", err)
+						assert.EqualError(t, err, tc.expectErrType[calls].Error(), "%+v", err)
 					}
 				} else {
 					require.NoError(t, err)


### PR DESCRIPTION
And fixed assert.EqualError params in right order in TestStrategyLoginConsent

## Related issue

The merge request does not relate to any issue, just fix confusing things in tests

## Proposed changes

The merge request does not propose any change.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

In the test `TestStrategyLoginConsent` we have the couple lines of code:

```go
c, err := strategy.HandleOAuth2AuthorizationRequest(w, r, &tc.req)
t.Logf("DefaultStrategy returned at call %d:\n\tgot: %+v\n\texpected: %s", calls, c, err)
```
The "got" and "expected" in this log confusing the developer because it just "result" and "err" returned from `HandleOAuth2AuthorizationRequest` func.

The second change fixes the params that passed to `assert.EqualError` func to the right order: https://godoc.org/github.com/stretchr/testify/assert#EqualError
