### PR TITLE
fix: correct CodeFromRemote syntax

### DIFF
--- a/docs/docs/5min-tutorial.mdx
+++ b/docs/docs/5min-tutorial.mdx
@@ -192,7 +192,11 @@ You can find it in
 The configuration gets loaded in docker-compose as specified in the
 [`quickstart.yml`](https://github.com/ory/hydra/blob/master/quickstart.yml).
 
-<CodeFromRemote src="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml" />
+<CodeFromRemote
+  lang="js"
+  link="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml"
+  src="https://raw.githubusercontent.com/ory/hydra/master/contrib/quickstart/5-min/hydra.yml"
+/>
 
 Have a look at the [reference configuration](./reference/configuration.md) for
 further information on all possible configuration options.

--- a/docs/versioned_docs/version-v1.10/5min-tutorial.mdx
+++ b/docs/versioned_docs/version-v1.10/5min-tutorial.mdx
@@ -195,7 +195,8 @@ The configuration gets loaded in docker-compose as specified in the
 <CodeFromRemote 
   lang="js"
   link="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml"
-src="https://raw.githubusercontent.com/ory/hydra/master/contrib/quickstart/5-min/hydra.yml" />
+  src="https://raw.githubusercontent.com/ory/hydra/master/contrib/quickstart/5-min/hydra.yml" 
+/>
 
 Have a look at the [reference configuration](./reference/configuration.md) for
 further information on all possible configuration options.

--- a/docs/versioned_docs/version-v1.10/5min-tutorial.mdx
+++ b/docs/versioned_docs/version-v1.10/5min-tutorial.mdx
@@ -192,7 +192,10 @@ You can find it in
 The configuration gets loaded in docker-compose as specified in the
 [`quickstart.yml`](https://github.com/ory/hydra/blob/master/quickstart.yml).
 
-<CodeFromRemote src="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml" />
+<CodeFromRemote 
+  lang="js"
+  link="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml"
+src="https://raw.githubusercontent.com/ory/hydra/master/contrib/quickstart/5-min/hydra.yml" />
 
 Have a look at the [reference configuration](./reference/configuration.md) for
 further information on all possible configuration options.

--- a/docs/versioned_docs/version-v1.9/5min-tutorial.mdx
+++ b/docs/versioned_docs/version-v1.9/5min-tutorial.mdx
@@ -195,7 +195,8 @@ The configuration gets loaded in docker-compose as specified in the
 <CodeFromRemote 
   lang="js"
   link="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml"
-src="https://raw.githubusercontent.com/ory/hydra/master/contrib/quickstart/5-min/hydra.yml" />
+  src="https://raw.githubusercontent.com/ory/hydra/master/contrib/quickstart/5-min/hydra.yml" 
+/>
 
 Have a look at the [reference configuration](./reference/configuration.md) for
 further information on all possible configuration options.

--- a/docs/versioned_docs/version-v1.9/5min-tutorial.mdx
+++ b/docs/versioned_docs/version-v1.9/5min-tutorial.mdx
@@ -192,7 +192,10 @@ You can find it in
 The configuration gets loaded in docker-compose as specified in the
 [`quickstart.yml`](https://github.com/ory/hydra/blob/master/quickstart.yml).
 
-<CodeFromRemote src="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml" />
+<CodeFromRemote 
+  lang="js"
+  link="https://github.com/ory/hydra/blob/master/contrib/quickstart/5-min/hydra.yml"
+src="https://raw.githubusercontent.com/ory/hydra/master/contrib/quickstart/5-min/hydra.yml" />
 
 Have a look at the [reference configuration](./reference/configuration.md) for
 further information on all possible configuration options.


### PR DESCRIPTION
## Related issue

fix: correct CodeFromRemote syntax
https://github.com/ory/hydra/commit/df50360343f94c1a5132c309790c75c4f1b65945
same as
https://github.com/ory/kratos/pull/1490#discussion_r666167642

edit: my bad was just the codefromremote

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
