### PR TITLE
fix: Add network specific error message to avoid confusion

### DIFF
--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -321,6 +321,7 @@ func (m *RegistryBase) newKeyStrategy(key string) (s jwk.JWTStrategy) {
 		var netError net.Error
 		if errors.As(err, &netError) {
 			m.Logger().WithError(err).Fatalf(`Could not ensure that signing keys for "%s" exists. A network error occurred, see error for specific details.`, key)
+			return
 		}
 
 		m.Logger().WithError(err).Fatalf(`Could not ensure that signing keys for "%s" exists. If you are running against a persistent SQL database this is most likely because your "secrets.system" ("SECRETS_SYSTEM" environment variable) is not set or changed. When running with an SQL database backend you need to make sure that the secret is set and stays the same, unless when doing key rotation. This may also happen when you forget to run "hydra migrate sql"..`, key)

--- a/driver/registry_base_test.go
+++ b/driver/registry_base_test.go
@@ -1,0 +1,42 @@
+package driver
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/ory/hydra/driver/config"
+	"github.com/ory/x/configx"
+	"github.com/ory/x/logrusx"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistryBase_newKeyStrategy_handlesNetworkError(t *testing.T) {
+	// Test ensures any network specific error is logged with a
+	// specific message when attempting to create a new key strategy: issue #2338
+
+	hook := test.Hook{} // Test hook for asserting log messages
+
+	l := logrusx.New("", "", logrusx.WithHook(&hook))
+	l.Logrus().SetOutput(ioutil.Discard)
+	l.Logrus().ExitFunc = func(int) {} // Override the exit func to avoid call to os.Exit
+
+	// Create a config and set a valid but unresolvable DSN
+	c := config.MustNew(l, configx.WithConfigFiles("../internal/.hydra.yaml"))
+	c.MustSet(config.KeyDSN, "postgres://user:password@127.0.0.1:9999/postgres")
+
+	registry, err := NewRegistryFromDSN(c, l)
+	if err != nil {
+		t.Error("failed to create registry: ", err)
+		return
+	}
+
+	registryBase := RegistryBase{r: registry, l: l}
+
+	strategy := registryBase.newKeyStrategy("key")
+
+	assert.Equal(t, nil, strategy)
+	assert.Equal(t, logrus.FatalLevel, hook.LastEntry().Level)
+	assert.Contains(t, hook.LastEntry().Message, "A network error occurred, see error for specific details.")
+}


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->
#2338

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
In the event of a general network error, avoid logging a misleading/confusing message.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
