### PR TITLE
feat: Add all subjects option to list consent sessions endpoint

### DIFF
--- a/consent/doc.go
+++ b/consent/doc.go
@@ -62,9 +62,15 @@ type swaggerRevokeConsentSessions struct {
 
 // swagger:parameters listSubjectConsentSessions
 type swaggerListSubjectConsentSessionsPayload struct {
+	// If set, lists only those consent sessions by the Subject that have been granted
+	//
 	// in: query
-	// required: true
 	Subject string `json:"subject"`
+
+	// If set to `?all=true`, lists consent sessions by all subjects that have been granted.
+	//
+	// in: query
+	All bool `json:"all"`
 }
 
 // swagger:parameters revokeAuthenticationSession

--- a/consent/manager.go
+++ b/consent/manager.go
@@ -47,7 +47,9 @@ type Manager interface {
 	VerifyAndInvalidateConsentRequest(ctx context.Context, verifier string) (*HandledConsentRequest, error)
 	FindGrantedAndRememberedConsentRequests(ctx context.Context, client, user string) ([]HandledConsentRequest, error)
 	FindSubjectsGrantedConsentRequests(ctx context.Context, user string, limit, offset int) ([]HandledConsentRequest, error)
+	FindGrantedConsentRequests(ctx context.Context, limit, offset int) ([]HandledConsentRequest, error)
 	CountSubjectsGrantedConsentRequests(ctx context.Context, user string) (int, error)
+	CountGrantedConsentRequests(ctx context.Context) (int, error)
 
 	// Cookie management
 	GetRememberedLoginSession(ctx context.Context, id string) (*LoginSession, error)

--- a/consent/manager_test_helpers.go
+++ b/consent/manager_test_helpers.go
@@ -638,7 +638,14 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 				},
 			} {
 				t.Run(fmt.Sprintf("case=%d/subject=%s", i, tc.subject), func(t *testing.T) {
-					consents, err := m.FindSubjectsGrantedConsentRequests(context.Background(), tc.subject, 100, 0)
+					var consents []HandledConsentRequest
+					var err error
+					switch {
+					case tc.subject == "":
+						consents, err = m.FindGrantedConsentRequests(context.Background(), 100, 0)
+					default:
+						consents, err = m.FindSubjectsGrantedConsentRequests(context.Background(), tc.subject, 100, 0)
+					}
 					assert.Equal(t, len(tc.challenges), len(consents))
 
 					if len(tc.challenges) == 0 {
@@ -650,8 +657,13 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 							assert.Contains(t, tc.clients, consent.ConsentRequest.Client.OutfacingID)
 						}
 					}
-
-					n, err := m.CountSubjectsGrantedConsentRequests(context.Background(), tc.subject)
+					var n int
+					switch {
+					case tc.subject == "":
+						n, err = m.CountGrantedConsentRequests(context.Background())
+					default:
+						n, err = m.CountSubjectsGrantedConsentRequests(context.Background(), tc.subject)
+					}
 					require.NoError(t, err)
 					assert.Equal(t, n, len(tc.challenges))
 

--- a/consent/sdk_test.go
+++ b/consent/sdk_test.go
@@ -149,15 +149,19 @@ func TestSDK(t *testing.T) {
 	_, err = sdk.Admin.GetConsentRequest(admin.NewGetConsentRequestParams().WithConsentChallenge("challenge2"))
 	require.Error(t, err)
 
-	csGot, err := sdk.Admin.ListSubjectConsentSessions(admin.NewListSubjectConsentSessionsParams().WithSubject("subject3"))
+	csGot, err := sdk.Admin.ListSubjectConsentSessions(admin.NewListSubjectConsentSessionsParams().WithSubject(pointerx.String("subject3")))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(csGot.Payload))
 	cs := csGot.Payload[0]
 	assert.Equal(t, "challenge3", *cs.ConsentRequest.Challenge)
 
-	csGot, err = sdk.Admin.ListSubjectConsentSessions(admin.NewListSubjectConsentSessionsParams().WithSubject("subject2"))
+	csGot, err = sdk.Admin.ListSubjectConsentSessions(admin.NewListSubjectConsentSessionsParams().WithSubject(pointerx.String("subject2")))
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(csGot.Payload))
+
+	csGot, err = sdk.Admin.ListSubjectConsentSessions(admin.NewListSubjectConsentSessionsParams().WithAll(pointerx.Bool(true)))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(csGot.Payload))
 
 	luGot, err := sdk.Admin.GetLogoutRequest(admin.NewGetLogoutRequestParams().WithLogoutChallenge("challengetestsdk-1"))
 	require.NoError(t, err)

