### PR TITLE
feat: Only pass state if it was set

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -885,9 +885,12 @@ func (s *DefaultStrategy) issueLogoutVerifier(w http.ResponseWriter, r *http.Req
 			)
 		}
 
-		redir = urlx.SetQuery(f, url.Values{
-			"state": {state},
-		}).String()
+		params := url.Values{}
+		if state != "" {
+			params.Add("state", state)
+		}
+
+		redir = urlx.SetQuery(f, params).String()
 	}
 
 	// We do not really want to verify if the user (from id token hint) has a session here because it doesn't really matter.


### PR DESCRIPTION
## Related issue

I didn't open an issue because I prefer to directly show the problem by submitting a PoC.

## Proposed changes

Using `state` in the logout flow is optional, so `state` can be
empty. In order to avoid an ugly `/post-logout-redirect-uri?state=`
URI, the state should only be appended if it is not empty.

Relevant specification: https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

If you are willing to accept this change, I'll add tests (and fix the typo in the commit).
