### PR TITLE
fix(oauth2): enforce assertion check on userinfo aud field

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -308,7 +308,7 @@ func (h *Handler) UserinfoHandler(w http.ResponseWriter, r *http.Request) {
 	delete(interim, "sid")
 	delete(interim, "jti")
 
-	if aud := interim["aud"].([]string); !ok || len(aud) == 0 {
+	if aud, ok := interim["aud"].([]string); !ok || len(aud) == 0 {
 		interim["aud"] = []string{c.GetID()}
 	}
 


### PR DESCRIPTION
## Related issue

N/A

## Proposed changes

This is so the check on the `ok` variable is effectual. Prior to this patch the type assertion on the *client.Client was setting the value of `ok`. Due to the fact the type assertion on *client.Client is already checked and on a false value it exits the func, this value will *always* be true.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

On the following line interim["aud"] is asserted as a string but never actually checked if the assertion is successful. 

https://github.com/ory/hydra/blob/master/oauth2/handler.go#L311

Why this doesn't fail entirely is above it you're setting `ok` when type asserting the client.

https://github.com/ory/hydra/blob/master/oauth2/handler.go#L297

Theoretically the result of the flow of this code section, what would happen is either:
1. the line asserting the client will not be ok, and the function will return after writing the error and the check on the `ok` variable will never occur
2. the line asserting the client will be ok and the function will continue to the assertion of the aud field, but `ok` is never assigned to again, so will always be true

Both scenarios result is effectively the same.