--- a/internal/httpclient/client/admin/list_subject_consent_sessions_parameters.go
+++ b/internal/httpclient/client/admin/list_subject_consent_sessions_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewListSubjectConsentSessionsParams creates a new ListSubjectConsentSessionsParams object,
@@ -59,8 +60,17 @@ func NewListSubjectConsentSessionsParamsWithHTTPClient(client *http.Client) *Lis
 */
 type ListSubjectConsentSessionsParams struct {
 
-	// Subject.
-	Subject string
+	/* All.
+
+	   If set to `?all=true`, lists consent sessions by all subjects that have been granted.
+	*/
+	All *bool
+
+	/* Subject.
+
+	   If set, lists only those consent sessions by the Subject that have been granted
+	*/
+	Subject *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -115,14 +125,25 @@ func (o *ListSubjectConsentSessionsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithAll adds the all to the list subject consent sessions params
+func (o *ListSubjectConsentSessionsParams) WithAll(all *bool) *ListSubjectConsentSessionsParams {
+	o.SetAll(all)
+	return o
+}
+
+// SetAll adds the all to the list subject consent sessions params
+func (o *ListSubjectConsentSessionsParams) SetAll(all *bool) {
+	o.All = all
+}
+
 // WithSubject adds the subject to the list subject consent sessions params
-func (o *ListSubjectConsentSessionsParams) WithSubject(subject string) *ListSubjectConsentSessionsParams {
+func (o *ListSubjectConsentSessionsParams) WithSubject(subject *string) *ListSubjectConsentSessionsParams {
 	o.SetSubject(subject)
 	return o
 }
 
 // SetSubject adds the subject to the list subject consent sessions params
-func (o *ListSubjectConsentSessionsParams) SetSubject(subject string) {
+func (o *ListSubjectConsentSessionsParams) SetSubject(subject *string) {
 	o.Subject = subject
 }
 
@@ -134,13 +155,37 @@ func (o *ListSubjectConsentSessionsParams) WriteToRequest(r runtime.ClientReques
 	}
 	var res []error
 
-	// query param subject
-	qrSubject := o.Subject
-	qSubject := qrSubject
-	if qSubject != "" {
+	if o.All != nil {
 
-		if err := r.SetQueryParam("subject", qSubject); err != nil {
-			return err
+		// query param all
+		var qrAll bool
+
+		if o.All != nil {
+			qrAll = *o.All
+		}
+		qAll := swag.FormatBool(qrAll)
+		if qAll != "" {
+
+			if err := r.SetQueryParam("all", qAll); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Subject != nil {
+
+		// query param subject
+		var qrSubject string
+
+		if o.Subject != nil {
+			qrSubject = *o.Subject
+		}
+		qSubject := qrSubject
+		if qSubject != "" {
+
+			if err := r.SetQueryParam("subject", qSubject); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/httpclient/models/volume.go
+++ b/internal/httpclient/models/volume.go
@@ -42,8 +42,7 @@ type Volume struct {
 	// Required: true
 	Options map[string]string `json:"Options"`
 
-	// The level at which the volume exists. Either `global` for cluster-wide,
-	// or `local` for machine level.
+	// The level at which the volume exists. Either `global` for cluster-wide, or `local` for machine level.
 	// Required: true
 	Scope *string `json:"Scope"`
 

--- a/spec/api.json
+++ b/spec/api.json
@@ -1366,9 +1366,15 @@
         "parameters": [
           {
             "type": "string",
+            "description": "If set, lists only those consent sessions by the Subject that have been granted",
             "name": "subject",
-            "in": "query",
-            "required": true
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "If set to `?all=true`, lists consent sessions by all subjects that have been granted.",
+            "name": "all",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2447,7 +2453,7 @@
           }
         },
         "Scope": {
-          "description": "The level at which the volume exists. Either `global` for cluster-wide,\nor `local` for machine level.",
+          "description": "The level at which the volume exists. Either `global` for cluster-wide, or `local` for machine level.",
           "type": "string"
         },
         "Status": {


### PR DESCRIPTION



## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
This adds `all` subjects option to list consent sessions endpoint: https://www.ory.sh/hydra/docs/reference/api#lists-all-consent-sessions-of-a-subject

This is to allow getting for all subjects explicitly instead of for a single subject.

It follows similar to `all` option for the endpoint to revoke consent sessions for a subject (for a specific client or all clients).

Regenerated swagger based code:
```
make sdk
```

Test passed:
```
make test
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
