### PR TITLE
feat: Enable emittance of response time metrics (achieving parity with Kratos)

### DIFF
--- a/metrics/prometheus/metrics.go
+++ b/metrics/prometheus/metrics.go
@@ -7,11 +7,43 @@ const (
 )
 
 // Metrics prototypes
+// Example:
+// 	Counter      *prometheus.CounterVec
+// 	ResponseTime *prometheus.HistogramVec
 type Metrics struct {
 	ResponseTime *prometheus.HistogramVec
 }
 
 // Method for creation new custom Prometheus  metrics
+// Example:
+// 	pm := &Metrics{
+//		Counter: prometheus.NewCounterVec(
+//			prometheus.CounterOpts{
+//				Name:        "servicename_requests_total",
+//				Help:        "Description",
+//				ConstLabels: map[string]string{
+//					"version":   version,
+//					"hash":      hash,
+//					"buildTime": buildTime,
+//				},
+//			},
+//			[]string{"endpoint"},
+//		),
+//		ResponseTime: prometheus.NewHistogramVec(
+//			prometheus.HistogramOpts{
+//				Name:        "servicename_response_time_seconds",
+//				Help:        "Description",
+//				ConstLabels: map[string]string{
+//					"version":   version,
+//					"hash":      hash,
+//					"buildTime": buildTime,
+//				},
+//			},
+//			[]string{"endpoint"},
+//		),
+//	}
+//	prometheus.Register(pm.Counter)
+//  prometheus.Register(pm.ResponseTime)
 func NewMetrics(version, hash, date string) *Metrics {
 	pm := &Metrics{
 		ResponseTime: prometheus.NewHistogramVec(

--- a/metrics/prometheus/metrics.go
+++ b/metrics/prometheus/metrics.go
@@ -1,46 +1,36 @@
 package prometheus
 
+import "github.com/prometheus/client_golang/prometheus"
+
 const (
 	MetricsPrometheusPath = "/metrics/prometheus"
 )
 
 // Metrics prototypes
-// Example:
-// 	Counter      *prometheus.CounterVec
-// 	ResponseTime *prometheus.HistogramVec
-type Metrics struct{}
+type Metrics struct {
+	ResponseTime *prometheus.HistogramVec
+}
 
 // Method for creation new custom Prometheus  metrics
-// Example:
-// 	pm := &Metrics{
-//		Counter: prometheus.NewCounterVec(
-//			prometheus.CounterOpts{
-//				Name:        "servicename_requests_total",
-//				Help:        "Description",
-//				ConstLabels: map[string]string{
-//					"version":   version,
-//					"hash":      hash,
-//					"buildTime": buildTime,
-//				},
-//			},
-//			[]string{"endpoint"},
-//		),
-//		ResponseTime: prometheus.NewHistogramVec(
-//			prometheus.HistogramOpts{
-//				Name:        "servicename_response_time_seconds",
-//				Help:        "Description",
-//				ConstLabels: map[string]string{
-//					"version":   version,
-//					"hash":      hash,
-//					"buildTime": buildTime,
-//				},
-//			},
-//			[]string{"endpoint"},
-//		),
-//	}
-//	prometheus.Register(pm.Counter)
-//  prometheus.Register(pm.ResponseTime)
 func NewMetrics(version, hash, date string) *Metrics {
-	pm := &Metrics{}
+	pm := &Metrics{
+		ResponseTime: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "hydra_response_time_seconds",
+				Help: "Description",
+				ConstLabels: map[string]string{
+					"version":   version,
+					"hash":      hash,
+					"buildTime": date,
+				},
+			},
+			[]string{"endpoint"},
+		),
+	}
+	err := prometheus.Register(pm.ResponseTime)
+
+	if err != nil {
+		panic(err)
+	}
 	return pm
 }

--- a/metrics/prometheus/middleware.go
+++ b/metrics/prometheus/middleware.go
@@ -23,5 +23,8 @@ func NewMetricsManager(version, hash, buildTime string) *MetricsManager {
 //	Response time metric
 //	pmm.prometheusMetrics.ResponseTime.WithLabelValues(r.URL.Path).Observe(time.Since(start).Seconds())
 func (pmm *MetricsManager) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	start := time.Now()
 	next(rw, r)
+
+	pmm.prometheusMetrics.ResponseTime.WithLabelValues(r.URL.Path).Observe(time.Since(start).Seconds())
 }

--- a/metrics/prometheus/middleware.go
+++ b/metrics/prometheus/middleware.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"net/http"
+	"time"
 )
 
 type MetricsManager struct {


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

Currently, Kratos emits response time metrics that can be used to monitor latency as well as Requests Per Second. [Kratos's metrics middleware](https://github.com/ory/kratos/blob/master/metrics/prometheus/middleware.go#L19-L23) looks like:
```
func (pmm *MetricsManager) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	start := time.Now()
	next(rw, r)

	pmm.prometheusMetrics.ResponseTime.WithLabelValues(r.URL.Path).Observe(time.Since(start).Seconds())
}
```

Currently, the equivalent in Hydra omits the first and last lines:
```
func (pmm *MetricsManager) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	next(rw, r)
}
```
Consequently, Hydra doesn't emit the response time metrics that would enable us to monitor latency/RPS. 

In our case, being able to monitor these metrics is an absolute necessity, and generally, it would seem desirable to have parity between Hydra and Kratos in this regard. 

This PR adds the missing lines to Hydra to enable emittance of these key metrics and achieve parity with Kratos.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
