### PR TITLE
fix: link in documentation

### DIFF
--- a/docs/docs/guides/login.mdx
+++ b/docs/docs/guides/login.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem'
 
 :::note
 
-Please read the [Login Flow Documentation](../concepts/login) first!
+Please read the [Login Flow Documentation](../concepts/login.mdx) first!
 
 :::
 

--- a/docs/versioned_docs/version-v1.10/guides/login.mdx
+++ b/docs/versioned_docs/version-v1.10/guides/login.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem'
 
 :::note
 
-Please read the [Login Flow Documentation](../concepts/login) first!
+Please read the [Login Flow Documentation](../concepts/login.mdx) first!
 
 :::
 


### PR DESCRIPTION
## Related issue

## Proposed changes
Currently, I receive a 404 error if I want to be redirected to 'Login flow page' via this link, this PR fix it

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments
