### PR TITLE
fix: Do not use error_hint anymore

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -281,14 +281,14 @@ func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		rfcerr := fosite.ErrorToRFC6749Error(err)
 		if rfcerr.StatusCode() == http.StatusUnauthorized {
-			w.Header().Set("WWW-Authenticate", fmt.Sprintf("error=%s,error_description=%s,error_hint=%s", rfcerr.ErrorField, rfcerr.DescriptionField, rfcerr.HintField))
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("error=%s,error_description=%s", rfcerr.ErrorField, rfcerr.GetDescription()))
 		}
 		h.r.Writer().WriteError(w, r, err)
 		return
 	}
 
 	if tokenType != fosite.AccessToken {
-		errorDescription := "Only access tokens are allowed in the authorization header"
+		errorDescription := "Only access tokens are allowed in the authorization header."
 		w.Header().Set("WWW-Authenticate", fmt.Sprintf("error_description=\"%s\"", errorDescription))
 		h.r.Writer().WriteErrorCode(w, r, http.StatusUnauthorized, errors.New(errorDescription))
 		return


### PR DESCRIPTION
## Proposed changes

Just a small fix to get rid of non-standard `error_hint`.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
