### PR TITLE
fix: Use PublicURL where given

### DIFF
--- a/consent/handler.go
+++ b/consent/handler.go
@@ -701,7 +701,7 @@ func (h *Handler) AcceptLogoutRequest(w http.ResponseWriter, r *http.Request, ps
 	}
 
 	h.r.Writer().Write(w, r, &RequestHandlerResponse{
-		RedirectTo: urlx.SetQuery(urlx.AppendPaths(h.c.IssuerURL(), "/oauth2/sessions/logout"), url.Values{"logout_verifier": {c.Verifier}}).String(),
+		RedirectTo: urlx.SetQuery(urlx.AppendPaths(h.c.PublicURL(), "/oauth2/sessions/logout"), url.Values{"logout_verifier": {c.Verifier}}).String(),
 	})
 }
 

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -417,8 +417,8 @@ func (p *Provider) adminFallbackURL(path string) *url.URL {
 }
 
 func (p *Provider) publicFallbackURL(path string) *url.URL {
-	if len(p.IssuerURL().String()) > 0 {
-		return urlx.AppendPaths(p.IssuerURL(), path)
+	if len(p.PublicURL().String()) > 0 {
+		return urlx.AppendPaths(p.PublicURL(), path)
 	}
 
 	return p.fallbackURL(path, p.publicHost(), p.publicPort())
@@ -454,7 +454,7 @@ func (p *Provider) ErrorURL() *url.URL {
 }
 
 func (p *Provider) PublicURL() *url.URL {
-	return urlRoot(p.p.RequestURIF(KeyPublicURL, p.publicFallbackURL("/")))
+	return urlRoot(p.p.RequestURIF(KeyPublicURL, p.IssuerURL()))
 }
 
 func (p *Provider) IssuerURL() *url.URL {
@@ -468,11 +468,11 @@ func (p *Provider) OAuth2ClientRegistrationURL() *url.URL {
 }
 
 func (p *Provider) OAuth2TokenURL() *url.URL {
-	return p.p.RequestURIF(KeyOAuth2TokenURL, urlx.AppendPaths(p.IssuerURL(), "/oauth2/token"))
+	return p.p.RequestURIF(KeyOAuth2TokenURL, urlx.AppendPaths(p.PublicURL(), "/oauth2/token"))
 }
 
 func (p *Provider) OAuth2AuthURL() *url.URL {
-	return p.p.RequestURIF(KeyOAuth2AuthURL, urlx.AppendPaths(p.IssuerURL(), "/oauth2/auth"))
+	return p.p.RequestURIF(KeyOAuth2AuthURL, urlx.AppendPaths(p.PublicURL(), "/oauth2/auth"))
 }
 
 func (p *Provider) JWKSURL() *url.URL {

--- a/driver/config/provider_test.go
+++ b/driver/config/provider_test.go
@@ -146,6 +146,36 @@ func TestProviderIssuerURL(t *testing.T) {
 	assert.Equal(t, "http://hydra.localhost/", p2.IssuerURL().String())
 }
 
+func TestProviderIssuerPublicURL(t *testing.T) {
+	l := logrusx.New("", "")
+	l.Logrus().SetOutput(ioutil.Discard)
+	p := MustNew(l)
+	p.MustSet(KeyIssuerURL, "http://hydra.localhost")
+	p.MustSet(KeyPublicURL, "http://hydra.example")
+
+	assert.Equal(t, "http://hydra.localhost/", p.IssuerURL().String())
+	assert.Equal(t, "http://hydra.example/", p.PublicURL().String())
+	assert.Equal(t, "http://hydra.localhost/.well-known/jwks.json", p.JWKSURL().String())
+	assert.Equal(t, "http://hydra.example/oauth2/fallbacks/consent", p.ConsentURL().String())
+	assert.Equal(t, "http://hydra.example/oauth2/fallbacks/login", p.LoginURL().String())
+	assert.Equal(t, "http://hydra.example/oauth2/fallbacks/logout", p.LogoutURL().String())
+	assert.Equal(t, "http://hydra.example/oauth2/token", p.OAuth2TokenURL().String())
+	assert.Equal(t, "http://hydra.example/oauth2/auth", p.OAuth2AuthURL().String())
+	assert.Equal(t, "http://hydra.example/userinfo", p.OIDCDiscoveryUserinfoEndpoint().String())
+
+	p2 := MustNew(l)
+	p2.MustSet(KeyIssuerURL, "http://hydra.localhost")
+	assert.Equal(t, "http://hydra.localhost/", p2.IssuerURL().String())
+	assert.Equal(t, "http://hydra.localhost/", p2.PublicURL().String())
+	assert.Equal(t, "http://hydra.localhost/.well-known/jwks.json", p2.JWKSURL().String())
+	assert.Equal(t, "http://hydra.localhost/oauth2/fallbacks/consent", p2.ConsentURL().String())
+	assert.Equal(t, "http://hydra.localhost/oauth2/fallbacks/login", p2.LoginURL().String())
+	assert.Equal(t, "http://hydra.localhost/oauth2/fallbacks/logout", p2.LogoutURL().String())
+	assert.Equal(t, "http://hydra.localhost/oauth2/token", p2.OAuth2TokenURL().String())
+	assert.Equal(t, "http://hydra.localhost/oauth2/auth", p2.OAuth2AuthURL().String())
+	assert.Equal(t, "http://hydra.localhost/userinfo", p2.OIDCDiscoveryUserinfoEndpoint().String())
+}
+
 func TestProviderCookieSameSiteMode(t *testing.T) {
 	l := logrusx.New("", "")
 	l.Logrus().SetOutput(ioutil.Discard)


### PR DESCRIPTION
## Related issue

#2422 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Use `urls.self.public` where possible and given, falling back to `urls.self.issuer`. Well-known URLs are continue to use `urls.self.issuer`.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
