### PR TITLE
chore: apply ory-prettier-styles to cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,9 @@ jobs:
       - checkout
       - golangci/lint
       - docs/check-format
+      - run: |
+          bash <(curl -s https://raw.githubusercontent.com/ory/ci/master/src/scripts/install/prettier.sh)
+          npm run format:check
 
 workflows:
   bdt:

--- a/cypress/helpers/index.js
+++ b/cypress/helpers/index.js
@@ -3,14 +3,14 @@ export const prng = () =>
     .toString(36)
     .substring(2)}${Math.random()
     .toString(36)
-    .substring(2)}`;
+    .substring(2)}`
 
 const isStatusOk = res =>
   res.ok
     ? Promise.resolve(res)
     : Promise.reject(
         new Error(`Received unexpected status code ${res.statusCode}`)
-      );
+      )
 
 export const findEndUserAuthorization = subject =>
   fetch(
@@ -19,7 +19,7 @@ export const findEndUserAuthorization = subject =>
       subject
   )
     .then(isStatusOk)
-    .then(res => res.json());
+    .then(res => res.json())
 
 export const revokeEndUserAuthorization = subject =>
   fetch(
@@ -27,7 +27,7 @@ export const revokeEndUserAuthorization = subject =>
       '/oauth2/auth/sessions/consent?subject=' +
       subject,
     { method: 'DELETE' }
-  ).then(isStatusOk);
+  ).then(isStatusOk)
 
 export const createClient = client =>
   fetch(Cypress.env('admin_url') + '/clients', {
@@ -37,7 +37,7 @@ export const createClient = client =>
   })
     .then(isStatusOk)
     .then(res => {
-      return res.json();
+      return res.json()
     })
     .then(body =>
       getClient(client.client_id).then(actual => {
@@ -48,12 +48,12 @@ export const createClient = client =>
                 body.client
               }`
             )
-          );
+          )
         }
 
-        return Promise.resolve(body);
+        return Promise.resolve(body)
       })
-    );
+    )
 
 export const deleteClients = () =>
   fetch(Cypress.env('admin_url') + '/clients', {
@@ -62,15 +62,15 @@ export const deleteClients = () =>
     .then(isStatusOk)
     .then(res => res.json())
     .then((body = []) => {
-      (body || []).forEach(({ client_id }) => deleteClient(client_id));
-    });
+      ;(body || []).forEach(({ client_id }) => deleteClient(client_id))
+    })
 
 const deleteClient = client_id =>
   fetch(Cypress.env('admin_url') + '/clients/' + client_id, {
     method: 'DELETE'
-  }).then(isStatusOk);
+  }).then(isStatusOk)
 
 const getClient = id =>
   fetch(Cypress.env('admin_url') + '/clients/' + id)
     .then(isStatusOk)
-    .then(res => res.json());
+    .then(res => res.json())

--- a/cypress/integration/admin/client_create.js
+++ b/cypress/integration/admin/client_create.js
@@ -1,21 +1,21 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('The Clients Admin Interface', function() {
   const nc = () => ({
     scope: 'foo openid offline_access',
     grant_types: ['client_credentials']
-  });
+  })
 
   it('should return client_secret with length 26 for newly created clients without client_secret specified', function() {
-    const client = nc();
+    const client = nc()
 
     cy.request(
       'POST',
       Cypress.env('admin_url') + '/clients',
       JSON.stringify(client)
     ).then(response => {
-      console.log(response.body, client);
-      expect(response.body.client_secret.length).to.equal(26);
-    });
-  });
-});
+      console.log(response.body, client)
+      expect(response.body.client_secret.length).to.equal(26)
+    })
+  })
+})

--- a/cypress/integration/oauth2/authorize_code.js
+++ b/cypress/integration/oauth2/authorize_code.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('The OAuth 2.0 Authorization Code Grant', function() {
   const nc = () => ({
@@ -9,13 +9,13 @@ describe('The OAuth 2.0 Authorization Code Grant', function() {
     token_endpoint_auth_method: 'client_secret_basic',
     redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should return an Access, Refresh, and ID Token when scope offline_access and openid are granted', function() {
-    const client = nc();
+    const client = nc()
     cy.authCodeFlow(client, {
       consent: { scope: ['offline_access', 'openid'] }
-    });
+    })
 
     cy.get('body')
       .invoke('text')
@@ -23,18 +23,18 @@ describe('The OAuth 2.0 Authorization Code Grant', function() {
         const {
           result,
           token: { access_token, id_token, refresh_token }
-        } = JSON.parse(content);
+        } = JSON.parse(content)
 
-        expect(result).to.equal('success');
-        expect(access_token).to.not.be.empty;
-        expect(id_token).to.not.be.empty;
-        expect(refresh_token).to.not.be.empty;
-      });
-  });
+        expect(result).to.equal('success')
+        expect(access_token).to.not.be.empty
+        expect(id_token).to.not.be.empty
+        expect(refresh_token).to.not.be.empty
+      })
+  })
 
   it('should return an Access and Refresh Token when scope offline_access is granted', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } });
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } })
 
     cy.get('body')
       .invoke('text')
@@ -42,18 +42,18 @@ describe('The OAuth 2.0 Authorization Code Grant', function() {
         const {
           result,
           token: { access_token, id_token, refresh_token }
-        } = JSON.parse(content);
+        } = JSON.parse(content)
 
-        expect(result).to.equal('success');
-        expect(access_token).to.not.be.empty;
-        expect(id_token).to.be.empty;
-        expect(refresh_token).to.not.be.empty;
-      });
-  });
+        expect(result).to.equal('success')
+        expect(access_token).to.not.be.empty
+        expect(id_token).to.be.empty
+        expect(refresh_token).to.not.be.empty
+      })
+  })
 
   it('should return an Access and ID Token when scope offline_access is granted', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['openid'] } });
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['openid'] } })
 
     cy.get('body')
       .invoke('text')
@@ -61,18 +61,18 @@ describe('The OAuth 2.0 Authorization Code Grant', function() {
         const {
           result,
           token: { access_token, id_token, refresh_token }
-        } = JSON.parse(content);
+        } = JSON.parse(content)
 
-        expect(result).to.equal('success');
-        expect(access_token).to.not.be.empty;
-        expect(id_token).to.not.be.empty;
-        expect(refresh_token).to.be.empty;
-      });
-  });
+        expect(result).to.equal('success')
+        expect(access_token).to.not.be.empty
+        expect(id_token).to.not.be.empty
+        expect(refresh_token).to.be.empty
+      })
+  })
 
   it('should return an Access Token when no scope is granted', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: [] } });
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: [] } })
 
     cy.get('body')
       .invoke('text')
@@ -80,12 +80,12 @@ describe('The OAuth 2.0 Authorization Code Grant', function() {
         const {
           result,
           token: { access_token, id_token, refresh_token }
-        } = JSON.parse(content);
+        } = JSON.parse(content)
 
-        expect(result).to.equal('success');
-        expect(access_token).to.not.be.empty;
-        expect(id_token).to.be.empty;
-        expect(refresh_token).to.be.empty;
-      });
-  });
-});
+        expect(result).to.equal('success')
+        expect(access_token).to.not.be.empty
+        expect(id_token).to.be.empty
+        expect(refresh_token).to.be.empty
+      })
+  })
+})

--- a/cypress/integration/oauth2/authorize_error.js
+++ b/cypress/integration/oauth2/authorize_error.js
@@ -1,5 +1,5 @@
-import { createClient, prng } from '../../helpers';
-import qs from 'querystring';
+import { createClient, prng } from '../../helpers'
+import qs from 'querystring'
 
 describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
   describe('rejecting login and consent requests', () => {
@@ -11,14 +11,14 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
       token_endpoint_auth_method: 'client_secret_basic',
       redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
       grant_types: ['authorization_code', 'refresh_token']
-    });
+    })
 
     it('should return an error when rejecting login', function() {
-      const client = nc();
+      const client = nc()
       cy.authCodeFlow(client, {
         login: { accept: false },
         consent: { skip: true }
-      });
+      })
 
       cy.get('body')
         .invoke('text')
@@ -27,23 +27,23 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
             result,
             error_description,
             token: { access_token, id_token, refresh_token } = {}
-          } = JSON.parse(content);
+          } = JSON.parse(content)
 
-          expect(result).to.equal('error');
+          expect(result).to.equal('error')
           expect(error_description).to.equal(
             'The resource owner denied the request'
-          );
-          expect(access_token).to.be.empty;
-          expect(id_token).to.be.empty;
-          expect(refresh_token).to.be.empty;
-        });
-    });
+          )
+          expect(access_token).to.be.empty
+          expect(id_token).to.be.empty
+          expect(refresh_token).to.be.empty
+        })
+    })
 
     it('should return an error when rejecting consent', function() {
-      const client = nc();
+      const client = nc()
       cy.authCodeFlow(client, {
         consent: { accept: false }
-      });
+      })
 
       cy.get('body')
         .invoke('text')
@@ -52,18 +52,18 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
             result,
             error_description,
             token: { access_token, id_token, refresh_token } = {}
-          } = JSON.parse(content);
+          } = JSON.parse(content)
 
-          expect(result).to.equal('error');
+          expect(result).to.equal('error')
           expect(error_description).to.equal(
             'The resource owner denied the request'
-          );
-          expect(access_token).to.be.empty;
-          expect(id_token).to.be.empty;
-          expect(refresh_token).to.be.empty;
-        });
-    });
-  });
+          )
+          expect(access_token).to.be.empty
+          expect(id_token).to.be.empty
+          expect(refresh_token).to.be.empty
+        })
+    })
+  })
 
   it('should return an error when an OAuth 2.0 Client ID is used that does not exist', () => {
     cy.visit(
@@ -71,16 +71,16 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
         'client_url'
       )}/oauth2/code?client_id=i-do-not-exist&client_secret=i-am-not-correct}`,
       { failOnStatusCode: false }
-    );
+    )
 
     cy.location().should(({ search, port }) => {
-      const query = qs.parse(search.substr(1));
-      expect(query.error).to.equal('invalid_client');
+      const query = qs.parse(search.substr(1))
+      expect(query.error).to.equal('invalid_client')
 
       // Should show ORY Hydra's Error URL because a redirect URL could not be determined
-      expect(port).to.equal(Cypress.env('public_port'));
-    });
-  });
+      expect(port).to.equal(Cypress.env('public_port'))
+    })
+  })
 
   it('should return an error when an OAuth 2.0 Client requests a scope that is not allowed to be requested', () => {
     const c = {
@@ -89,24 +89,24 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
       scope: 'foo',
       redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
       grant_types: ['authorization_code']
-    };
-    cy.wrap(createClient(c));
+    }
+    cy.wrap(createClient(c))
 
     cy.visit(
       `${Cypress.env('client_url')}/oauth2/code?client_id=${
         c.client_id
       }&client_secret=${c.client_secret}&scope=bar`,
       { failOnStatusCode: false }
-    );
+    )
 
     cy.location().should(({ search, port }) => {
-      const query = qs.parse(search.substr(1));
-      expect(query.error).to.equal('invalid_scope');
+      const query = qs.parse(search.substr(1))
+      expect(query.error).to.equal('invalid_scope')
 
       // This is a client error so we expect the client app to show the error
-      expect(port).to.equal(Cypress.env('client_port'));
-    });
-  });
+      expect(port).to.equal(Cypress.env('client_port'))
+    })
+  })
 
   it('should return an error when an OAuth 2.0 Client requests a response type it is not allowed to call', () => {
     const c = {
@@ -114,18 +114,18 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
       client_secret: prng(),
       redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
       response_types: ['token'] // disallows Authorization Code Grant
-    };
-    cy.wrap(createClient(c));
+    }
+    cy.wrap(createClient(c))
 
     cy.visit(
       `${Cypress.env('client_url')}/oauth2/code?client_id=${
         c.client_id
       }&client_secret=${c.client_secret}`,
       { failOnStatusCode: false }
-    );
+    )
 
