### PR TITLE
docs: Fix {Go,JS,PHP} SDK links

### DIFF
--- a/docs/versioned_docs/version-v1.10/sdk.md
+++ b/docs/versioned_docs/version-v1.10/sdk.md
@@ -37,8 +37,9 @@ repositories:
 
 We also provide more info for these SDKs:
 
-- [Golang](sdk/go)
-- [JavaScript](sdk/js)
+- [Go](./go)
+- [JavaScript](./js)
+- [PHP](./php)
 
 Take a look at the source: [Generated SDKs for Ory Hydra](https://github.com/ory/sdk/tree/master/clients/hydra/)
 


### PR DESCRIPTION
The current doc https://www.ory.sh/hydra/docs/sdk/ links to 404:
> We also provide more info for these SDKs:
>
>  -  [Golang](https://www.ory.sh/hydra/docs/sdk/sdk/go)
> -   [JavaScript](https://www.ory.sh/hydra/docs/sdk/sdk/js)

This PR fixes this (and adds PHP)