### PR TITLE
feat: Refresh Token Reuse Detection

### DIFF
--- a/cypress/integration/oauth2/jwt.js
+++ b/cypress/integration/oauth2/jwt.js
@@ -1,6 +1,6 @@
 import { prng } from '../../helpers'
 
-describe('The OAuth 2.0 Refresh Token Grant', () => {
+describe('OAuth 2.0 JSON Web Token Access Tokens', () => {
   before(function () {
     // this must be a function otherwise this.skip() fails because the context is wrong
     if (

--- a/cypress/integration/oauth2/refresh_token.js
+++ b/cypress/integration/oauth2/refresh_token.js
@@ -1,6 +1,6 @@
 import { prng } from '../../helpers'
 
-describe('OAuth 2.0 JSON Web Token Access Tokens', function () {
+describe('The OAuth 2.0 Refresh Token Grant', function () {
   const nc = () => ({
     client_id: prng(),
     client_secret: prng(),
@@ -38,5 +38,41 @@ describe('OAuth 2.0 JSON Web Token Access Tokens', function () {
         expect(token.id_token).to.not.be.empty
         expect(token.refresh_token).to.not.be.empty
       })
+  })
+
+  it('should revoke Refresh Token on reuse', function () {
+    const referrer = `${Cypress.env('client_url')}/empty`
+    cy.visit(referrer, {
+      failOnStatusCode: false
+    })
+
+    const client = {
+      client_id: prng(),
+      scope: 'offline_access',
+      redirect_uris: [referrer],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none'
+    }
+
+    cy.authCodeFlowBrowser(client, {
+      consent: { scope: ['offline_access'] }
+    }).then((originalResponse) => {
+      expect(originalResponse.status).to.eq(200)
+
+      const originalToken = originalResponse.body.refresh_token
+
+      cy.refreshTokenBrowser(client, originalToken).then(
+        (refreshedResponse) => {
+          const refreshedToken = refreshedResponse.body.refresh_token
+
+          return cy
+            .refreshTokenBrowser(client, originalToken)
+            .then((response) => expect(response.status).to.eq(401))
+            .then(() => cy.refreshTokenBrowser(client, refreshedToken))
+            .then((response) => expect(response.status).to.eq(401))
+        }
+      )
+    })
   })
 })

--- a/cypress/integration/oauth2/refresh_token.js
+++ b/cypress/integration/oauth2/refresh_token.js
@@ -59,18 +59,28 @@ describe('The OAuth 2.0 Refresh Token Grant', function () {
       consent: { scope: ['offline_access'] }
     }).then((originalResponse) => {
       expect(originalResponse.status).to.eq(200)
+      expect(originalResponse.body.refresh_token).to.not.be.empty
 
       const originalToken = originalResponse.body.refresh_token
 
       cy.refreshTokenBrowser(client, originalToken).then(
         (refreshedResponse) => {
+          expect(refreshedResponse.status).to.eq(200)
+          expect(refreshedResponse.body.refresh_token).to.not.be.empty
+
           const refreshedToken = refreshedResponse.body.refresh_token
 
           return cy
             .refreshTokenBrowser(client, originalToken)
-            .then((response) => expect(response.status).to.eq(401))
+            .then((response) => {
+              expect(response.status).to.eq(401)
+              expect(response.body.error).to.eq('token_inactive')
+            })
             .then(() => cy.refreshTokenBrowser(client, refreshedToken))
-            .then((response) => expect(response.status).to.eq(401))
+            .then((response) => {
+              expect(response.status).to.eq(401)
+              expect(response.body.error).to.eq('token_inactive')
+            })
         }
       )
     })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,7 +23,7 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-import { createClient } from '../helpers'
+import { createClient, prng } from '../helpers'
 
 Cypress.Commands.add(
   'authCodeFlow',
@@ -93,4 +93,114 @@ Cypress.Commands.add(
       }
     }
   }
+)
+
+Cypress.Commands.add(
+  'authCodeFlowBrowser',
+  (
+    client,
+    {
+      consent: {
+        accept: acceptConsent = true,
+        skip: skipConsent = false,
+        remember: rememberConsent = false,
+        scope: acceptScope = []
+      } = {},
+      login: {
+        accept: acceptLogin = true,
+        skip: skipLogin = false,
+        remember: rememberLogin = false,
+        username = 'foo@bar.com',
+        password = 'foobar'
+      } = {},
+      createClient: doCreateClient = true
+    } = {}
+  ) => {
+    if (doCreateClient) {
+      cy.wrap(createClient(client))
+    }
+
+    const codeChallenge = 'QeNVR-BHuB6I2d0HycQzp2qUNNKi_-5QoR4fQSifLH0'
+    const codeVerifier =
+      'ZmRrenFxZ3pid3A0T0xqY29falJNUS5lWlY4SDBxS182U21uQkhjZ3UuOXpnd3NOak56d2lLMTVYemNNdHdNdlE5TW03WC1RZUlaM0N5R2FhdGRpNW1oVGhjbzVuRFBD'
+    const state = prng()
+
+    const authURL = new URL(`${Cypress.env('public_url')}/oauth2/auth`)
+    authURL.searchParams.set('response_type', 'code')
+    authURL.searchParams.set('client_id', client.client_id)
+    authURL.searchParams.set('redirect_uri', client.redirect_uris[0])
+    authURL.searchParams.set('scope', client.scope)
+    authURL.searchParams.set('state', state)
+    authURL.searchParams.set('code_challenge', codeChallenge)
+    authURL.searchParams.set('code_challenge_method', 'S256')
+
+    cy.window().then((win) => {
+      return win.open(authURL, '_self')
+    })
+
+    if (!skipLogin) {
+      cy.get('#email').type(username, { delay: 1 })
+      cy.get('#password').type(password, { delay: 1 })
+
+      if (rememberLogin) {
+        cy.get('#remember').click()
+      }
+
+      if (acceptLogin) {
+        cy.get('#accept').click()
+      } else {
+        cy.get('#reject').click()
+      }
+    }
+
+    if (!skipConsent) {
+      acceptScope.forEach((s) => {
+        cy.get(`#${s}`).click()
+      })
+
+      if (rememberConsent) {
+        cy.get('#remember').click()
+      }
+
+      if (acceptConsent) {
+        cy.get('#accept').click()
+      } else {
+        cy.get('#reject').click()
+      }
+    }
+
+    return cy.location('search').then((search) => {
+      const callbackParams = new URLSearchParams(search)
+      const code = callbackParams.get('code')
+
+      expect(code).to.exist
+
+      return cy.request({
+        url: `${Cypress.env('public_url')}/oauth2/token`,
+        method: 'POST',
+        form: true,
+        body: {
+          grant_type: 'authorization_code',
+          client_id: client.client_id,
+          redirect_uri: client.redirect_uris[0],
+          code: code,
+          code_verifier: codeVerifier
+        }
+      })
+    })
+  }
+)
+
+Cypress.Commands.add('refreshTokenBrowser', (client, token) =>
+  cy.request({
+    url: `${Cypress.env('public_url')}/oauth2/token`,
+    method: 'POST',
+    form: true,
+    body: {
+      grant_type: 'refresh_token',
+      client_id: client.client_id,
+      refresh_token: token
+    },
+    failOnStatusCode: false
+  })
 )

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -173,7 +173,7 @@ Cypress.Commands.add(
       const callbackParams = new URLSearchParams(search)
       const code = callbackParams.get('code')
 
-      expect(code).to.exist
+      expect(code).to.not.be.empty
 
       return cy.request({
         url: `${Cypress.env('public_url')}/oauth2/token`,

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gobuffalo/pop/v5 v5.3.3
 	github.com/gobuffalo/x v0.0.0-20181007152206-913e47c59ca7
 	github.com/gobwas/glob v0.2.3
-	github.com/golang/mock v1.4.3
+	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.0
@@ -35,7 +35,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/ory/analytics-go/v4 v4.0.1
 	github.com/ory/cli v0.0.35
-	github.com/ory/fosite v0.36.0
+	github.com/ory/fosite v0.39.0
 	github.com/ory/go-acc v0.2.6
 	github.com/ory/graceful v0.1.1
 	github.com/ory/herodot v0.9.2
@@ -50,14 +50,13 @@ require (
 	github.com/sawadashota/encrypta v0.0.2
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
-	github.com/sqs/goreturns v0.0.0-20181028201513-538ac6014518 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/tidwall/gjson v1.6.7
 	github.com/toqueteos/webbrowser v1.2.0
 	github.com/uber/jaeger-lib v2.4.0+incompatible // indirect
 	github.com/urfave/negroni v1.0.0
 	go.uber.org/automaxprocs v1.3.0
-	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
+	golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/tools v0.0.0-20201019175715-b894a3290fff

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
-github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
-github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
+github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -993,8 +993,8 @@ github.com/ory/dockertest/v3 v3.5.4/go.mod h1:J8ZUbNB2FOhm1cFZW9xBpDsODqsSWcyYgt
 github.com/ory/dockertest/v3 v3.6.3 h1:L8JWiGgR+fnj90AEOkTFIEp4j5uWAK72P3IUsYgn2cs=
 github.com/ory/dockertest/v3 v3.6.3/go.mod h1:EFLcVUOl8qCwp9NyDAcCDtq/QviLtYswW/VbWzUnTNE=
 github.com/ory/fosite v0.29.0/go.mod h1:0atSZmXO7CAcs6NPMI/Qtot8tmZYj04Nddoold4S2h0=
-github.com/ory/fosite v0.36.0 h1:6XGd9sE0h/y6XJx3L3iRm/UFPHVEnARQch0YFxvxziQ=
-github.com/ory/fosite v0.36.0/go.mod h1:NE15bS1ya8E4J8VmminFY+nsZdoBQu+5/vGF2ELvDsY=
+github.com/ory/fosite v0.39.0 h1:u1Ct/ME7XYzREvufr7ehBIdq/KatjVLIYg/ABqWzprw=
+github.com/ory/fosite v0.39.0/go.mod h1:37r59qkOSPueYKmaA7EHiXrDMF1B+XPN+MgkZgTRg3Y=
 github.com/ory/go-acc v0.0.0-20181118080137-ddc355013f90/go.mod h1:sxnvPCxChFuSmTJGj8FdMupeq1BezCiEpDjTUXQ4hf4=
 github.com/ory/go-acc v0.2.5/go.mod h1:4Kb/UnPcT8qRAk3IAxta+hvVapdxTLWtrr7bFLlEgpw=
 github.com/ory/go-acc v0.2.6 h1:YfI+L9dxI7QCtWn2RbawqO0vXhiThdXu/RgizJBbaq0=
@@ -1353,8 +1353,8 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
-golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c h1:9HhBz5L/UjnK9XLtiZhYAdue5BVKep3PMmS2LuPDt8k=
+golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1502,7 +1502,8 @@ golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a h1:i47hUS795cOydZI4AwJQCKXOr4BvxzvikwDoDtHhP2Y=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -1736,5 +1737,3 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jC
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
-rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
-rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/oauth2/fosite_store_helpers.go
+++ b/oauth2/fosite_store_helpers.go
@@ -178,6 +178,7 @@ func TestHelperRunner(t *testing.T, store InternalRegistry, k string) {
 	t.Run(fmt.Sprintf("case=testFositeStoreSetClientAssertionJWT/db=%s", k), testFositeStoreSetClientAssertionJWT(store))
 	t.Run(fmt.Sprintf("case=testFositeStoreClientAssertionJWTValid/db=%s", k), testFositeStoreClientAssertionJWTValid(store))
 	t.Run(fmt.Sprintf("case=testHelperDeleteAccessTokens/db=%s", k), testHelperDeleteAccessTokens(store))
+	t.Run(fmt.Sprintf("case=testHelperRevokeAccessToken/db=%s", k), testHelperRevokeAccessToken(store))
 }
 
 func testHelperRequestIDMultiples(m InternalRegistry, _ string) func(t *testing.T) {
@@ -380,8 +381,29 @@ func testHelperDeleteAccessTokens(x InternalRegistry) func(t *testing.T) {
 		err = m.DeleteAccessTokens(ctx, defaultRequest.Client.GetID())
 		require.NoError(t, err)
 
+		req, err := m.GetAccessTokenSession(ctx, "4321", &Session{})
+		assert.Nil(t, req)
+		assert.EqualError(t, err, fosite.ErrNotFound.Error())
+	}
+}
+
+func testHelperRevokeAccessToken(x InternalRegistry) func(t *testing.T) {
+	return func(t *testing.T) {
+		m := x.OAuth2Storage()
+		ctx := context.Background()
+
+		err := m.CreateAccessTokenSession(ctx, "4321", &defaultRequest)
+		require.NoError(t, err)
+
 		_, err = m.GetAccessTokenSession(ctx, "4321", &Session{})
-		assert.Error(t, err)
+		require.NoError(t, err)
+
+		err = m.RevokeAccessToken(ctx, defaultRequest.GetID())
+		require.NoError(t, err)
+
+		req, err := m.GetAccessTokenSession(ctx, "4321", &Session{})
+		assert.Nil(t, req)
+		assert.EqualError(t, err, fosite.ErrNotFound.Error())
 	}
 }
 

--- a/oauth2/fosite_store_helpers.go
+++ b/oauth2/fosite_store_helpers.go
@@ -284,11 +284,13 @@ func testHelperRevokeRefreshToken(x InternalRegistry) func(t *testing.T) {
 		err = m.RevokeRefreshToken(ctx, reqIdTwo)
 		require.NoError(t, err)
 
-		_, err = m.GetRefreshTokenSession(ctx, "1111", &Session{})
-		assert.NotNil(t, err)
+		req, err := m.GetRefreshTokenSession(ctx, "1111", &Session{})
+		assert.NotNil(t, req)
+		assert.EqualError(t, err, fosite.ErrInactiveToken.Error())
 
-		_, err = m.GetRefreshTokenSession(ctx, "1122", &Session{})
-		assert.NotNil(t, err)
+		req, err = m.GetRefreshTokenSession(ctx, "1122", &Session{})
+		assert.NotNil(t, req)
+		assert.EqualError(t, err, fosite.ErrInactiveToken.Error())
 
 	}
 }

--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -231,15 +231,15 @@ func (p *Persister) findSessionBySignature(ctx context.Context, rawSignature str
 			return errorsx.WithStack(fosite.ErrNotFound)
 		} else if err != nil {
 			return sqlcon.HandleError(err)
-		} else if !r.Active && table == sqlTableCode {
+		} else if !r.Active {
 			fr, err = r.toRequest(ctx, session, p)
 			if err != nil {
 				return err
-			} else {
+			} else if table == sqlTableCode {
 				return errorsx.WithStack(fosite.ErrInvalidatedAuthorizeCode)
+			} else if table == sqlTableRefresh {
+				return errorsx.WithStack(fosite.ErrInactiveToken)
 			}
-		} else if !r.Active {
-			return errorsx.WithStack(fosite.ErrInactiveToken)
 		}
 
 		fr, err = r.toRequest(ctx, session, p)
@@ -247,7 +247,7 @@ func (p *Persister) findSessionBySignature(ctx context.Context, rawSignature str
 	})
 }
 
-func (p *Persister) deleteSession(ctx context.Context, signature string, table tableName) error {
+func (p *Persister) deleteSessionBySignature(ctx context.Context, signature string, table tableName) error {
 	signature = p.hashSignature(signature, table)
 
 	/* #nosec G201 table is static */
@@ -257,7 +257,7 @@ func (p *Persister) deleteSession(ctx context.Context, signature string, table t
 			Exec())
 }
 
-func (p *Persister) revokeSession(ctx context.Context, id string, table tableName) error {
+func (p *Persister) deleteSessionByRequestID(ctx context.Context, id string, table tableName) error {
 	/* #nosec G201 table is static */
 	if err := p.Connection(ctx).RawQuery(
 		fmt.Sprintf("DELETE FROM %s WHERE request_id=?", OAuth2RequestSQL{Table: table}.TableName()),
@@ -273,6 +273,18 @@ func (p *Persister) revokeSession(ctx context.Context, id string, table tableNam
 		return err
 	}
 	return nil
+}
+
+func (p *Persister) deactivateSessionByRequestID(ctx context.Context, id string, table tableName) error {
+	/* #nosec G201 table is static */
+	return sqlcon.HandleError(
+		p.Connection(ctx).
+			RawQuery(
+				fmt.Sprintf("UPDATE %s SET active=false WHERE request_id=?", OAuth2RequestSQL{Table: table}.TableName()),
+				id,
+			).
+			Exec(),
+	)
 }
 
 func (p *Persister) CreateAuthorizeCodeSession(ctx context.Context, signature string, requester fosite.Requester) (err error) {
@@ -302,7 +314,7 @@ func (p *Persister) GetAccessTokenSession(ctx context.Context, signature string,
 }
 
 func (p *Persister) DeleteAccessTokenSession(ctx context.Context, signature string) (err error) {
-	return p.deleteSession(ctx, signature, sqlTableAccess)
+	return p.deleteSessionBySignature(ctx, signature, sqlTableAccess)
 }
 
 func (p *Persister) CreateRefreshTokenSession(ctx context.Context, signature string, requester fosite.Requester) (err error) {
@@ -314,7 +326,7 @@ func (p *Persister) GetRefreshTokenSession(ctx context.Context, signature string
 }
 
 func (p *Persister) DeleteRefreshTokenSession(ctx context.Context, signature string) (err error) {
-	return p.deleteSession(ctx, signature, sqlTableRefresh)
+	return p.deleteSessionBySignature(ctx, signature, sqlTableRefresh)
 }
 
 func (p *Persister) CreateOpenIDConnectSession(ctx context.Context, signature string, requester fosite.Requester) error {
@@ -326,7 +338,7 @@ func (p *Persister) GetOpenIDConnectSession(ctx context.Context, signature strin
 }
 
 func (p *Persister) DeleteOpenIDConnectSession(ctx context.Context, signature string) error {
-	return p.deleteSession(ctx, signature, sqlTableOpenID)
+	return p.deleteSessionBySignature(ctx, signature, sqlTableOpenID)
 }
 
 func (p *Persister) GetPKCERequestSession(ctx context.Context, signature string, session fosite.Session) (fosite.Requester, error) {
@@ -338,15 +350,15 @@ func (p *Persister) CreatePKCERequestSession(ctx context.Context, signature stri
 }
 
 func (p *Persister) DeletePKCERequestSession(ctx context.Context, signature string) error {
-	return p.deleteSession(ctx, signature, sqlTablePKCE)
+	return p.deleteSessionBySignature(ctx, signature, sqlTablePKCE)
 }
 
 func (p *Persister) RevokeRefreshToken(ctx context.Context, id string) error {
-	return p.revokeSession(ctx, id, sqlTableRefresh)
+	return p.deactivateSessionByRequestID(ctx, id, sqlTableRefresh)
 }
 
 func (p *Persister) RevokeAccessToken(ctx context.Context, id string) error {
-	return p.revokeSession(ctx, id, sqlTableAccess)
+	return p.deleteSessionByRequestID(ctx, id, sqlTableAccess)
 }
 
 func (p *Persister) FlushInactiveAccessTokens(ctx context.Context, notAfter time.Time) error {

--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -237,9 +237,9 @@ func (p *Persister) findSessionBySignature(ctx context.Context, rawSignature str
 				return err
 			} else if table == sqlTableCode {
 				return errorsx.WithStack(fosite.ErrInvalidatedAuthorizeCode)
-			} else if table == sqlTableRefresh {
-				return errorsx.WithStack(fosite.ErrInactiveToken)
 			}
+
+			return errorsx.WithStack(fosite.ErrInactiveToken)
 		}
 
 		fr, err = r.toRequest(ctx, session, p)

--- a/test/e2e/oauth2-client/src/index.js
+++ b/test/e2e/oauth2-client/src/index.js
@@ -456,6 +456,11 @@ app.get('/openid/session/check', async (req, res) => {
   })
 })
 
+app.get('/empty', (req, res) => {
+  res.setHeader('Content-Type', 'text/html')
+  res.send(Buffer.from('<div>Nothing to see here.</div>'))
+})
+
 app.listen(config.port, function () {
   console.log(`Listening on port ${config.port}!`)
 })


### PR DESCRIPTION
## Related issue

Closes #2022

## Proposed changes

This PR leverages support for Refresh Token reuse Detection added in https://github.com/ory/fosite/pull/567. It makes hydra's `Persister` stop deleting refresh tokens, but deactivating them similar to whats done for authorization codes.

Modules need to be updated if PR for fosite gets merged.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

See https://github.com/ory/fosite/pull/567 for fosite PR.
