### PR TITLE
fix: Fixed WWW-Authenticate header in userinfo handler

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -263,6 +263,10 @@ func (h *Handler) WellKnownHandler(w http.ResponseWriter, r *http.Request) {
 //
 // For more information please [refer to the spec](http://openid.net/specs/openid-connect-core-1_0.html#UserInfo).
 //
+// In the case of authentication error, a WWW-Authenticate header might be set in the response
+// with more information about the error. See [the spec](https://datatracker.ietf.org/doc/html/rfc6750#section-3)
+// for more details about header format.
+//
 //     Produces:
 //     - application/json
 //
@@ -281,7 +285,7 @@ func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		rfcerr := fosite.ErrorToRFC6749Error(err)
 		if rfcerr.StatusCode() == http.StatusUnauthorized {
-			w.Header().Set("WWW-Authenticate", fmt.Sprintf("error=%s,error_description=%s", rfcerr.ErrorField, rfcerr.GetDescription()))
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="%s",error_description="%s"`, rfcerr.ErrorField, rfcerr.GetDescription()))
 		}
 		h.r.Writer().WriteError(w, r, err)
 		return
@@ -289,7 +293,7 @@ func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request) {
 
 	if tokenType != fosite.AccessToken {
 		errorDescription := "Only access tokens are allowed in the authorization header."
-		w.Header().Set("WWW-Authenticate", fmt.Sprintf("error_description=\"%s\"", errorDescription))
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_token",error_description="%s"`, errorDescription))
 		h.r.Writer().WriteErrorCode(w, r, http.StatusUnauthorized, errors.New(errorDescription))
 		return
 	}

--- a/oauth2/handler_test.go
+++ b/oauth2/handler_test.go
@@ -190,7 +190,7 @@ func TestUserinfo(t *testing.T) {
 					Return(fosite.RefreshToken, nil, nil)
 			},
 			checkForUnauthorized: func(t *testing.T, body []byte, headers http.Header) {
-				assert.True(t, headers.Get("WWW-Authenticate") != "", "%s", headers)
+				assert.True(t, headers.Get("WWW-Authenticate") == `Bearer error="invalid_token",error_description="Only access tokens are allowed in the authorization header."`, "%s", headers)
 			},
 			expectStatusCode: http.StatusUnauthorized,
 		},
@@ -201,7 +201,7 @@ func TestUserinfo(t *testing.T) {
 					Return(fosite.AccessToken, nil, fosite.ErrRequestUnauthorized)
 			},
 			checkForUnauthorized: func(t *testing.T, body []byte, headers http.Header) {
-				assert.True(t, headers.Get("WWW-Authenticate") != "", "%s", headers)
+				assert.True(t, headers.Get("WWW-Authenticate") == `Bearer error="request_unauthorized",error_description="The request could not be authorized. Check that you provided valid credentials in the right format."`, "%s", headers)
 			},
 			expectStatusCode: http.StatusUnauthorized,
 		},


### PR DESCRIPTION
## Proposed changes

Fixing the header value based on the spec.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
