### PR TITLE
feat: Enable "nbf" (not before) claim to be optional for Access Token

### DIFF
--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -78,6 +78,7 @@ const (
 	KeyGrantAllClientCredentialsScopesPerDefault = "oauth2.client_credentials.default_grant_allowed_scope"
 	KeyExposeOAuth2Debug                         = "oauth2.expose_internal_errors"
 	KeyOAuth2LegacyErrors                        = "oauth2.include_legacy_error_fields"
+	KeyExcludeNotBeforeClaim                     = "oauth2.exclude_not_before_claim"
 )
 
 const DSNMemory = "memory"
@@ -235,6 +236,10 @@ func (p *Provider) DSN() string {
 
 func (p *Provider) EncryptSessionData() bool {
 	return p.p.BoolF(KeyEncryptSessionData, true)
+}
+
+func (p *Provider) ExcludeNotBeforeClaim() bool {
+	return p.p.BoolF(KeyExcludeNotBeforeClaim, false)
 }
 
 func (p *Provider) DataSourcePlugin() string {

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -724,10 +724,11 @@ func (h *Handler) AuthHandler(w http.ResponseWriter, r *http.Request, _ httprout
 			}},
 			Subject: session.ConsentRequest.Subject,
 		},
-		Extra:            session.Session.AccessToken,
-		KID:              accessTokenKeyID,
-		ClientID:         authorizeRequest.GetClient().GetID(),
-		ConsentChallenge: session.ID,
+		Extra:                 session.Session.AccessToken,
+		KID:                   accessTokenKeyID,
+		ClientID:              authorizeRequest.GetClient().GetID(),
+		ConsentChallenge:      session.ID,
+		ExcludeNotBeforeClaim: h.c.ExcludeNotBeforeClaim(),
 	})
 	if err != nil {
 		x.LogError(r, err, h.r.Logger())

--- a/oauth2/session.go
+++ b/oauth2/session.go
@@ -36,6 +36,7 @@ type Session struct {
 	KID                    string
 	ClientID               string
 	ConsentChallenge       string
+	ExcludeNotBeforeClaim  bool
 }
 
 func NewSession(subject string) *Session {
@@ -56,7 +57,6 @@ func (s *Session) GetJWTClaims() jwt.JWTClaimsContainer {
 		Extra:     map[string]interface{}{"ext": s.Extra},
 		ExpiresAt: s.GetExpiresAt(fosite.AccessToken),
 		IssuedAt:  time.Now(),
-		NotBefore: time.Now(),
 
 		// No need to set the audience because that's being done by fosite automatically.
 		// Audience:  s.Audience,
@@ -70,6 +70,9 @@ func (s *Session) GetJWTClaims() jwt.JWTClaimsContainer {
 		// Setting these here will cause the token to have the same iat/nbf values always
 		// IssuedAt:  s.DefaultSession.Claims.IssuedAt,
 		// NotBefore: s.DefaultSession.Claims.IssuedAt,
+	}
+	if !s.ExcludeNotBeforeClaim {
+		claims.NotBefore = claims.IssuedAt
 	}
 
 	if claims.Extra == nil {

--- a/spec/config.json
+++ b/spec/config.json
@@ -766,6 +766,14 @@
             true
           ]
         },
+        "exclude_not_before_claim": {
+          "type": "boolean",
+          "description": "Set to true if you want to exclude claim `nbf (not before)` part of access token.",
+          "default": false,
+          "examples": [
+            true
+          ]
+        },
         "hashers": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
## Related issue
[1542](https://github.com/ory/hydra/issues/1542)

## Proposed changes
Enable "nbf" (not before) claim to be optional as part of Access Token. This is compatible given the existing standard.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

Unsure where I should append the required tests, please advice. Executed all tests as part of package of `oauth2`.