### PR TITLE
docs: add long flag --grant-types in 5min tutorial

### DIFF
--- a/docs/docs/5min-tutorial.mdx
+++ b/docs/docs/5min-tutorial.mdx
@@ -95,7 +95,7 @@ $ docker-compose -f quickstart.yml exec hydra \
     --endpoint http://127.0.0.1:4445/ \
     --id my-client \
     --secret secret \
-    -g client_credentials
+    --grant-types client_credentials
 ```
 
 Let's perform the client credentials grant:

--- a/docs/versioned_docs/version-v1.10/5min-tutorial.mdx
+++ b/docs/versioned_docs/version-v1.10/5min-tutorial.mdx
@@ -95,7 +95,7 @@ $ docker-compose -f quickstart.yml exec hydra \
     --endpoint http://127.0.0.1:4445/ \
     --id my-client \
     --secret secret \
-    -g client_credentials
+    --grant-types client_credentials
 ```
 
 Let's perform the client credentials grant:


### PR DESCRIPTION
Hi

Short flag like `-g` are handy in an interactive context when a veteran user has to type long commands again and again.

Here, this tutorial is a entry point for someone discovering the `hydra` CLI and it's not obvious yet that it refers the to `--grant-types`.
Also it's more consistent with the following snippet on the same page that uses `--grant-types` explicitly.

Thanks
