### PR TITLE
docs: Fix subject identifier algorithms to match configuration

### DIFF
--- a/docs/docs/advanced.md
+++ b/docs/docs/advanced.md
@@ -282,7 +282,7 @@ layout:
 ```yaml
 oidc:
   subject_identifiers:
-    enabled:
+    supported_types:
       - public
       - pairwise
 ```
@@ -294,7 +294,7 @@ When `pairwise` is enabled, you must also set
 ```yaml
 oidc:
   subject_identifiers:
-    enabled:
+    supported_types:
       - public
       - pairwise
     pairwise:

--- a/docs/versioned_docs/version-v1.9/advanced.md
+++ b/docs/versioned_docs/version-v1.9/advanced.md
@@ -282,7 +282,7 @@ layout:
 ```yaml
 oidc:
   subject_identifiers:
-    enabled:
+    supported_types:
       - public
       - pairwise
 ```
@@ -294,7 +294,7 @@ When `pairwise` is enabled, you must also set
 ```yaml
 oidc:
   subject_identifiers:
-    enabled:
+    supported_types:
       - public
       - pairwise
     pairwise:


### PR DESCRIPTION
On https://www.ory.sh/hydra/docs/reference/configuration/ under 'subject identifiers' the name for defining which subject identifier algorithms are supported it is called "supported_types", not "enabled" as in these pages.

Testing shows that "supported_types" is the correct value for use in Hydra.


## Related issue

No related issue

## Proposed changes

Update documentation page to match reality

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

The page I have made a change to created some confusion when we enabled pairwise subject identifiers.
I don't care to read all the policies, as it is a miniscule change. Sorry.