### PR TITLE
Updated Examples section part of the page

### DIFF
--- a/docs/versioned_docs/version-v1.10/guides/kubernetes-helm-chart.mdx
+++ b/docs/versioned_docs/version-v1.10/guides/kubernetes-helm-chart.mdx
@@ -143,14 +143,14 @@ Let's install the Login and Consent App first
 
 ```bash
 $ helm install hydra-example-idp ory/example-idp \
-    --set 'hydraAdminUrl=http://hydra-example-admin:4445/' \
+    --set 'hydraAdminUrl=http://hydra-example-admin/' \
     --set 'hydraPublicUrl=http://public.hydra.localhost/' \
     --set 'ingress.enabled=true'
 ```
 
 with hostnames
 
-- `http://hydra-example-admin:4445/` corresponding to deployment name
+- `http://hydra-example-admin` corresponding to deployment name
   `--name hydra-example` (see next code sample) with suffix `-admin` which is
   the hostname of the ORY Hydra Admin API Service.
 - `https://public.hydra.localhost/` which is the default value for
@@ -163,7 +163,7 @@ the ORY Hydra Helm Chart
 
 ```bash
 $ helm install hydra-example ory/hydra \
-    --set 'hydra.config.secrets.system=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)' \
+    --set 'hydra.config.secrets.system={'$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)'}' \
     --set 'hydra.config.dsn=memory' \
     --set 'hydra.config.urls.self.issuer=http://public.hydra.localhost/' \
     --set 'hydra.config.urls.login=http://example-idp.localhost/login' \


### PR DESCRIPTION
Below are the changes made under Examples section

1. from hydraAdminUrl=http://hydra-example-admin:4445/'  to hydraAdminUrl=http://hydra-example-admin/' as we don't expose port number when using URL and ingress and will take care of the mapping the port behind scenes

2. Changed from --set 'hydra.config.secrets.system=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)' to --set 'hydra.config.secrets.system={'$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)'}' as hydra.config.secrets.system expects a list of strings, so embraced with curly braces so a random list of strings will be generated.

If we don't add the above 2nd change then it will result in error as `Error: execution error at (hydra/templates/secrets.yaml:16:22): Expected hydra.config.secrets.system to be a list of strings` so in order to make the example deployment work without issues we need to execute the command with curly braces around with quote marks which depicts a list of strings and the deployment will be a successful one as tested in local environment and made changes.