### PR TITLE
fix: Make token user command work with public clients

### DIFF
--- a/cmd/token_user.go
+++ b/cmd/token_user.go
@@ -115,12 +115,12 @@ and success, unless if the --no-shutdown flag is provided.`,
 			noShutdown := flagx.MustGetBool(cmd, "no-shutdown")
 
 			clientID := flagx.MustGetString(cmd, "client-id")
-			clientSecret := flagx.MustGetString(cmd, "client-secret")
-			if clientID == "" || clientSecret == "" {
+			if clientID == "" {
 				fmt.Print(cmd.UsageString())
-				fmt.Println("Please provide a Client ID and Client Secret using flags --client-id and --client-secret, or environment variables OAUTH2_CLIENT_ID and OAUTH2_CLIENT_SECRET.")
+				fmt.Println("Please provide a Client ID using --client-id flag, or OAUTH2_CLIENT_ID environment variable.")
 				return
 			}
+			clientSecret := flagx.MustGetString(cmd, "client-secret")
 
 			proto := "http"
 			if isSSL {


### PR DESCRIPTION
## Related issue

See thread: https://ory-community.slack.com/archives/C012RBW0F18/p1618883706197100

## Proposed changes

- [x] Do not require client secret when running `hydra token user` making it work with public clients

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).



