### PR TITLE
docs:move faq sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -90,14 +90,14 @@
     "debug/csrf", 
     "debug/config", 
     "debug/token-endpoint-auth-method", 
-    "debug/logout"
+    "debug/logout", 
+    "faq"
   ],
   "SDKs": ["sdk", "sdk/go", "sdk/js", "sdk/php"],
   "Development": ["milestones"],
   "Further Reading": [
     "case-study", 
     "benchmark", 
-    "security-architecture", 
-    "faq"
+    "security-architecture"
   ]
 }

--- a/docs/versioned_sidebars/version-v1.9-sidebars.json
+++ b/docs/versioned_sidebars/version-v1.9-sidebars.json
@@ -332,6 +332,10 @@
         {
           "type": "doc",
           "id": "version-v1.9/debug/logout"
+        },
+        {
+          "type": "doc",
+          "id": "version-v1.9/faq"
         }
       ]
     },
@@ -385,10 +389,6 @@
         {
           "type": "doc",
           "id": "version-v1.9/security-architecture"
-        },
-        {
-          "type": "doc",
-          "id": "version-v1.9/faq"
         }
       ]
     },


### PR DESCRIPTION
Moved the FAQ section from `further reading` to `debug&help` since it is mostly about issues that arise during setup or production. 
Personally I would consult `further reading` only when I have read everything else, am bored, or really want to know every detail. It is not a place where I would look for frequently asked questions.

We can certainly improve the FAQ system overall, it is a work in progress. But for the time being I think its ok to have the FAQ in `debug&help`