### PR TITLE
docs: change deprecated fallback url

### DIFF
--- a/docs/versioned_docs/version-v1.8/configure-deploy.mdx
+++ b/docs/versioned_docs/version-v1.8/configure-deploy.mdx
@@ -141,7 +141,7 @@ Let's dive into the various settings:
   that URL in the next sections.
 
 Note: In this example we did not define a value for the optional setting
-`OAUTH2_ERROR_URL`. This URL can be used to provide an endpoint which will
+`URLS_ERROR`. This URL can be used to provide an endpoint which will
 receive error messages from ORY Hydra that should be displayed to the end user.
 The URL receives `error` and `error_description` parameters. If this value is
 not set, Hydra uses the fallback endpoint `/oauth2/fallbacks/error` and displays


### PR DESCRIPTION
Changed the fallback url as proposed in #2254.
Since OAUTH2_ERROR_URL is deprecated.
It should not be changed for the 1.8. docs, correct?

closes #2254

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
