### PR TITLE
ci(docs): rename consts key in package.json to config

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "prettier": "ory-prettier-styles",
-  "consts": {
+  "config": {
     "prettierTarget": "{docs/**,docs,scripts,static,contrib}/*.{md,mdx,json,js,css,html}|*.{js,md}"
   },
   "scripts": {
@@ -15,8 +15,8 @@
     "swizzle": "docusaurus swizzle",
     "serve": "docusaurus serve",
     "deploy": "docusaurus deploy",
-    "format": "prettier --write ${npm_package_consts_prettierTarget}",
-    "format:check": "prettier --check ${npm_package_consts_prettierTarget}",
+    "format": "prettier --write ${npm_package_config_prettierTarget}",
+    "format:check": "prettier --check ${npm_package_config_prettierTarget}",
     "postinstall": "patch-package"
   },
   "dependencies": {


### PR DESCRIPTION
## Related issue
npm@v7 implements https://github.com/npm/rfcs/blob/latest/implemented/0021-reduce-lifecycle-script-environment.md
This means that only stuff under the `config` key can be referenced in scripts. This change is still compatible with npm@v6.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Rename `consts` to `config` in the package.json
