### PR TITLE
Replace fatal error of jaeger initialization with print

### DIFF
--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -432,20 +432,12 @@ func (m *RegistryBase) SubjectIdentifierAlgorithm() map[string]consent.SubjectId
 
 func (m *RegistryBase) Tracer(ctx context.Context) *tracing.Tracer {
 	if m.trc == nil {
-		var err error
-		var t *tracing.Tracer
-
-		// Make 3 attempts to initialize tracer
-		for i := 0; i < 3; i++ {
-			t, err = tracing.New(m.l, m.C.Tracing())
-			if err != nil {
-				m.Logger().WithError(err).Println("Unable to initialize Tracer. Retrying")
-			} else {
-				m.trc = t
-				break
-			}
+		t, err := tracing.New(m.l, m.C.Tracing())
+		if err != nil {
+			m.Logger().WithError(err).Println("Unable to initialize Tracer.")
+		} else {
+			m.trc = t
 		}
-		m.Logger().WithError(err).Println("Failed to initialize Tracer.")
 	}
 
 	return m.trc

--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -434,7 +434,7 @@ func (m *RegistryBase) Tracer(ctx context.Context) *tracing.Tracer {
 	if m.trc == nil {
 		t, err := tracing.New(m.l, m.C.Tracing())
 		if err != nil {
-			m.Logger().WithError(err).Println("Unable to initialize Tracer.")
+			m.Logger().WithError(err).Error("Unable to initialize Tracer.")
 		} else {
 			m.trc = t
 		}

--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -432,11 +432,20 @@ func (m *RegistryBase) SubjectIdentifierAlgorithm() map[string]consent.SubjectId
 
 func (m *RegistryBase) Tracer(ctx context.Context) *tracing.Tracer {
 	if m.trc == nil {
-		t, err := tracing.New(m.l, m.C.Tracing())
-		if err != nil {
-			m.Logger().WithError(err).Fatalf("Unable to initialize Tracer.")
+		var err error
+		var t *tracing.Tracer
+
+		// Make 3 attempts to initialize tracer
+		for i := 0; i < 3; i++ {
+			t, err = tracing.New(m.l, m.C.Tracing())
+			if err != nil {
+				m.Logger().WithError(err).Println("Unable to initialize Tracer. Retrying")
+			} else {
+				m.trc = t
+				break
+			}
 		}
-		m.trc = t
+		m.Logger().WithError(err).Println("Failed to initialize Tracer.")
 	}
 
 	return m.trc


### PR DESCRIPTION
Replace `Fatalf()` with `Println()` to log when unable to initialize a tracer. This avoid unnecessary exits. ~~Additionally, total 3 attempts are made to init the tracer.~~

Fixes #2642 

CC: @aeneasr 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
