### PR TITLE
fix: parameter for Private Key in config

### DIFF
--- a/spec/config.json
+++ b/spec/config.json
@@ -230,7 +230,7 @@
           ]
         },
         "cert": {
-          "description": "Configures the private key (pem encoded).",
+          "description": "Configures the public certificate (pem encoded).",
           "allOf": [
             {
               "$ref": "#/definitions/pem_file"


### PR DESCRIPTION
>So the line that says "cert - Configures the private key" in the example config file is incorrect. It should be changed to read "Configures the certificate" or possibly "Configures the public certificate".

Thanks a lot for spotting and basically fixing this,  @pha3z

## Related issue

https://github.com/ory/hydra/discussions/2587
