### PR TITLE
fix: document describe error

### DIFF
--- a/docs/docs/debug.mdx
+++ b/docs/docs/debug.mdx
@@ -64,7 +64,7 @@ have multiple reasons:
 4. You consent app did not send `granted_scope: ["offline"]` or
    `granted_scope: ["offline_access"]` when accepting the consent request.
 5. The OAuth 2.0 Client making the request is not allowed to request the scope
-   `openid`.
+   `refresh_token`.
 
 ## OAuth 2.0 Authorize Code Flow fails
 

--- a/docs/docs/debug.mdx
+++ b/docs/docs/debug.mdx
@@ -63,7 +63,7 @@ have multiple reasons:
    `/oauth2/auth`.
 4. You consent app did not send `granted_scope: ["offline"]` or
    `granted_scope: ["offline_access"]` when accepting the consent request.
-5. The OAuth 2.0 Client making the request is not allowed to request the scope
+5. The OAuth 2.0 Client making the request is not allowed to grant type
    `refresh_token`.
 
 ## OAuth 2.0 Authorize Code Flow fails

--- a/docs/versioned_docs/version-v1.9/debug.mdx
+++ b/docs/versioned_docs/version-v1.9/debug.mdx
@@ -64,7 +64,7 @@ have multiple reasons:
 4. You consent app did not send `granted_scope: ["offline"]` or
    `granted_scope: ["offline_access"]` when accepting the consent request.
 5. The OAuth 2.0 Client making the request is not allowed to request the scope
-   `openid`.
+   `refresh_token`.
 
 ## OAuth 2.0 Authorize Code Flow fails
 

--- a/docs/versioned_docs/version-v1.9/debug.mdx
+++ b/docs/versioned_docs/version-v1.9/debug.mdx
@@ -63,7 +63,7 @@ have multiple reasons:
    `/oauth2/auth`.
 4. You consent app did not send `granted_scope: ["offline"]` or
    `granted_scope: ["offline_access"]` when accepting the consent request.
-5. The OAuth 2.0 Client making the request is not allowed to request the scope
+5. The OAuth 2.0 Client making the request is not allowed to grant type
    `refresh_token`.
 
 ## OAuth 2.0 Authorize Code Flow fails


### PR DESCRIPTION
Fixed document describe error.
> The OAuth 2.0 Client making the request is not allowed to request the scope `openid`

Should be `refresh_token`, according [here](https://github.com/ory/fosite/blob/master/handler/oauth2/flow_authorize_code_token.go#L129)
```go
func canIssueRefreshToken(c *AuthorizeExplicitGrantHandler, request fosite.Requester) bool {
	// Require one of the refresh token scopes, if set.GetGrantTypes
	if len(c.RefreshTokenScopes) > 0 && !request.GetGrantedScopes().HasOneOf(c.RefreshTokenScopes...) {
		return false
	}
	// Do not issue a refresh token to clients that cannot use the refresh token grant type.
	if !request.GetClient().GetGrantTypes().Has("refresh_token") {
		return false
	}
	return true
}
```