### PR TITLE
oidc.subject_identifiers config key change

### DIFF
--- a/docs/versioned_docs/version-v1.9/reference/configuration.md
+++ b/docs/versioned_docs/version-v1.9/reference/configuration.md
@@ -802,15 +802,15 @@ oidc:
   #     salt: some-random-salt
   #
   subject_identifiers:
-    ## enabled ##
+    ## supported_types ##
     #
     # Set this value using environment variables on
     # - Linux/macOS:
-    #    $ export OIDC_SUBJECT_IDENTIFIERS_ENABLED=<value>
+    #    $ export OIDC_SUBJECT_IDENTIFIERS_SUPPORTED_TYPES=<value>
     # - Windows Command Line (CMD):
-    #    > set OIDC_SUBJECT_IDENTIFIERS_ENABLED=<value>
+    #    > set OIDC_SUBJECT_IDENTIFIERS_SUPPORTED_TYPES=<value>
     #
-    enabled:
+    supported_types:
       - public
       - pairwise
 


### PR DESCRIPTION
oidc.subject_identifiers.enabled is now oidc.subject_identifiers.supported_types. Docs should get updated.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
