### PR TITLE
fix: Revert mode default and maximum values

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -41,9 +41,9 @@
         "mode": {
           "type": "integer",
           "description": "Mode of unix socket in numeric form",
-          "default": 755,
+          "default": 493,
           "minimum": 0,
-          "maximum": 777
+          "maximum": 511
         }
       }
     },


### PR DESCRIPTION
I made a mistake in previous pull request, these socket mode values are in decimal, not octal format. Sorry.