-    cy.get('body').should('contain', 'unsupported_response_type');
-  });
+    cy.get('body').should('contain', 'unsupported_response_type')
+  })
 
   it('should return an error when an OAuth 2.0 Client requests a grant type it is not allowed to call', () => {
     const c = {
@@ -133,23 +133,23 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
       client_secret: prng(),
       redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
       grant_types: ['client_credentials']
-    };
-    cy.wrap(createClient(c));
+    }
+    cy.wrap(createClient(c))
 
     cy.visit(
       `${Cypress.env('client_url')}/oauth2/code?client_id=${
         c.client_id
       }&client_secret=${c.client_secret}&scope=`,
       { failOnStatusCode: false }
-    );
+    )
 
-    cy.get('#email').type('foo@bar.com', { delay: 1 });
-    cy.get('#password').type('foobar', { delay: 1 });
-    cy.get('#accept').click();
-    cy.get('#accept').click();
+    cy.get('#email').type('foo@bar.com', { delay: 1 })
+    cy.get('#password').type('foobar', { delay: 1 })
+    cy.get('#accept').click()
+    cy.get('#accept').click()
 
-    cy.get('body').should('contain', 'unauthorized_client');
-  });
+    cy.get('body').should('contain', 'unauthorized_client')
+  })
 
   it('should return an error when an OAuth 2.0 Client requests a redirect_uri that is not preregistered', () => {
     const c = {
@@ -157,23 +157,23 @@ describe('OAuth 2.0 Authorization Endpoint Error Handling', () => {
       client_secret: prng(),
       redirect_uris: ['http://some-other-domain/not-callback'],
       grant_types: ['client_credentials']
-    };
-    cy.wrap(createClient(c));
+    }
+    cy.wrap(createClient(c))
 
     cy.visit(
       `${Cypress.env('client_url')}/oauth2/code?client_id=${
         c.client_id
       }&client_secret=${c.client_secret}&scope=`,
       { failOnStatusCode: false }
-    );
+    )
 
     cy.location().should(({ search, port }) => {
-      const query = qs.parse(search.substr(1));
-      expect(query.error).to.equal('invalid_request');
-      expect(query.error_hint).to.contain('redirect_uri');
+      const query = qs.parse(search.substr(1))
+      expect(query.error).to.equal('invalid_request')
+      expect(query.error_hint).to.contain('redirect_uri')
 
       // Should show ORY Hydra's Error URL because a redirect URL could not be determined
-      expect(port).to.equal(Cypress.env('public_port'));
-    });
-  });
-});
+      expect(port).to.equal(Cypress.env('public_port'))
+    })
+  })
+})

