### PR TITLE
fix: adds sqa section to config.schema.json

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -1025,6 +1025,26 @@
         }
       }
     },
+    "sqa": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Software Quality Assurance telemetry configuration section",
+      "properties": {
+        "opt_out" : {
+          "type": "boolean",
+          "description": "Disables anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa",
+          "default": false,
+          "examples": [
+            true
+          ]
+        }
+      },
+      "examples": [
+        {
+          "opt_out": true
+        }
+      ]
+    },
     "version": {
       "type": "string",
       "title": "The Hydra version this config is written for.",


### PR DESCRIPTION
Move from viper to koanf caused env vars without corresponding
paths in config.schema.json to be ignored. This commit adds
missing sqa section, so the SQA_OPT_OUT env var has effect again.

Closes: #2358

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
