### PR TITLE
fix: Audience should include client ID

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -308,9 +308,22 @@ func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request) {
 	delete(interim, "sid")
 	delete(interim, "jti")
 
-	if aud, ok := interim["aud"].([]string); !ok || len(aud) == 0 {
-		interim["aud"] = []string{c.GetID()}
+	aud, ok := interim["aud"].([]string)
+	if !ok || len(aud) == 0 {
+		aud = []string{c.GetID()}
+	} else {
+		found := false
+		for _, a := range aud {
+			if a == c.GetID() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			aud = append(aud, c.GetID())
+		}
 	}
+	interim["aud"] = aud
 
 	if c.UserinfoSignedResponseAlg == "RS256" {
 		interim["jti"] = uuid.New()


### PR DESCRIPTION
## Proposed changes

[The spec](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) says:

> The aud value SHOULD be or include the RP's Client ID value. 

So this makes sure client ID is always there. It is true though that that section talks only about the situation when response is signed.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