--- a/cypress/integration/oauth2/client_creds.js
+++ b/cypress/integration/oauth2/client_creds.js
@@ -1,4 +1,4 @@
-import { createClient, prng } from '../../helpers';
+import { createClient, prng } from '../../helpers'
 
 describe('The OAuth 2.0 Authorization Code Grant', function() {
   const nc = () => ({
@@ -6,11 +6,11 @@ describe('The OAuth 2.0 Authorization Code Grant', function() {
     client_secret: prng(),
     scope: 'foo openid offline_access',
     grant_types: ['client_credentials']
-  });
+  })
 
   it('should return an Access Token but not Refresh or ID Token for client_credentials flow', function() {
-    const client = nc();
-    cy.wrap(createClient(client));
+    const client = nc()
+    cy.wrap(createClient(client))
 
     cy.request(
       `${Cypress.env('client_url')}/oauth2/cc?client_id=${
@@ -23,12 +23,12 @@ describe('The OAuth 2.0 Authorization Code Grant', function() {
         const {
           result,
           token: { access_token, id_token, refresh_token } = {}
-        } = body;
+        } = body
 
-        expect(result).to.equal('success');
-        expect(access_token).to.not.be.empty;
-        expect(id_token).to.be.empty;
-        expect(refresh_token).to.be.empty;
-      });
-  });
-});
+        expect(result).to.equal('success')
+        expect(access_token).to.not.be.empty
+        expect(id_token).to.be.empty
+        expect(refresh_token).to.be.empty
+      })
+  })
+})

--- a/cypress/integration/oauth2/consent.js
+++ b/cypress/integration/oauth2/consent.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('OAuth 2.0 End-User Authorization', () => {
   const nc = () => ({
@@ -7,26 +7,26 @@ describe('OAuth 2.0 End-User Authorization', () => {
     scope: 'offline_access',
     redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   const hasConsent = (client, body) => {
-    let found = false;
+    let found = false
     body.forEach(({ consent_request: { client: { client_id } } }) => {
       if (client_id === client.client_id) {
-        found = true;
+        found = true
       }
-    });
-    return found;
-  };
+    })
+    return found
+  }
 
   it('should check if end user authorization exists', () => {
-    const client = nc();
+    const client = nc()
     cy.authCodeFlow(client, {
       consent: {
         scope: ['offline_access'],
         remember: true
       }
-    });
+    })
 
     cy.request(
       Cypress.env('admin_url') +
@@ -34,22 +34,22 @@ describe('OAuth 2.0 End-User Authorization', () => {
     )
       .its('body')
       .then(body => {
-        expect(body.length).to.be.greaterThan(0);
-        expect(hasConsent(client, body)).to.be.true;
+        expect(body.length).to.be.greaterThan(0)
+        expect(hasConsent(client, body)).to.be.true
         body.forEach(consent => {
           expect(
             consent.handled_at.match(
               /^[2-9]\d{3}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
             )
-          ).not.to.be.empty;
-        });
-      });
+          ).not.to.be.empty
+        })
+      })
 
     cy.request(
       'DELETE',
       Cypress.env('admin_url') +
         '/oauth2/auth/sessions/consent?subject=foo@bar.com&all=true'
-    );
+    )
 
     cy.request(
       Cypress.env('admin_url') +
@@ -57,22 +57,22 @@ describe('OAuth 2.0 End-User Authorization', () => {
     )
       .its('body')
       .then(body => {
-        expect(body.length).to.eq(0);
-        expect(hasConsent(client, body)).to.be.false;
-      });
+        expect(body.length).to.eq(0)
+        expect(hasConsent(client, body)).to.be.false
+      })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/introspect/at`)
       .its('body')
       .then(body => {
-        expect(body.result).to.equal('success');
-        expect(body.body.active).to.be.false;
-      });
+        expect(body.result).to.equal('success')
+        expect(body.body.active).to.be.false
+      })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/introspect/rt`)
       .its('body')
       .then(body => {
-        expect(body.result).to.equal('success');
-        expect(body.body.active).to.be.false;
-      });
-  });
-});
+        expect(body.result).to.equal('success')
+        expect(body.body.active).to.be.false
+      })
+  })
+})

--- a/cypress/integration/oauth2/introspect.js
+++ b/cypress/integration/oauth2/introspect.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('OpenID Connect Token Introspection', () => {
   const nc = () => ({
@@ -7,47 +7,47 @@ describe('OpenID Connect Token Introspection', () => {
     scope: 'offline_access',
     redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should introspect access token', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } });
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } })
 
     cy.get('body')
       .invoke('text')
       .then(content => {
-        const { result } = JSON.parse(content);
-        expect(result).to.equal('success');
-      });
+        const { result } = JSON.parse(content)
+        expect(result).to.equal('success')
+      })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/introspect/at`)
       .its('body')
       .then(body => {
-        expect(body.result).to.equal('success');
-        expect(body.body.active).to.be.true;
-        expect(body.body.sub).to.be.equal('foo@bar.com');
-        expect(body.body.token_type).to.be.equal('access_token');
-      });
-  });
+        expect(body.result).to.equal('success')
+        expect(body.body.active).to.be.true
+        expect(body.body.sub).to.be.equal('foo@bar.com')
+        expect(body.body.token_type).to.be.equal('access_token')
+      })
+  })
 
   it('should introspect refresh token', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } });
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } })
 
     cy.get('body')
       .invoke('text')
       .then(content => {
-        const { result } = JSON.parse(content);
-        expect(result).to.equal('success');
-      });
+        const { result } = JSON.parse(content)
+        expect(result).to.equal('success')
+      })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/introspect/rt`)
       .its('body')
       .then(body => {
-        expect(body.result).to.equal('success');
-        expect(body.body.active).to.be.true;
-        expect(body.body.sub).to.be.equal('foo@bar.com');
-        expect(body.body.token_type).to.be.equal('refresh_token');
-      });
-  });
-});
+        expect(body.result).to.equal('success')
+        expect(body.body.active).to.be.true
+        expect(body.body.sub).to.be.equal('foo@bar.com')
+        expect(body.body.token_type).to.be.equal('refresh_token')
+      })
+  })
+})

--- a/cypress/integration/oauth2/jwt.js
+++ b/cypress/integration/oauth2/jwt.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('The OAuth 2.0 Refresh Token Grant', () => {
   before(function() {
@@ -7,9 +7,9 @@ describe('The OAuth 2.0 Refresh Token Grant', () => {
       Cypress.env('jwt_enabled') !== 'true' &&
       !Boolean(Cypress.env('jwt_enabled'))
     ) {
-      this.skip();
+      this.skip()
     }
-  });
+  })
 
   const nc = () => ({
     client_id: prng(),
@@ -17,31 +17,31 @@ describe('The OAuth 2.0 Refresh Token Grant', () => {
     scope: 'offline_access',
     redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should return an Access Token in JWT format and validate it and a Refresh Token in opaque format', () => {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } });
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/refresh`)
       .its('body')
       .then(body => {
-        const { result, token } = body;
-        expect(result).to.equal('success');
+        const { result, token } = body
+        expect(result).to.equal('success')
 
-        expect(token.access_token).to.not.be.empty;
-        expect(token.refresh_token).to.not.be.empty;
-        expect(token.access_token.split('.').length).to.equal(3);
-        expect(token.refresh_token.split('.').length).to.equal(2);
-      });
+        expect(token.access_token).to.not.be.empty
+        expect(token.refresh_token).to.not.be.empty
+        expect(token.access_token.split('.').length).to.equal(3)
+        expect(token.refresh_token.split('.').length).to.equal(2)
+      })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/validate-jwt`)
       .its('body')
       .then(body => {
-        console.log(body);
-        expect(body.sub).to.eq('foo@bar.com');
-        expect(body.client_id).to.eq(client.client_id);
-        expect(body.jti).to.not.be.empty;
-      });
-  });
-});
+        console.log(body)
+        expect(body.sub).to.eq('foo@bar.com')
+        expect(body.client_id).to.eq(client.client_id)
+        expect(body.jti).to.not.be.empty
+      })
+  })
+})

--- a/cypress/integration/oauth2/refresh_token.js
+++ b/cypress/integration/oauth2/refresh_token.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('OAuth 2.0 JSON Web Token Access Tokens', function() {
   const nc = () => ({
@@ -7,36 +7,36 @@ describe('OAuth 2.0 JSON Web Token Access Tokens', function() {
     scope: 'offline_access openid',
     redirect_uris: [`${Cypress.env('client_url')}/oauth2/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should return an Access and Refresh Token and refresh the Access Token', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } });
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['offline_access'] } })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/refresh`)
       .its('body')
       .then(body => {
-        const { result, token } = body;
-        expect(result).to.equal('success');
-        expect(token.access_token).to.not.be.empty;
-        expect(token.refresh_token).to.not.be.empty;
-      });
-  });
+        const { result, token } = body
+        expect(result).to.equal('success')
+        expect(token.access_token).to.not.be.empty
+        expect(token.refresh_token).to.not.be.empty
+      })
+  })
 
   it('should return an Access, ID, and Refresh Token and refresh the Access Token and ID Token', function() {
-    const client = nc();
+    const client = nc()
     cy.authCodeFlow(client, {
       consent: { scope: ['offline_access', 'openid'] }
-    });
+    })
 
     cy.request(`${Cypress.env('client_url')}/oauth2/refresh`)
       .its('body')
       .then(body => {
-        const { result, token } = body;
-        expect(result).to.equal('success');
-        expect(token.access_token).to.not.be.empty;
-        expect(token.id_token).to.not.be.empty;
-        expect(token.refresh_token).to.not.be.empty;
-      });
-  });
-});
+        const { result, token } = body
+        expect(result).to.equal('success')
+        expect(token.access_token).to.not.be.empty
+        expect(token.id_token).to.not.be.empty
+        expect(token.refresh_token).to.not.be.empty
+      })
+  })
+})

--- a/cypress/integration/openid/authorize_code.js
+++ b/cypress/integration/openid/authorize_code.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('OpenID Connect Authorize Code Grant', () => {
   const nc = () => ({
@@ -9,11 +9,11 @@ describe('OpenID Connect Authorize Code Grant', () => {
     token_endpoint_auth_method: 'client_secret_basic',
     redirect_uris: [`${Cypress.env('client_url')}/openid/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should return an access, refresh, and ID token', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['openid'] } }, 'openid');
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['openid'] } }, 'openid')
 
     cy.get('body')
       .invoke('text')
