### PR TITLE
fix: add content-type header to hook request

### DIFF
--- a/oauth2/hook.go
+++ b/oauth2/hook.go
@@ -81,6 +81,7 @@ func RefreshTokenHook(config *config.Provider) AccessRequestHook {
 					WithDebug("refresh token hook: new http request"),
 			)
 		}
+		req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -915,6 +915,8 @@ func TestAuthCodeWithMockStrategy(t *testing.T) {
 
 					t.Run("should call refresh token hook if configured", func(t *testing.T) {
 						hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							assert.Equal(t, r.Header.Get("Content-Type"), "application/json; charset=UTF-8")
+
 							var hookReq hydraoauth2.RefreshTokenHookRequest
 							require.NoError(t, json.NewDecoder(r.Body).Decode(&hookReq))
 							require.Equal(t, hookReq.Subject, "foo")


### PR DESCRIPTION
Current implementation doesn't set this header which makes some servers reject the request.

## Related issue(s)

#2649

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
