### PR TITLE
feat: Add the MaxTagValueLength config for jaeger of tracing

### DIFF
--- a/driver/config/provider_test.go
+++ b/driver/config/provider_test.go
@@ -308,6 +308,7 @@ func TestViperProviderValidates(t *testing.T) {
 			SamplerValue:       1,
 			SamplerServerURL:   "http://sampling",
 			Propagation:        "jaeger",
+			MaxTagValueLength:  1024,
 		},
 		Zipkin: &tracing.ZipkinConfig{
 			ServerURL: "http://zipkin/api/v2/spans",

--- a/go.mod
+++ b/go.mod
@@ -43,12 +43,12 @@ require (
 	github.com/oleiade/reflections v1.0.0
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/ory/analytics-go/v4 v4.0.1
-	github.com/ory/cli v0.0.48
+	github.com/ory/cli v0.0.49
 	github.com/ory/fosite v0.39.0
 	github.com/ory/go-acc v0.2.6
 	github.com/ory/graceful v0.1.1
 	github.com/ory/herodot v0.9.3
-	github.com/ory/x v0.0.212
+	github.com/ory/x v0.0.219
 	github.com/pborman/uuid v1.2.1
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -881,6 +881,8 @@ github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jandelgado/gcov2lcov v1.0.4-0.20210120124023-b83752c6dc08 h1:vn5CHED3UxZKIneSxETU9SXXGgsILP8hZHlx+M0u1BQ=
 github.com/jandelgado/gcov2lcov v1.0.4-0.20210120124023-b83752c6dc08/go.mod h1:NnSxK6TMlg1oGDBfGelGbjgorT5/L3cchlbtgFYZSss=
+github.com/jandelgado/gcov2lcov v1.0.4 h1:ADwQPyNsxguqzznIbfQTENwY9FU88JdXEvpdHR9c48A=
+github.com/jandelgado/gcov2lcov v1.0.4/go.mod h1:NnSxK6TMlg1oGDBfGelGbjgorT5/L3cchlbtgFYZSss=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1135,6 +1137,8 @@ github.com/ory/cli v0.0.35/go.mod h1:8iyLto6q8TiVgxbm4/D64Mt+Tavk1k18g786ZDM298Q
 github.com/ory/cli v0.0.41/go.mod h1:l5KYqpqmTB81BF+SlHwgH56Fp5IY+TMIdFKTPDkPolw=
 github.com/ory/cli v0.0.48 h1:cAX2BJhyGOFQgwnidxTvOZLoIbmQsBNEj0IYJ+lGO9s=
 github.com/ory/cli v0.0.48/go.mod h1:IH1juqUjTWCVFM3PzINym92O0AACtSqQ6p/jgqaxvec=
+github.com/ory/cli v0.0.49 h1:VFmctThbFr3GR9tZAQkX+C2wz8gMTi6f287cLxfMDQ4=
+github.com/ory/cli v0.0.49/go.mod h1:IH1juqUjTWCVFM3PzINym92O0AACtSqQ6p/jgqaxvec=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/dockertest/v3 v3.5.4/go.mod h1:J8ZUbNB2FOhm1cFZW9xBpDsODqsSWcyYgtJYVPcnF70=
@@ -1199,6 +1203,8 @@ github.com/ory/x v0.0.205/go.mod h1:A1s4iwmFIppRXZLF3J9GGWeY/HpREVm0Dk5z/787iek=
 github.com/ory/x v0.0.207/go.mod h1:sBgvUAcmc2lmtOBe5VMcV2vNAlADT4bkFHomG29y7N4=
 github.com/ory/x v0.0.212 h1:7PpEOdrXGP/tMGyv0m1ERy74oCS/Z11hlkxVs9OC1GE=
 github.com/ory/x v0.0.212/go.mod h1:RDxYOolvMdzumYnHWha8D+RoLjYtGszyDDed4OCGC54=
+github.com/ory/x v0.0.219 h1:1crcXRS4QiwzPUIww92A7cR8iqzugG7MRbg0G/UMKDY=
+github.com/ory/x v0.0.219/go.mod h1:+IoYSpjkno72PwxqScyNAVAD2ffZE6SjuFrdb2lU5Kg=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/parnurzeal/gorequest v0.2.15/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/internal/.hydra.yaml
+++ b/internal/.hydra.yaml
@@ -135,6 +135,7 @@ tracing:
     jaeger:
       local_agent_address: 127.0.0.1:6831
       propagation: jaeger
+      max_tag_value_length: 1024
       sampling:
         type: const
         value: 1

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -433,6 +433,8 @@ tracing:
       local_agent_address: 127.0.0.1:6831
       # The tracing header format
       propagation: jaeger
+      # The maximum length of jaeger tag value
+      max_tag_value_length: 1024
       sampling:
         # The type of the sampler you want to use. Supports:
         # - const

--- a/spec/config.json
+++ b/spec/config.json
@@ -937,6 +937,11 @@
                     "jaeger"
                   ]
                 },
+                "max_tag_value_length": {
+                  "type": "integer",
+                  "description": "The value passed to the max tag value length that has been configured.",
+                  "minimum": 0
+                },
                 "sampling": {
                   "type": "object",
                   "propertyNames": {


### PR DESCRIPTION
## Related issue

#2447 

## Proposed changes

Integration with this change [feat: [Jaeger] Add maxTagValueLength for the feature request #2447](https://github.com/ory/x/pull/327) and make it configurable in ory/hydra. 

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).