@@ -22,15 +22,15 @@ describe('OpenID Connect Authorize Code Grant', () => {
           result,
           token: { access_token, id_token, refresh_token },
           claims: { sub, sid }
-        } = JSON.parse(content);
+        } = JSON.parse(content)
 
-        expect(result).to.equal('success');
-        expect(access_token).to.not.be.empty;
-        expect(id_token).to.not.be.empty;
-        expect(refresh_token).to.be.empty;
+        expect(result).to.equal('success')
+        expect(access_token).to.not.be.empty
+        expect(id_token).to.not.be.empty
+        expect(refresh_token).to.be.empty
 
-        expect(sub).to.eq('foo@bar.com');
-        expect(sid).to.not.be.empty;
-      });
-  });
-});
+        expect(sub).to.eq('foo@bar.com')
+        expect(sid).to.not.be.empty
+      })
+  })
+})

--- a/cypress/integration/openid/logout.js
+++ b/cypress/integration/openid/logout.js
@@ -1,4 +1,4 @@
-import { deleteClients, prng } from '../../helpers';
+import { deleteClients, prng } from '../../helpers'
 
 const nc = () => ({
   client_id: prng(),
@@ -7,12 +7,12 @@ const nc = () => ({
   subject_type: 'public',
   redirect_uris: [`${Cypress.env('client_url')}/openid/callback`],
   grant_types: ['authorization_code']
-});
+})
 
 describe('OpenID Connect Logout', () => {
   after(() => {
-    cy.wrap(deleteClients());
-  });
+    cy.wrap(deleteClients())
+  })
 
   describe('logout without id_token_hint', () => {
     beforeEach(() => {
@@ -20,19 +20,19 @@ describe('OpenID Connect Logout', () => {
         'oauth2_authentication_session',
         'oauth2_authentication_session_insecure',
         'connect.sid'
-      );
-    });
+      )
+    })
 
     before(() => {
-      cy.wrap(deleteClients());
-    });
+      cy.wrap(deleteClients())
+    })
 
     const client = {
       ...nc(),
       backchannel_logout_uri: `${Cypress.env(
         'client_url'
       )}/openid/session/end/bc`
-    };
+    }
 
     it('should log in and remember login without id_token_hint', function() {
       cy.authCodeFlow(
@@ -42,14 +42,14 @@ describe('OpenID Connect Logout', () => {
           consent: { scope: ['openid'], remember: true }
         },
         'openid'
-      );
+      )
 
       cy.request(`${Cypress.env('client_url')}/openid/session/check`)
         .its('body')
         .then(({ has_session }) => {
-          expect(has_session).to.be.true;
-        });
-    });
+          expect(has_session).to.be.true
+        })
+    })
 
     it('should show the logout page and complete logout without id_token_hint', () => {
       // cy.request(`${Cypress.env('client_url')}/openid/session/check`)
@@ -60,12 +60,12 @@ describe('OpenID Connect Logout', () => {
 
       cy.visit(`${Cypress.env('client_url')}/openid/session/end?simple=1`, {
         failOnStatusCode: false
-      });
+      })
 
-      cy.get('#accept').click();
+      cy.get('#accept').click()
 
-      cy.get('h1').should('contain', 'Your log out request however succeeded.');
-    });
+      cy.get('h1').should('contain', 'Your log out request however succeeded.')
+    })
 
     it('should show the login screen again because we logged out', () => {
       cy.authCodeFlow(
@@ -76,9 +76,9 @@ describe('OpenID Connect Logout', () => {
           createClient: false
         },
         'openid'
-      );
-    });
-  });
+      )
+    })
+  })
 
   // The Back-Channel test should run before the front-channel test because otherwise both tests need a long time to finish.
   describe('Back-Channel', () => {
@@ -87,19 +87,19 @@ describe('OpenID Connect Logout', () => {
         'oauth2_authentication_session',
         'oauth2_authentication_session_insecure',
         'connect.sid'
-      );
-    });
+      )
+    })
 
     before(() => {
-      cy.wrap(deleteClients());
-    });
+      cy.wrap(deleteClients())
+    })
 
     const client = {
       ...nc(),
       backchannel_logout_uri: `${Cypress.env(
         'client_url'
       )}/openid/session/end/bc`
-    };
+    }
 
     it('should log in and remember login with back-channel', function() {
       cy.authCodeFlow(
@@ -109,37 +109,37 @@ describe('OpenID Connect Logout', () => {
           consent: { scope: ['openid'], remember: true }
         },
         'openid'
-      );
+      )
 
       cy.request(`${Cypress.env('client_url')}/openid/session/check`)
         .its('body')
         .then(({ has_session }) => {
-          expect(has_session).to.be.true;
-        });
-    });
+          expect(has_session).to.be.true
+        })
+    })
 
     it('should show the logout page and complete logout with back-channel', () => {
       cy.request(`${Cypress.env('client_url')}/openid/session/check`)
         .its('body')
         .then(({ has_session }) => {
-          expect(has_session).to.be.true;
-        });
+          expect(has_session).to.be.true
+        })
 
       cy.visit(`${Cypress.env('client_url')}/openid/session/end`, {
         failOnStatusCode: false
-      });
+      })
 
