### PR TITLE
docs: update examples to new helm install command format

### DIFF
--- a/docs/docs/guides/kubernetes-helm-chart.mdx
+++ b/docs/docs/guides/kubernetes-helm-chart.mdx
@@ -144,12 +144,10 @@ running Kubernetes locally, please adjust the hostnames accordingly.
 Let's install the Login and Consent App first
 
 ```bash
-$ helm install \
+$ helm install hydra-example-idp ory/example-idp \
     --set 'hydraAdminUrl=http://hydra-example-admin:4445/' \
     --set 'hydraPublicUrl=http://public.hydra.localhost/' \
-    --set 'ingress.enabled=true' \
-    --name hydra-example-idp \
-    ory/example-idp
+    --set 'ingress.enabled=true'
 ```
 
 with hostnames
@@ -166,7 +164,7 @@ outside of `localhost` and only for testing and demonstration purposes. Install
 the ORY Hydra Helm Chart
 
 ```bash
-$ helm install \
+$ helm install hydra-example ory/hydra \
     --set 'hydra.config.secrets.system=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)' \
     --set 'hydra.config.dsn=memory' \
     --set 'hydra.config.urls.self.issuer=http://public.hydra.localhost/' \
@@ -175,9 +173,7 @@ $ helm install \
     --set 'hydra.config.urls.logout=http://example-idp.localhost/logout' \
     --set 'ingress.public.enabled=true' \
     --set 'ingress.admin.enabled=true' \
-    --set 'hydra.dangerousForceHttp=true' \
-    --name hydra-example \
-    ory/hydra
+    --set 'hydra.dangerousForceHttp=true'
 ```
 
 with hostnames

--- a/docs/versioned_docs/version-v1.9/guides/kubernetes-helm-chart.mdx
+++ b/docs/versioned_docs/version-v1.9/guides/kubernetes-helm-chart.mdx
@@ -144,12 +144,10 @@ running Kubernetes locally, please adjust the hostnames accordingly.
 Let's install the Login and Consent App first
 
 ```bash
-$ helm install \
+$ helm install hydra-example-idp ory/example-idp \
     --set 'hydraAdminUrl=http://hydra-example-admin:4445/' \
     --set 'hydraPublicUrl=http://public.hydra.localhost/' \
-    --set 'ingress.enabled=true' \
-    --name hydra-example-idp \
-    ory/example-idp
+    --set 'ingress.enabled=true'
 ```
 
 with hostnames
@@ -166,7 +164,7 @@ outside of `localhost` and only for testing and demonstration purposes. Install
 the ORY Hydra Helm Chart
 
 ```bash
-$ helm install \
+$ helm install hydra-example ory/hydra \
     --set 'hydra.config.secrets.system=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)' \
     --set 'hydra.config.dsn=memory' \
     --set 'hydra.config.urls.self.issuer=http://public.hydra.localhost/' \
@@ -175,9 +173,7 @@ $ helm install \
     --set 'hydra.config.urls.logout=http://example-idp.localhost/logout' \
     --set 'ingress.public.enabled=true' \
     --set 'ingress.admin.enabled=true' \
-    --set 'hydra.dangerousForceHttp=true' \
-    --name hydra-example \
-    ory/hydra
+    --set 'hydra.dangerousForceHttp=true'
 ```
 
 with hostnames


### PR DESCRIPTION
## Proposed changes

Tried example with helm 3.5.2 and it does not support `--name` flag. So I moved name and repository to first line of commands.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
