### PR TITLE
docs: corrected a link within the docs

### DIFF
--- a/docs/versioned_docs/version-v1.9/guides/login.mdx
+++ b/docs/versioned_docs/version-v1.9/guides/login.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem'
 
 :::note
 
-Please read the [Login Flow Documentation](../concepts/login) first!
+Please read the [Login Flow Documentation](../../concepts/login) first!
 
 :::
 

--- a/docs/versioned_docs/version-v1.9/guides/login.mdx
+++ b/docs/versioned_docs/version-v1.9/guides/login.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem'
 
 :::note
 
-Please read the [Login Flow Documentation](../../concepts/login) first!
+Please read the [Login Flow Documentation](../concepts/login.mdx) first!
 
 :::
 


### PR DESCRIPTION
This PR corrects the link of the first note in https://www.ory.sh/hydra/docs/guides/concepts/login
to https://www.ory.sh/hydra/docs/concepts/login

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