-      cy.get('#accept').click();
+      cy.get('#accept').click()
 
-      cy.get('h1').should('contain', 'Your log out request however succeeded.');
+      cy.get('h1').should('contain', 'Your log out request however succeeded.')
 
       cy.request(`${Cypress.env('client_url')}/openid/session/check`)
         .its('body')
         .then(({ has_session }) => {
-          expect(has_session).to.be.false;
-        });
-    });
-  });
+          expect(has_session).to.be.false
+        })
+    })
+  })
 
   describe('Front-Channel', () => {
     beforeEach(() => {
@@ -147,19 +147,19 @@ describe('OpenID Connect Logout', () => {
         'oauth2_authentication_session',
         'oauth2_authentication_session_insecure',
         'connect.sid'
-      );
-    });
+      )
+    })
 
     before(() => {
-      cy.wrap(deleteClients());
-    });
+      cy.wrap(deleteClients())
+    })
 
     const client = {
       ...nc(),
       frontchannel_logout_uri: `${Cypress.env(
         'client_url'
       )}/openid/session/end/fc`
-    };
+    }
 
     it('should log in and remember login with front-channel', () => {
       cy.authCodeFlow(
@@ -169,35 +169,35 @@ describe('OpenID Connect Logout', () => {
           consent: { scope: ['openid'], remember: true }
         },
         'openid'
-      );
+      )
 
       cy.request(`${Cypress.env('client_url')}/openid/session/check`)
         .its('body')
         .then(({ has_session }) => {
-          expect(has_session).to.be.true;
-        });
-    });
+          expect(has_session).to.be.true
+        })
+    })
 
     it('should show the logout page and complete logout with front-channel', () => {
       cy.request(`${Cypress.env('client_url')}/openid/session/check`)
         .its('body')
         .then(({ has_session }) => {
-          expect(has_session).to.be.true;
-        });
+          expect(has_session).to.be.true
+        })
 
       cy.visit(`${Cypress.env('client_url')}/openid/session/end`, {
         failOnStatusCode: false
-      });
+      })
 
-      cy.get('#accept').click();
+      cy.get('#accept').click()
 
-      cy.get('h1').should('contain', 'Your log out request however succeeded.');
+      cy.get('h1').should('contain', 'Your log out request however succeeded.')
 
       cy.request(`${Cypress.env('client_url')}/openid/session/check`)
         .its('body')
         .then(({ has_session }) => {
-          expect(has_session).to.be.false;
-        });
-    });
-  });
-});
+          expect(has_session).to.be.false
+        })
+    })
+  })
+})

--- a/cypress/integration/openid/prompt.js
+++ b/cypress/integration/openid/prompt.js
@@ -1,5 +1,5 @@
-import { createClient, prng } from '../../helpers';
-import qs from 'querystring';
+import { createClient, prng } from '../../helpers'
+import qs from 'querystring'
 
 describe('OpenID Connect Prompt', () => {
   const nc = () => ({
@@ -8,28 +8,28 @@ describe('OpenID Connect Prompt', () => {
     scope: 'openid',
     redirect_uris: [`${Cypress.env('client_url')}/openid/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should fail prompt=none when no session exists', function() {
-    const client = nc();
-    cy.wrap(createClient(client));
+    const client = nc()
+    cy.wrap(createClient(client))
 
     cy.visit(
       `${Cypress.env('client_url')}/openid/code?client_id=${
         client.client_id
       }&client_secret=${client.client_secret}&prompt=none`,
       { failOnStatusCode: false }
-    );
+    )
 
     cy.location().should(({ search, port }) => {
-      const query = qs.parse(search.substr(1));
-      expect(query.error).to.equal('login_required');
-      expect(port).to.equal(Cypress.env('client_port'));
-    });
-  });
+      const query = qs.parse(search.substr(1))
+      expect(query.error).to.equal('login_required')
+      expect(port).to.equal(Cypress.env('client_port'))
+    })
+  })
 
   it('should pass with prompt=none if both login and consent were remembered', function() {
-    const client = nc();
+    const client = nc()
 
     cy.authCodeFlow(
       client,
@@ -38,7 +38,7 @@ describe('OpenID Connect Prompt', () => {
         consent: { scope: ['openid'], remember: true }
       },
       'openid'
-    );
+    )
 
     cy.request(
       `${Cypress.env('client_url')}/openid/code?client_id=${
@@ -50,14 +50,14 @@ describe('OpenID Connect Prompt', () => {
         const {
           result,
           token: { access_token }
-        } = body;
-        expect(result).to.equal('success');
-        expect(access_token).to.not.be.empty;
-      });
-  });
+        } = body
+        expect(result).to.equal('success')
+        expect(access_token).to.not.be.empty
+      })
+  })
 
   it('should require login with prompt=login even when session exists', function() {
-    const client = nc();
+    const client = nc()
 
     cy.authCodeFlow(
       client,
@@ -66,7 +66,7 @@ describe('OpenID Connect Prompt', () => {
         consent: { scope: ['openid'], remember: true }
       },
       'openid'
-    );
+    )
 
     cy.request(
       `${Cypress.env('client_url')}/openid/code?client_id=${
@@ -75,11 +75,11 @@ describe('OpenID Connect Prompt', () => {
     )
       .its('body')
       .then(body => {
-        expect(body).to.contain('Please log in');
-      });
-  });
+        expect(body).to.contain('Please log in')
+      })
+  })
   it('should require consent with prompt=consent even when session exists', function() {
-    const client = nc();
+    const client = nc()
 
     cy.authCodeFlow(
       client,
@@ -88,7 +88,7 @@ describe('OpenID Connect Prompt', () => {
         consent: { scope: ['openid'], remember: true }
       },
       'openid'
-    );
+    )
 
     cy.request(
       `${Cypress.env('client_url')}/openid/code?client_id=${
@@ -97,7 +97,7 @@ describe('OpenID Connect Prompt', () => {
     )
       .its('body')
       .then(body => {
-        expect(body).to.contain('An application requests access to your data!');
-      });
-  });
-});
+        expect(body).to.contain('An application requests access to your data!')
+      })
+  })
+})

