### PR TITLE
chore: docs sidebar uniform

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,7 +1,7 @@
 ---
 id: index
 slug: /
-title: ORY Hydra
+title: Introduction
 sidebar_label: Introduction
 ---
 


### PR DESCRIPTION
Just small change so it looks uniform for all projects in ory.sh/docs
```
Ory Hydra:
- Introduction 
     - Introduction
```
instead of 
```
Ory Hydra:
- Introduction 
     - ORY Hydra
```