### PR TITLE
fix: add the missing keys import command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func RegisterCommandRecursive(parent *cobra.Command) {
 	keyCmd.AddCommand(NewKeysCreateCmd())
 	keyCmd.AddCommand(NewKeysDeleteCmd())
 	keyCmd.AddCommand(NewKeysGetCmd())
+	keyCmd.AddCommand(NewKeysImportCmd())
 
 	migrateCmd := NewMigrateCmd()
 	parent.AddCommand(migrateCmd)


### PR DESCRIPTION
## Related issue

#2520

## Proposed changes

It looks like the `clientCmd.AddCommand(NewKeysImportCmd())` line was missed during a recent refactor, I just added it.

## Checklist

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

I looked briefly at adding tests but it looked like it would require some refactoring of the current strategy. If you would like me to look into it I can spend some time on it.