--- a/cypress/integration/openid/revoke.js
+++ b/cypress/integration/openid/revoke.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('OpenID Connect Token Revokation', () => {
   const nc = () => ({
@@ -7,67 +7,67 @@ describe('OpenID Connect Token Revokation', () => {
     scope: 'openid offline_access',
     redirect_uris: [`${Cypress.env('client_url')}/openid/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should be able to revoke the access token', function() {
-    const client = nc();
+    const client = nc()
     cy.authCodeFlow(
       client,
       { consent: { scope: ['openid', 'offline_access'] } },
       'openid'
-    );
+    )
 
     cy.get('body')
       .invoke('text')
       .then(content => {
-        const { result } = JSON.parse(content);
-        expect(result).to.equal('success');
-      });
+        const { result } = JSON.parse(content)
+        expect(result).to.equal('success')
+      })
 
     cy.request(`${Cypress.env('client_url')}/openid/revoke/at`)
       .its('body')
       .then(response => {
-        expect(response.result).to.equal('success');
-      });
+        expect(response.result).to.equal('success')
+      })
 
     cy.request(`${Cypress.env('client_url')}/openid/userinfo`, {
       failOnStatusCode: false
     })
       .its('body')
       .then(response => {
-        expect(response.error).to.contain('request_unauthorized');
-      });
-  });
+        expect(response.error).to.contain('request_unauthorized')
+      })
+  })
 
   it('should be able to revoke the refresh token', function() {
-    const client = nc();
+    const client = nc()
     cy.authCodeFlow(
       client,
       { consent: { scope: ['openid', 'offline_access'] } },
       'openid'
-    );
+    )
 
     cy.get('body')
       .invoke('text')
       .then(content => {
-        const { result } = JSON.parse(content);
-        expect(result).to.equal('success');
-      });
+        const { result } = JSON.parse(content)
+        expect(result).to.equal('success')
+      })
 
     cy.request(`${Cypress.env('client_url')}/openid/revoke/rt`, {
       failOnStatusCode: false
     })
       .its('body')
       .then(response => {
-        expect(response.result).to.equal('success');
-      });
+        expect(response.result).to.equal('success')
+      })
 
     cy.request(`${Cypress.env('client_url')}/openid/userinfo`, {
       failOnStatusCode: false
     })
       .its('body')
       .then(response => {
-        expect(response.error).to.contain('request_unauthorized');
-      });
-  });
-});
+        expect(response.error).to.contain('request_unauthorized')
+      })
+  })
+})

--- a/cypress/integration/openid/userinfo.js
+++ b/cypress/integration/openid/userinfo.js
@@ -1,4 +1,4 @@
-import { prng } from '../../helpers';
+import { prng } from '../../helpers'
 
 describe('OpenID Connect Userinfo', () => {
   const nc = () => ({
@@ -7,24 +7,24 @@ describe('OpenID Connect Userinfo', () => {
     scope: 'openid',
     redirect_uris: [`${Cypress.env('client_url')}/openid/callback`],
     grant_types: ['authorization_code', 'refresh_token']
-  });
+  })
 
   it('should return a proper userinfo response', function() {
-    const client = nc();
-    cy.authCodeFlow(client, { consent: { scope: ['openid'] } }, 'openid');
+    const client = nc()
+    cy.authCodeFlow(client, { consent: { scope: ['openid'] } }, 'openid')
 
     cy.get('body')
       .invoke('text')
       .then(content => {
-        const { result } = JSON.parse(content);
-        expect(result).to.equal('success');
-      });
+        const { result } = JSON.parse(content)
+        expect(result).to.equal('success')
+      })
 
     cy.request(`${Cypress.env('client_url')}/openid/userinfo`)
       .its('body')
       .then(({ sub, sid } = {}) => {
-        expect(sub).to.eq('foo@bar.com');
-        expect(sid).to.not.be.empty;
-      });
-  });
-});
+        expect(sub).to.eq('foo@bar.com')
+        expect(sid).to.not.be.empty
+      })
+  })
+})

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -14,4 +14,4 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-};
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,7 +23,7 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-import { createClient } from '../helpers';
+import { createClient } from '../helpers'
 
 Cypress.Commands.add(
   'authCodeFlow',
@@ -50,7 +50,7 @@ Cypress.Commands.add(
     path = 'oauth2'
   ) => {
     if (doCreateClient) {
-      cy.wrap(createClient(client));
+      cy.wrap(createClient(client))
     }
 
     cy.visit(
@@ -61,37 +61,37 @@ Cypress.Commands.add(
         '+'
       )}&prompt=${prompt}`,
       { failOnStatusCode: false }
-    );
+    )
 
     if (!skipLogin) {
-      cy.get('#email').type(username, { delay: 1 });
-      cy.get('#password').type(password, { delay: 1 });
+      cy.get('#email').type(username, { delay: 1 })
+      cy.get('#password').type(password, { delay: 1 })
 
       if (rememberLogin) {
-        cy.get('#remember').click();
+        cy.get('#remember').click()
       }
 
       if (acceptLogin) {
-        cy.get('#accept').click();
+        cy.get('#accept').click()
       } else {
-        cy.get('#reject').click();
+        cy.get('#reject').click()
       }
     }
 
     if (!skipConsent) {
       acceptScope.forEach(s => {
-        cy.get(`#${s}`).click();
-      });
+        cy.get(`#${s}`).click()
+      })
 
       if (rememberConsent) {
-        cy.get('#remember').click();
+        cy.get('#remember').click()
       }
 
       if (acceptConsent) {
-        cy.get('#accept').click();
+        cy.get('#accept').click()
       } else {
-        cy.get('#reject').click();
+        cy.get('#reject').click()
       }
     }
   }
-);
+)

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands';
+import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,6 +2074,12 @@
         }
       }
     },
+    "ory-prettier-styles": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.1.1.tgz",
+      "integrity": "sha512-Kv5GUQw0nFDO6w/HcIMNQAh75QeG4ZhrpNuRJaHSlsTvTx9rwpr+bVfeXrhXQsovUW51PF6OvLW3LA0AdDdSzw==",
+      "dev": true
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
   "name": "@oryd/hydra",
   "version": "0.0.0",
   "private": true,
+  "prettier": "ory-prettier-styles",
+  "config": {
+    "prettierTarget": "{test,cypress}/**/*.js"
+  },
   "scripts": {
-    "format": "prettier --single-quote --trailing-comma none --write \"{test,cypress}/**/*.js\"",
+    "format": "prettier --write ${npm_package_config_prettierTarget}",
+    "format:check": "prettier --check ${npm_package_config_prettierTarget}",
     "test": "cypress run",
     "test:watch": "cypress open",
     "wait-on": "wait-on",
@@ -11,6 +16,7 @@
   },
   "devDependencies": {
     "cypress": "^3.8.1",
+    "ory-prettier-styles": "^1.1.1",
     "prettier": "^1.17.0",
     "standard": "^12.0.1",
     "wait-on": "^3.2.0"

--- a/test/e2e/oauth2-client/src/index.js
+++ b/test/e2e/oauth2-client/src/index.js
@@ -1,37 +1,37 @@
-const express = require('express');
-const session = require('express-session');
-const uuid = require('node-uuid');
-const oauth2 = require('simple-oauth2');
-const fetch = require('node-fetch');
-const ew = require('express-winston');
-const winston = require('winston');
-const { Issuer } = require('openid-client');
-const { URLSearchParams } = require('url');
-const bodyParser = require('body-parser');
-const jwksClient = require('jwks-rsa');
-const jwt = require('jsonwebtoken');
+const express = require('express')
+const session = require('express-session')
+const uuid = require('node-uuid')
+const oauth2 = require('simple-oauth2')
+const fetch = require('node-fetch')
+const ew = require('express-winston')
+const winston = require('winston')
+const { Issuer } = require('openid-client')
+const { URLSearchParams } = require('url')
+const bodyParser = require('body-parser')
+const jwksClient = require('jwks-rsa')
+const jwt = require('jsonwebtoken')
 
-const app = express();
+const app = express()
 
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.urlencoded({ extended: true }))
 
