### PR TITLE
chore: update repository template to 455ef889

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,24 +9,35 @@ jobs:
     if: github.repository_owner == 'ory'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |
-            I am marking this issue as stale as it has not received any engagement from the community or maintainers in over half a year. That does not imply that the issue has no merit! If you feel strongly about this issue
+            Hello contributors!
+
+            I am marking this issue as stale as it has not received any engagement from the community or maintainers a year. That does not imply that the issue has no merit! If you feel strongly about this issue
 
             - open a PR referencing and resolving the issue;
             - leave a comment on it and discuss ideas how you could contribute towards resolving it;
+            - leave a comment and describe in detail why this issue is critical for your use case;
             - open a new issue with updated details and a plan on resolving the issue.
 
-            We are cleaning up issues every now and then, primarily to keep the 4000+ issues in our backlog in check and to [prevent](https://www.jeffgeerling.com/blog/2020/saying-no-burnout-open-source-maintainer) [maintainer](https://www.jeffgeerling.com/blog/2016/why-i-close-prs-oss-project-maintainer-notes) [burnout](https://docs.brew.sh/Maintainers-Avoiding-Burnout). Burnout in open source maintainership is a [widespread](https://opensource.guide/best-practices/#its-okay-to-hit-pause) and serious issue. It can lead to severe personal and health issues as well as [enabling catastrophic](https://haacked.com/archive/2019/05/28/maintainer-burnout/) [attack vectors](https://www.gradiant.org/en/blog/open-source-maintainer-burnout-as-an-attack-surface/).
+            Throughout its lifetime, Ory has received over 10.000 issues and PRs. To sustain that growth, we need to prioritize and focus on issues that are important to the community. A good indication of importance, and thus priority, is activity on a topic.
 
-            Thank you for your understanding and to anyone who participated in the issue! 🙏✌️
+            Unfortunately, [burnout](https://www.jeffgeerling.com/blog/2016/why-i-close-prs-oss-project-maintainer-notes) has become a [topic](https://opensource.guide/best-practices/#its-okay-to-hit-pause) of [concern](https://docs.brew.sh/Maintainers-Avoiding-Burnout) amongst open-source projects.
 
-            If you feel strongly about this issues and have ideas on resolving it, please comment. Otherwise it will be closed in 30 days!
+            It can lead to severe personal and health issues as well as [opening](https://haacked.com/archive/2019/05/28/maintainer-burnout/) catastrophic [attack vectors](https://www.gradiant.org/en/blog/open-source-maintainer-burnout-as-an-attack-surface/).
+
+            The motivation for this automation is to help prioritize issues in the backlog and not ignore, reject, or belittle anyone.
+
+            If this issue was marked as stale erroneous you can exempt it by adding the `backlog` label, assigning someone, or setting a milestone for it.
+
+            Thank you for your understanding and to anyone who participated in the conversation! And as written above, please do participate in the conversation if this topic is important to you!
+
+            Thank you 🙏✌️
           stale-issue-label: 'stale'
-          exempt-issue-labels: 'bug,blocking,docs'
-          days-before-stale: 180
+          exempt-issue-labels: 'bug,blocking,docs,backlog'
+          days-before-stale: 365
           days-before-close: 30
           exempt-milestones: true
           exempt-assignees: true

--- a/docs/docs/guides/oauth2-token-introspection.mdx
+++ b/docs/docs/guides/oauth2-token-introspection.mdx
@@ -45,7 +45,8 @@ fetch('http://<ory-hydra-admin-api>/oauth2/introspect', {
 })
 ```
 
-Where `<ory-hydra-admin-api>` implies `http://localhost:4445` if deployed locally.
+Where `<ory-hydra-admin-api>` implies `http://localhost:4445` if deployed
+locally.
 
 #### CURL
 


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/455ef8896cd7ddfa08f4c2b8325c528bcdb65762.