-const blacklistedSid = [];
+const blacklistedSid = []
 
 const isStatusOk = res =>
   res.ok
     ? Promise.resolve(res)
     : Promise.reject(
         new Error(`Received unexpected status code ${res.statusCode}`)
-      );
+      )
 
 const config = {
   url: process.env.AUTHORIZATION_SERVER_URL || 'http://127.0.0.1:5000/',
   public: process.env.PUBLIC_URL || 'http://127.0.0.1:5000/',
   admin: process.env.ADMIN_URL || 'http://127.0.0.1:5001/',
   port: parseInt(process.env.PORT) || 5003
-};
+}
 
-const redirect_uri = `http://127.0.0.1:${config.port}`;
+const redirect_uri = `http://127.0.0.1:${config.port}`
 
 app.use(
   ew.logger({
@@ -41,7 +41,7 @@ app.use(
       winston.format.simple()
     )
   })
-);
+)
 
 app.use(
   session({
@@ -53,7 +53,7 @@ app.use(
       httpOnly: true
     }
   })
-);
+)
 
 const nc = req =>
   Issuer.discover(config.public).then(issuer => {
@@ -61,22 +61,22 @@ const nc = req =>
     issuer.metadata.token_endpoint = new URL(
       '/oauth2/token',
       config.public
-    ).toString();
+    ).toString()
     issuer.metadata.jwks_uri = new URL(
       '/.well-known/jwks.json',
       config.public
-    ).toString();
+    ).toString()
     issuer.metadata.revocation_endpoint = new URL(
       '/oauth2/revoke',
       config.public
-    ).toString();
+    ).toString()
     issuer.metadata.introspection_endpoint = new URL(
       '/oauth2/introspect',
       config.admin
-    ).toString();
+    ).toString()
 
-    return Promise.resolve(new issuer.Client(req.session.oidc_credentials));
-  });
+    return Promise.resolve(new issuer.Client(req.session.oidc_credentials))
+  })
 
 app.get('/oauth2/code', async (req, res) => {
   const credentials = {
@@ -90,14 +90,14 @@ app.get('/oauth2/code', async (req, res) => {
       tokenPath: '/oauth2/token',
       authorizePath: '/oauth2/auth'
     }
-  };
+  }
 
-  const state = uuid.v4();
-  const scope = req.query.scope || '';
+  const state = uuid.v4()
+  const scope = req.query.scope || ''
 
-  req.session.credentials = credentials;
-  req.session.state = state;
-  req.session.scope = scope.split(' ');
+  req.session.credentials = credentials
+  req.session.state = state
+  req.session.scope = scope.split(' ')
 
   res.redirect(
     oauth2.create(credentials).authorizationCode.authorizeURL({
@@ -105,23 +105,23 @@ app.get('/oauth2/code', async (req, res) => {
       scope,
       state
     })
-  );
-});
+  )
+})
 
 app.get('/oauth2/callback', async (req, res) => {
   if (req.query.error) {
-    res.send(JSON.stringify(Object.assign({ result: 'error' }, req.query)));
-    return;
+    res.send(JSON.stringify(Object.assign({ result: 'error' }, req.query)))
+    return
   }
 
   if (req.query.state !== req.session.state) {
-    res.send(JSON.stringify({ result: 'error', error: 'states mismatch' }));
-    return;
+    res.send(JSON.stringify({ result: 'error', error: 'states mismatch' }))
+    return
   }
 
   if (!req.query.code) {
-    res.send(JSON.stringify({ result: 'error', error: 'no code given' }));
-    return;
+    res.send(JSON.stringify({ result: 'error', error: 'no code given' }))
+    return
   }
 
   oauth2
@@ -132,17 +132,17 @@ app.get('/oauth2/callback', async (req, res) => {
       code: req.query.code
     })
     .then(token => {
-      req.session.oauth2_flow = { token }; // code returns {access_token} because why not...
-      res.send({ result: 'success', token });
+      req.session.oauth2_flow = { token } // code returns {access_token} because why not...
+      res.send({ result: 'success', token })
     })
     .catch(err => {
       if (err.data.payload) {
-        res.send(JSON.stringify(err.data.payload));
-        return;
+        res.send(JSON.stringify(err.data.payload))
+        return
       }
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/oauth2/refresh', function(req, res) {
   oauth2
@@ -150,13 +150,13 @@ app.get('/oauth2/refresh', function(req, res) {
     .accessToken.create(req.session.oauth2_flow.token)
     .refresh()
     .then(token => {
-      req.session.oauth2_flow = token; // refresh returns {token:{access_token}} because why not...
-      res.send({ result: 'success', token: token.token });
+      req.session.oauth2_flow = token // refresh returns {token:{access_token}} because why not...
+      res.send({ result: 'success', token: token.token })
     })
     .catch(err => {
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/oauth2/revoke', (req, res) => {
   oauth2
@@ -164,41 +164,41 @@ app.get('/oauth2/revoke', (req, res) => {
     .accessToken.create(req.session.oauth2_flow.token)
     .revoke(req.query.type || 'access_token')
     .then(() => {
-      res.sendStatus(201);
+      res.sendStatus(201)
     })
     .catch(err => {
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/oauth2/validate-jwt', (req, res) => {
   const client = jwksClient({
     jwksUri: new URL('/.well-known/jwks.json', config.public).toString()
-  });
+  })
 
   jwt.verify(
     req.session.oauth2_flow.token.access_token,
     (header, callback) => {
       client.getSigningKey(header.kid, function(err, key) {
-        const signingKey = key.publicKey || key.rsaPublicKey;
-        callback(null, signingKey);
-      });
+        const signingKey = key.publicKey || key.rsaPublicKey
+        callback(null, signingKey)
+      })
     },
     (err, decoded) => {
       if (err) {
-        console.error(err);
-        res.send(400);
-        return;
+        console.error(err)
+        res.send(400)
+        return
       }
 
-      res.send(decoded);
+      res.send(decoded)
     }
-  );
-});
+  )
+})
 
 app.get('/oauth2/introspect/at', (req, res) => {
-  const params = new URLSearchParams();
-  params.append('token', req.session.oauth2_flow.token.access_token);
+  const params = new URLSearchParams()
+  params.append('token', req.session.oauth2_flow.token.access_token)
 
   fetch(new URL('/oauth2/introspect', config.admin).toString(), {
     method: 'POST',
@@ -208,14 +208,14 @@ app.get('/oauth2/introspect/at', (req, res) => {
     .then(res => res.json())
     .then(body => res.json({ result: 'success', body }))
     .catch(err => {
-      console.error(err);
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      console.error(err)
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/oauth2/introspect/rt', async (req, res) => {
-  const params = new URLSearchParams();
-  params.append('token', req.session.oauth2_flow.token.refresh_token);
+  const params = new URLSearchParams()
+  params.append('token', req.session.oauth2_flow.token.refresh_token)
 
   fetch(new URL('/oauth2/introspect', config.admin).toString(), {
     method: 'POST',
@@ -225,9 +225,9 @@ app.get('/oauth2/introspect/rt', async (req, res) => {
     .then(res => res.json())
     .then(body => res.json({ result: 'success', body }))
     .catch(err => {
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 // client credentials
 
@@ -244,23 +244,23 @@ app.get('/oauth2/cc', (req, res) => {
     options: {
       authorizationMethod: 'header'
     }
-  };
+  }
 
   oauth2
     .create(credentials)
     .clientCredentials.getToken({ scope: req.query.scope.split(' ') })
     .then(token => {
-      res.send({ result: 'success', token });
+      res.send({ result: 'success', token })
     })
     .catch(err => {
       if (err.data.payload) {
-        res.send(JSON.stringify(err.data.payload));
-        return;
+        res.send(JSON.stringify(err.data.payload))
+        return
       }
 
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 // openid
 
@@ -268,45 +268,45 @@ app.get('/openid/code', async (req, res) => {
   const credentials = {
     client_id: req.query.client_id,
     client_secret: req.query.client_secret
-  };
+  }
 
-  const state = uuid.v4();
-  const nonce = uuid.v4();
-  const scope = req.query.scope || '';
+  const state = uuid.v4()
+  const nonce = uuid.v4()
+  const scope = req.query.scope || ''
 
-  req.session.oidc_credentials = credentials;
-  req.session.state = state;
-  req.session.nonce = nonce;
-  req.session.scope = scope.split(' ');
+  req.session.oidc_credentials = credentials
+  req.session.state = state
+  req.session.nonce = nonce
+  req.session.scope = scope.split(' ')
 
-  const client = await nc(req);
+  const client = await nc(req)
   const url = client.authorizationUrl({
     redirect_uri: `${redirect_uri}/openid/callback`,
     scope: scope,
     state: state,
     nonce: nonce,
     prompt: req.query.prompt
-  });
-  res.redirect(url);
-});
+  })
+  res.redirect(url)
+})
 
 app.get('/openid/callback', async (req, res) => {
   if (req.query.error) {
-    res.send(JSON.stringify(Object.assign({ result: 'error' }, req.query)));
-    return;
+    res.send(JSON.stringify(Object.assign({ result: 'error' }, req.query)))
+    return
   }
 
   if (req.query.state !== req.session.state) {
-    res.send(JSON.stringify({ result: 'error', error: 'states mismatch' }));
-    return;
+    res.send(JSON.stringify({ result: 'error', error: 'states mismatch' }))
+    return
   }
 
   if (!req.query.code) {
-    res.send(JSON.stringify({ result: 'error', error: 'no code given' }));
-    return;
+    res.send(JSON.stringify({ result: 'error', error: 'no code given' }))
+    return
   }
 
-  const client = await nc(req);
+  const client = await nc(req)
   client
     .authorizationCallback(`${redirect_uri}/openid/callback`, req.query, {
       state: req.session.state,
@@ -314,148 +314,148 @@ app.get('/openid/callback', async (req, res) => {
       response_type: 'code'
     })
     .then(ts => {
-      req.session.openid_token = ts;
-      req.session.openid_claims = ts.claims;
-      res.send({ result: 'success', token: ts, claims: ts.claims });
+      req.session.openid_token = ts
+      req.session.openid_claims = ts.claims
+      res.send({ result: 'success', token: ts, claims: ts.claims })
     })
     .catch(err => {
-      console.error(err);
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      console.error(err)
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/openid/userinfo', async (req, res) => {
-  const client = await nc(req);
+  const client = await nc(req)
   client
     .userinfo(req.session.openid_token.access_token)
     .then(ui => res.json(ui))
     .catch(err => {
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/openid/revoke/at', async (req, res) => {
-  const client = await nc(req);
+  const client = await nc(req)
   client
     .revoke(req.session.openid_token.access_token)
     .then(() => res.json({ result: 'success' }))
     .catch(err => {
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/openid/revoke/rt', async (req, res) => {
-  const client = await nc(req);
+  const client = await nc(req)
   client
     .revoke(req.session.openid_token.refresh_token)
     .then(() => res.json({ result: 'success' }))
     .catch(err => {
-      res.send(JSON.stringify({ error: err.toString() }));
-    });
-});
+      res.send(JSON.stringify({ error: err.toString() }))
+    })
+})
 
 app.get('/openid/session/end', async (req, res) => {
-  const client = await nc(req);
-  const state = uuid.v4();
+  const client = await nc(req)
+  const state = uuid.v4()
 
   if (req.query.simple) {
-    res.redirect(new URL('/oauth2/sessions/logout', config.public).toString());
+    res.redirect(new URL('/oauth2/sessions/logout', config.public).toString())
   } else {
-    req.session.logout_state = state;
+    req.session.logout_state = state
     res.redirect(
       client.endSessionUrl({
         state,
         id_token_hint:
           req.query.id_token_hint || req.session.openid_token.id_token
       })
-    );
+    )
   }
-});
+})
 
 app.get('/openid/session/end/fc', async (req, res) => {
   if (req.session.openid_claims.sid !== req.query.sid) {
-    res.sendStatus(400);
-    return;
+    res.sendStatus(400)
+    return
   }
 
   if (req.session.openid_claims.iss !== req.query.iss) {
-    res.sendStatus(400);
-    return;
+    res.sendStatus(400)
+    return
   }
 
   setTimeout(() => {
     req.session.destroy(() => {
-      res.send('ok');
-    });
-  }, 500);
-});
+      res.send('ok')
+    })
+  }, 500)
+})
 
 app.post('/openid/session/end/bc', (req, res) => {
   const client = jwksClient({
     jwksUri: new URL('/.well-known/jwks.json', config.public).toString()
-  });
+  })
 
   jwt.verify(
     req.body.logout_token,
     (header, callback) => {
       client.getSigningKey(header.kid, (err, key) => {
         if (err) {
-          console.error(err);
-          res.sendStatus(400);
-          return;
+          console.error(err)
+          res.sendStatus(400)
+          return
         }
 
-        callback(null, key.publicKey || key.rsaPublicKey);
-      });
+        callback(null, key.publicKey || key.rsaPublicKey)
+      })
     },
     (err, decoded) => {
       if (err) {
-        console.error(err);
-        res.sendStatus(400);
-        return;
+        console.error(err)
+        res.sendStatus(400)
+        return
       }
 
       if (decoded.nonce) {
-        console.error('nonce is set but should not be', decoded.nonce);
-        res.sendStatus(400);
-        return;
+        console.error('nonce is set but should not be', decoded.nonce)
+        res.sendStatus(400)
+        return
       }
 
       if (decoded.sid.length === 0) {
-        console.error('sid should be set but is not', decoded.sid);
-        res.sendStatus(400);
-        return;
+        console.error('sid should be set but is not', decoded.sid)
+        res.sendStatus(400)
+        return
       }
 
       if (decoded.iss.indexOf(config.url) === -1) {
-        console.error('issuer is mismatching', decoded.iss, config.url);
-        res.sendStatus(400);
-        return;
+        console.error('issuer is mismatching', decoded.iss, config.url)
+        res.sendStatus(400)
+        return
       }
 
-      blacklistedSid.push(decoded.sid);
-      res.send('ok');
+      blacklistedSid.push(decoded.sid)
+      res.send('ok')
     }
-  );
-});
+  )
+})
 
 app.get('/openid/session/check', async (req, res) => {
-  const { openid_claims: { sid = '' } = {} } = req.session;
+  const { openid_claims: { sid = '' } = {} } = req.session
 
   if (blacklistedSid.indexOf(sid) > -1) {
     req.session.destroy(() => {
-      res.json({ has_session: false });
-    });
-    return;
+      res.json({ has_session: false })
+    })
+    return
   }
 
   res.json({
     has_session:
       Boolean(req.session.oauth2_flow) ||
       (Boolean(req.session.openid_token) && Boolean(req.session.openid_claims))
-  });
-});
+  })
+})
 
 app.listen(config.port, function() {
-  console.log(`Listening on port ${config.port}!`);
-});
+  console.log(`Listening on port ${config.port}!`)
+})


### PR DESCRIPTION
This enforces `ory-prettier-styles` for cypress tests. The format is now also checked in the cci/validate task.