### PR TITLE
feat: drop methods for finding keys by public/private prefix 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -200,6 +200,15 @@ type Client struct {
 	Metadata sqlxx.JSONRawMessage `json:"metadata,omitempty" db:"metadata"`
 }
 
+type AuthenticatedClient struct {
+	ClientID                          string `json:"client_id" db:"id"`
+	FrontChannelLogoutURI             string `json:"frontchannel_logout_uri,omitempty" db:"frontchannel_logout_uri"`
+	FrontChannelLogoutSessionRequired bool   `json:"frontchannel_logout_session_required,omitempty" db:"frontchannel_logout_session_required"`
+	BackChannelLogoutURI              string `json:"backchannel_logout_uri,omitempty" db:"backchannel_logout_uri"`
+	BackChannelLogoutSessionRequired  bool   `json:"backchannel_logout_session_required,omitempty" db:"backchannel_logout_session_required"`
+	LoginSessionID                    string `json:"login_session_id,omitempty" db:"login_session_id"`
+}
+
 func (Client) TableName() string {
 	return "hydra_client"
 }

--- a/consent/manager.go
+++ b/consent/manager.go
@@ -43,6 +43,7 @@ type Manager interface {
 	HandleConsentRequest(ctx context.Context, challenge string, r *HandledConsentRequest) (*ConsentRequest, error)
 	RevokeSubjectConsentSession(ctx context.Context, user string) error
 	RevokeSubjectClientConsentSession(ctx context.Context, user, client string) error
+	RevokeSubjectClientLoginSessionConsentSession(ctx context.Context, user, client, loginSessionId string) error
 
 	VerifyAndInvalidateConsentRequest(ctx context.Context, verifier string) (*HandledConsentRequest, error)
 	FindGrantedAndRememberedConsentRequests(ctx context.Context, client, user string) ([]HandledConsentRequest, error)
@@ -64,8 +65,9 @@ type Manager interface {
 	CreateForcedObfuscatedLoginSession(ctx context.Context, session *ForcedObfuscatedLoginSession) error
 	GetForcedObfuscatedLoginSession(ctx context.Context, client, obfuscated string) (*ForcedObfuscatedLoginSession, error)
 
-	ListUserAuthenticatedClientsWithFrontChannelLogout(ctx context.Context, subject, sid string) ([]client.Client, error)
-	ListUserAuthenticatedClientsWithBackChannelLogout(ctx context.Context, subject, sid string) ([]client.Client, error)
+	ListUserSessionAuthenticatedClientsWithFrontChannelLogout(ctx context.Context, subject, sid string) ([]client.AuthenticatedClient, error)
+	ListUserSessionAuthenticatedClientsWithBackChannelLogout(ctx context.Context, subject, sid string) ([]client.AuthenticatedClient, error)
+	ListUserAuthenticatedClientsWithBackChannelLogout(ctx context.Context, subject string) ([]client.AuthenticatedClient, error)
 
 	CreateLogoutRequest(ctx context.Context, request *LogoutRequest) error
 	GetLogoutRequest(ctx context.Context, challenge string) (*LogoutRequest, error)

--- a/consent/manager_test_helpers.go
+++ b/consent/manager_test_helpers.go
@@ -736,7 +736,7 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 				}
 
 				for _, ls := range sessions {
-					check := func(t *testing.T, expected map[string][]client.Client, actual []client.Client) {
+					check := func(t *testing.T, expected map[string][]client.Client, actual []client.AuthenticatedClient) {
 						es, ok := expected[ls.ID]
 						if !ok {
 							require.Len(t, actual, 0)
@@ -747,10 +747,10 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 						for _, e := range es {
 							var found bool
 							for _, a := range actual {
-								if e.OutfacingID == a.OutfacingID {
+								if e.OutfacingID == a.ClientID {
 									found = true
 								}
-								assert.Equal(t, e.OutfacingID, a.OutfacingID)
+								assert.Equal(t, e.OutfacingID, a.ClientID)
 								assert.Equal(t, e.FrontChannelLogoutURI, a.FrontChannelLogoutURI)
 								assert.Equal(t, e.BackChannelLogoutURI, a.BackChannelLogoutURI)
 							}
@@ -758,14 +758,14 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 						}
 					}
 
-					t.Run(fmt.Sprintf("method=ListUserAuthenticatedClientsWithFrontChannelLogout/session=%s/subject=%s", ls.ID, ls.Subject), func(t *testing.T) {
-						actual, err := m.ListUserAuthenticatedClientsWithFrontChannelLogout(context.Background(), ls.Subject, ls.ID)
+					t.Run(fmt.Sprintf("method=ListUserSessionAuthenticatedClientsWithFrontChannelLogout/session=%s/subject=%s", ls.ID, ls.Subject), func(t *testing.T) {
+						actual, err := m.ListUserSessionAuthenticatedClientsWithFrontChannelLogout(context.Background(), ls.Subject, ls.ID)
 						require.NoError(t, err)
 						check(t, frontChannels, actual)
 					})
 
-					t.Run(fmt.Sprintf("method=ListUserAuthenticatedClientsWithBackChannelLogout/session=%s", ls.ID), func(t *testing.T) {
-						actual, err := m.ListUserAuthenticatedClientsWithBackChannelLogout(context.Background(), ls.Subject, ls.ID)
+					t.Run(fmt.Sprintf("method=ListUserSessionAuthenticatedClientsWithBackChannelLogout/session=%s", ls.ID), func(t *testing.T) {
+						actual, err := m.ListUserSessionAuthenticatedClientsWithBackChannelLogout(context.Background(), ls.Subject, ls.ID)
 						require.NoError(t, err)
 						check(t, backChannels, actual)
 					})

--- a/consent/strategy.go
+++ b/consent/strategy.go
@@ -21,6 +21,7 @@
 package consent
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/ory/fosite"
@@ -31,4 +32,8 @@ var _ Strategy = new(DefaultStrategy)
 type Strategy interface {
 	HandleOAuth2AuthorizationRequest(w http.ResponseWriter, r *http.Request, req fosite.AuthorizeRequester) (*HandledConsentRequest, error)
 	HandleOpenIDConnectLogout(w http.ResponseWriter, r *http.Request) (*LogoutResult, error)
+	ExecuteBackChannelLogoutBySubject(ctx context.Context, r *http.Request, subject string) error
+	ExecuteBackChannelLogoutBySession(ctx context.Context, r *http.Request, subject, sid string) error
+	ExecuteBackChannelLogoutByClient(ctx context.Context, r *http.Request, subject, client string) error
+	ExecuteBackChannelLogoutByClientSession(ctx context.Context, r *http.Request, subject, client, sid string) error
 }

--- a/docs/docs/.static/api.json
+++ b/docs/docs/.static/api.json
@@ -1,15 +1,7 @@
 {
-  "consumes": [
-    "application/json",
-    "application/x-www-form-urlencoded"
-  ],
-  "produces": [
-    "application/json"
-  ],
-  "schemes": [
-    "http",
-    "https"
-  ],
+  "consumes": ["application/json", "application/x-www-form-urlencoded"],
+  "produces": ["application/json"],
+  "schemes": ["http", "https"],
   "swagger": "2.0",
   "info": {
     "description": "Welcome to the ORY Hydra HTTP API documentation. You will find documentation for all HTTP APIs here.",
@@ -21,19 +13,10 @@
     "/.well-known/jwks.json": {
       "get": {
         "description": "This endpoint returns JSON Web Keys to be used as public keys for verifying OpenID Connect ID Tokens and,\nif enabled, OAuth 2.0 JWT Access Tokens. This endpoint can be used with client libraries like\n[node-jwks-rsa](https://github.com/auth0/node-jwks-rsa) among others.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "public"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["public"],
         "summary": "JSON Web Keys Discovery",
         "operationId": "wellKnown",
         "responses": {
@@ -55,16 +38,9 @@
     "/.well-known/openid-configuration": {
       "get": {
         "description": "The well known endpoint an be used to retrieve information for OpenID Connect clients. We encourage you to not roll\nyour own OpenID Connect client but to use an OpenID Connect client library instead. You can learn more on this\nflow at https://openid.net/specs/openid-connect-discovery-1_0.html .\n\nPopular libraries for OpenID Connect clients include oidc-client-js (JavaScript), go-oidc (Golang), and others.\nFor a full list of clients go here: https://openid.net/developers/certified/",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "public"
-        ],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["public"],
         "summary": "OpenID Connect Discovery",
         "operationId": "discoverOpenIDConfiguration",
         "responses": {
@@ -92,19 +68,10 @@
     "/clients": {
       "get": {
         "description": "This endpoint lists all clients in the database, and never returns client secrets. As a default it lists the first 100 clients. The `limit` parameter can be used to retrieve more clients, but it has an upper bound at 500 objects. Pagination should be used to retrieve more than 500 objects.\n\nOAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. To manage ORY Hydra, you will need an OAuth 2.0 Client as well. Make sure that this endpoint is well protected and only callable by first-party components.\nThe \"Link\" header is also included in successful responses, which contains one or more links for pagination, formatted like so: '\u003chttps://hydra-url/admin/clients?limit={limit}\u0026offset={offset}\u003e; rel=\"{page}\"', where page is one of the following applicable pages: 'first', 'next', 'last', and 'previous'.\nMultiple links can be included in this header, and will be separated by a comma.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "List OAuth 2.0 Clients",
         "operationId": "listOAuth2Clients",
         "parameters": [
@@ -155,19 +122,10 @@
       },
       "post": {
         "description": "Create a new OAuth 2.0 client If you pass `client_secret` the secret will be used, otherwise a random secret will be generated. The secret will be returned in the response and you will not be able to retrieve it later on. Write the secret down and keep it somwhere safe.\n\nOAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. To manage ORY Hydra, you will need an OAuth 2.0 Client as well. Make sure that this endpoint is well protected and only callable by first-party components.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Create an OAuth 2.0 Client",
         "operationId": "createOAuth2Client",
         "parameters": [
@@ -211,19 +169,10 @@
     "/clients/{id}": {
       "get": {
         "description": "Get an OAUth 2.0 client by its ID. This endpoint never returns passwords.\n\nOAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. To manage ORY Hydra, you will need an OAuth 2.0 Client as well. Make sure that this endpoint is well protected and only callable by first-party components.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Get an OAuth 2.0 Client.",
         "operationId": "getOAuth2Client",
         "parameters": [
@@ -258,19 +207,10 @@
       },
       "put": {
         "description": "Update an existing OAuth 2.0 Client. If you pass `client_secret` the secret will be updated and returned via the API. This is the only time you will be able to retrieve the client secret, so write it down and keep it safe.\n\nOAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. To manage ORY Hydra, you will need an OAuth 2.0 Client as well. Make sure that this endpoint is well protected and only callable by first-party components.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Update an OAuth 2.0 Client",
         "operationId": "updateOAuth2Client",
         "parameters": [
@@ -306,19 +246,10 @@
       },
       "delete": {
         "description": "Delete an existing OAuth 2.0 Client by its ID.\n\nOAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. To manage ORY Hydra, you will need an OAuth 2.0 Client as well. Make sure that this endpoint is well protected and only callable by first-party components.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Deletes an OAuth 2.0 Client",
         "operationId": "deleteOAuth2Client",
         "parameters": [
@@ -350,19 +281,10 @@
       },
       "patch": {
         "description": "Patch an existing OAuth 2.0 Client. If you pass `client_secret` the secret will be updated and returned via the API. This is the only time you will be able to retrieve the client secret, so write it down and keep it safe.\n\nOAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. To manage ORY Hydra, you will need an OAuth 2.0 Client as well. Make sure that this endpoint is well protected and only callable by first-party components.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Patch an OAuth 2.0 Client",
         "operationId": "patchOAuth2Client",
         "parameters": [
@@ -400,12 +322,8 @@
     "/health/alive": {
       "get": {
         "description": "This endpoint returns a 200 status code when the HTTP server is up running.\nThis status does currently not include checks whether the database connection is working.\n\nIf the service supports TLS Edge Termination, this endpoint does not require the\n`X-Forwarded-Proto` header to be set.\n\nBe aware that if you are running multiple nodes of this service, the health status will never\nrefer to the cluster state, only to a single instance.",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "produces": ["application/json"],
+        "tags": ["admin"],
         "summary": "Check Alive Status",
         "operationId": "isInstanceAlive",
         "responses": {
@@ -427,12 +345,8 @@
     "/health/ready": {
       "get": {
         "description": "This endpoint returns a 200 status code when the HTTP server is up running and the environment dependencies (e.g.\nthe database) are responsive as well.\n\nIf the service supports TLS Edge Termination, this endpoint does not require the\n`X-Forwarded-Proto` header to be set.\n\nBe aware that if you are running multiple nodes of this service, the health status will never\nrefer to the cluster state, only to a single instance.",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "public"
-        ],
+        "produces": ["application/json"],
+        "tags": ["public"],
         "summary": "Check Readiness Status",
         "operationId": "isInstanceReady",
         "responses": {
@@ -454,19 +368,10 @@
     "/keys/{set}": {
       "get": {
         "description": "This endpoint can be used to retrieve JWK Sets stored in ORY Hydra.\n\nA JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Retrieve a JSON Web Key Set",
         "operationId": "getJsonWebKeySet",
         "parameters": [
@@ -507,19 +412,10 @@
       },
       "put": {
         "description": "Use this method if you do not want to let Hydra generate the JWKs for you, but instead save your own.\n\nA JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Update a JSON Web Key Set",
         "operationId": "updateJsonWebKeySet",
         "parameters": [
@@ -567,19 +463,10 @@
       },
       "post": {
         "description": "This endpoint is capable of generating JSON Web Key Sets for you. There a different strategies available, such as symmetric cryptographic keys (HS256, HS512) and asymetric cryptographic keys (RS256, ECDSA). If the specified JSON Web Key Set does not exist, it will be created.\n\nA JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Generate a New JSON Web Key",
         "operationId": "createJsonWebKeySet",
         "parameters": [
@@ -627,19 +514,10 @@
       },
       "delete": {
         "description": "Use this endpoint to delete a complete JSON Web Key Set and all the keys in that set.\n\nA JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Delete a JSON Web Key Set",
         "operationId": "deleteJsonWebKeySet",
         "parameters": [
@@ -679,19 +557,10 @@
     "/keys/{set}/{kid}": {
       "get": {
         "description": "This endpoint returns a singular JSON Web Key, identified by the set and the specific key ID (kid).",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Fetch a JSON Web Key",
         "operationId": "getJsonWebKey",
         "parameters": [
@@ -733,19 +602,10 @@
       },
       "put": {
         "description": "Use this method if you do not want to let Hydra generate the JWKs for you, but instead save your own.\n\nA JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Update a JSON Web Key",
         "operationId": "updateJsonWebKey",
         "parameters": [
@@ -800,19 +660,10 @@
       },
       "delete": {
         "description": "Use this endpoint to delete a single JSON Web Key.\n\nA JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Delete a JSON Web Key",
         "operationId": "deleteJsonWebKey",
         "parameters": [
@@ -859,12 +710,8 @@
     "/metrics/prometheus": {
       "get": {
         "description": "```\nmetadata:\nannotations:\nprometheus.io/port: \"4434\"\nprometheus.io/path: \"/metrics/prometheus\"\n```",
-        "produces": [
-          "plain/text"
-        ],
-        "tags": [
-          "metadata"
-        ],
+        "produces": ["plain/text"],
+        "tags": ["metadata"],
         "summary": "Get snapshot metrics from the service. If you're using k8s, you can then add annotations to\nyour deployment like so:",
         "operationId": "prometheus",
         "responses": {
@@ -877,16 +724,9 @@
     "/oauth2/auth": {
       "get": {
         "description": "This endpoint is not documented here because you should never use your own implementation to perform OAuth2 flows.\nOAuth2 is a very popular protocol and a library for your programming language will exists.\n\nTo learn more about this flow please refer to the specification: https://tools.ietf.org/html/rfc6749",
-        "consumes": [
-          "application/x-www-form-urlencoded"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "public"
-        ],
+        "consumes": ["application/x-www-form-urlencoded"],
+        "schemes": ["http", "https"],
+        "tags": ["public"],
         "summary": "The OAuth 2.0 Authorize Endpoint",
         "operationId": "oauthAuth",
         "responses": {
@@ -911,19 +751,10 @@
     "/oauth2/auth/requests/consent": {
       "get": {
         "description": "When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider\nto authenticate the subject and then tell ORY Hydra now about it. If the subject authenticated, he/she must now be asked if\nthe OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.\n\nThe consent provider which handles this request and is a web app implemented and hosted by you. It shows a subject interface which asks the subject to\ngrant or deny the client access to the requested scope (\"Application my-dropbox-app wants write access to all your private files\").\n\nThe consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent\nprovider uses that challenge to fetch information on the OAuth2 request and then tells ORY Hydra if the subject accepted\nor rejected the request.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Get Consent Request Information",
         "operationId": "getConsentRequest",
         "parameters": [
@@ -965,19 +796,10 @@
     "/oauth2/auth/requests/consent/accept": {
       "put": {
         "description": "When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider\nto authenticate the subject and then tell ORY Hydra now about it. If the subject authenticated, he/she must now be asked if\nthe OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.\n\nThe consent provider which handles this request and is a web app implemented and hosted by you. It shows a subject interface which asks the subject to\ngrant or deny the client access to the requested scope (\"Application my-dropbox-app wants write access to all your private files\").\n\nThe consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent\nprovider uses that challenge to fetch information on the OAuth2 request and then tells ORY Hydra if the subject accepted\nor rejected the request.\n\nThis endpoint tells ORY Hydra that the subject has authorized the OAuth 2.0 client to access resources on his/her behalf.\nThe consent provider includes additional information, such as session data for access and ID tokens, and if the\nconsent request should be used as basis for future requests.\n\nThe response contains a redirect URL which the consent provider should redirect the user-agent to.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Accept a Consent Request",
         "operationId": "acceptConsentRequest",
         "parameters": [
@@ -1020,19 +842,10 @@
     "/oauth2/auth/requests/consent/reject": {
       "put": {
         "description": "When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider\nto authenticate the subject and then tell ORY Hydra now about it. If the subject authenticated, he/she must now be asked if\nthe OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.\n\nThe consent provider which handles this request and is a web app implemented and hosted by you. It shows a subject interface which asks the subject to\ngrant or deny the client access to the requested scope (\"Application my-dropbox-app wants write access to all your private files\").\n\nThe consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent\nprovider uses that challenge to fetch information on the OAuth2 request and then tells ORY Hydra if the subject accepted\nor rejected the request.\n\nThis endpoint tells ORY Hydra that the subject has not authorized the OAuth 2.0 client to access resources on his/her behalf.\nThe consent provider must include a reason why the consent was not granted.\n\nThe response contains a redirect URL which the consent provider should redirect the user-agent to.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Reject a Consent Request",
         "operationId": "rejectConsentRequest",
         "parameters": [
@@ -1075,19 +888,10 @@
     "/oauth2/auth/requests/login": {
       "get": {
         "description": "When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider\n(sometimes called \"identity provider\") to authenticate the subject and then tell ORY Hydra now about it. The login\nprovider is an web-app you write and host, and it must be able to authenticate (\"show the subject a login screen\")\na subject (in OAuth2 the proper name for subject is \"resource owner\").\n\nThe authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login\nprovider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Get a Login Request",
         "operationId": "getLoginRequest",
         "parameters": [
@@ -1135,19 +939,10 @@
     "/oauth2/auth/requests/login/accept": {
       "put": {
         "description": "When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider\n(sometimes called \"identity provider\") to authenticate the subject and then tell ORY Hydra now about it. The login\nprovider is an web-app you write and host, and it must be able to authenticate (\"show the subject a login screen\")\na subject (in OAuth2 the proper name for subject is \"resource owner\").\n\nThe authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login\nprovider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.\n\nThis endpoint tells ORY Hydra that the subject has successfully authenticated and includes additional information such as\nthe subject's ID and if ORY Hydra should remember the subject's subject agent for future authentication attempts by setting\na cookie.\n\nThe response contains a redirect URL which the login provider should redirect the user-agent to.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Accept a Login Request",
         "operationId": "acceptLoginRequest",
         "parameters": [
@@ -1202,19 +997,10 @@
     "/oauth2/auth/requests/login/reject": {
       "put": {
         "description": "When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, ORY Hydra asks the login provider\n(sometimes called \"identity provider\") to authenticate the subject and then tell ORY Hydra now about it. The login\nprovider is an web-app you write and host, and it must be able to authenticate (\"show the subject a login screen\")\na subject (in OAuth2 the proper name for subject is \"resource owner\").\n\nThe authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login\nprovider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.\n\nThis endpoint tells ORY Hydra that the subject has not authenticated and includes a reason why the authentication\nwas be denied.\n\nThe response contains a redirect URL which the login provider should redirect the user-agent to.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Reject a Login Request",
         "operationId": "rejectLoginRequest",
         "parameters": [
@@ -1269,16 +1055,9 @@
     "/oauth2/auth/requests/logout": {
       "get": {
         "description": "Use this endpoint to fetch a logout request.",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Get a Logout Request",
         "operationId": "getLogoutRequest",
         "parameters": [
@@ -1320,16 +1099,9 @@
     "/oauth2/auth/requests/logout/accept": {
       "put": {
         "description": "When a user or an application requests ORY Hydra to log out a user, this endpoint is used to confirm that logout request.\nNo body is required.\n\nThe response contains a redirect URL which the consent provider should redirect the user-agent to.",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Accept a Logout Request",
         "operationId": "acceptLogoutRequest",
         "parameters": [
@@ -1365,16 +1137,9 @@
     "/oauth2/auth/requests/logout/reject": {
       "put": {
         "description": "When a user or an application requests ORY Hydra to log out a user, this endpoint is used to deny that logout request.\nNo body is required.\n\nThe response is empty as the logout provider has to chose what action to perform next.",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Reject a Logout Request",
         "operationId": "rejectLogoutRequest",
         "parameters": [
@@ -1414,19 +1179,10 @@
     "/oauth2/auth/sessions/consent": {
       "get": {
         "description": "This endpoint lists all subject's granted consent sessions, including client and granted scope.\nIf the subject is unknown or has not granted any consent sessions yet, the endpoint returns an\nempty JSON array with status code 200 OK.\n\n\nThe \"Link\" header is also included in successful responses, which contains one or more links for pagination, formatted like so: '\u003chttps://hydra-url/admin/oauth2/auth/sessions/consent?subject={user}\u0026limit={limit}\u0026offset={offset}\u003e; rel=\"{page}\"', where page is one of the following applicable pages: 'first', 'next', 'last', and 'previous'.\nMultiple links can be included in this header, and will be separated by a comma.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Lists All Consent Sessions of a Subject",
         "operationId": "listSubjectConsentSessions",
         "parameters": [
@@ -1463,19 +1219,10 @@
       },
       "delete": {
         "description": "This endpoint revokes a subject's granted consent sessions for a specific OAuth 2.0 Client and invalidates all\nassociated OAuth 2.0 Access Tokens.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Revokes Consent Sessions of a Subject for a Specific OAuth 2.0 Client",
         "operationId": "revokeConsentSessions",
         "parameters": [
@@ -1521,19 +1268,10 @@
     "/oauth2/auth/sessions/login": {
       "delete": {
         "description": "This endpoint invalidates a subject's authentication session. After revoking the authentication session, the subject\nhas to re-authenticate at ORY Hydra. This endpoint does not invalidate any tokens and does not work with OpenID Connect\nFront- or Back-channel logout.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Invalidates All Login Sessions of a Certain User\nInvalidates a Subject's Authentication Session",
         "operationId": "revokeAuthenticationSession",
         "parameters": [
@@ -1566,16 +1304,9 @@
     "/oauth2/flush": {
       "post": {
         "description": "This endpoint flushes expired OAuth2 access tokens from the database. You can set a time after which no tokens will be\nnot be touched, in case you want to keep recent tokens for auditing. Refresh tokens can not be flushed as they are deleted\nautomatically when performing the refresh flow.",
-        "consumes": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Flush Expired OAuth2 Access Tokens",
         "operationId": "flushInactiveOAuth2Tokens",
         "parameters": [
@@ -1609,19 +1340,10 @@
     "/oauth2/introspect": {
       "post": {
         "description": "The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token\nis neither expired nor revoked. If a token is active, additional information on the token will be included. You can\nset additional data for a token by setting `accessTokenExtra` during the consent flow.\n\nFor more information [read this blog post](https://www.oauth.com/oauth2-servers/token-introspection-endpoint/).",
-        "consumes": [
-          "application/x-www-form-urlencoded"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/x-www-form-urlencoded"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Introspect OAuth2 Tokens",
         "operationId": "introspectOAuth2Token",
         "parameters": [
@@ -1672,16 +1394,9 @@
           }
         ],
         "description": "Revoking a token (both access and refresh) means that the tokens will be invalid. A revoked access token can no\nlonger be used to make access requests, and a revoked refresh token can no longer be used to refresh an access token.\nRevoking a refresh token also invalidates the access token that was created with it. A token may only be revoked by\nthe client the token was generated for.",
-        "consumes": [
-          "application/x-www-form-urlencoded"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "public"
-        ],
+        "consumes": ["application/x-www-form-urlencoded"],
+        "schemes": ["http", "https"],
+        "tags": ["public"],
         "summary": "Revoke OAuth2 Tokens",
         "operationId": "revokeOAuth2Token",
         "parameters": [
@@ -1714,13 +1429,8 @@
     "/oauth2/sessions/logout": {
       "get": {
         "description": "This endpoint initiates and completes user logout at ORY Hydra and initiates OpenID Connect Front-/Back-channel logout:\n\nhttps://openid.net/specs/openid-connect-frontchannel-1_0.html\nhttps://openid.net/specs/openid-connect-backchannel-1_0.html",
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "public"
-        ],
+        "schemes": ["http", "https"],
+        "tags": ["public"],
         "summary": "OpenID Connect Front-Backchannel Enabled Logout",
         "operationId": "disconnectUser",
         "responses": {
@@ -1741,19 +1451,10 @@
           }
         ],
         "description": "The client makes a request to the token endpoint by sending the\nfollowing parameters using the \"application/x-www-form-urlencoded\" HTTP\nrequest entity-body.\n\n\u003e Do not implement a client for this endpoint yourself. Use a library. There are many libraries\n\u003e available for any programming language. You can find a list of libraries here: https://oauth.net/code/\n\u003e\n\u003e Do note that Hydra SDK does not implement this endpoint properly. Use one of the libraries listed above!",
-        "consumes": [
-          "application/x-www-form-urlencoded"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "public"
-        ],
+        "consumes": ["application/x-www-form-urlencoded"],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["public"],
         "summary": "The OAuth 2.0 Token Endpoint",
         "operationId": "oauth2Token",
         "parameters": [
@@ -1815,16 +1516,9 @@
     "/oauth2/tokens": {
       "delete": {
         "description": "This endpoint deletes OAuth2 access tokens issued for a client from the database",
-        "consumes": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "consumes": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["admin"],
         "summary": "Delete OAuth2 Access Tokens from a Client",
         "operationId": "deleteOAuth2Token",
         "parameters": [
@@ -1862,16 +1556,9 @@
           }
         ],
         "description": "This endpoint returns the payload of the ID Token, including the idTokenExtra values, of\nthe provided OAuth 2.0 Access Token.\n\nFor more information please [refer to the spec](http://openid.net/specs/openid-connect-core-1_0.html#UserInfo).\n\nIn the case of authentication error, a WWW-Authenticate header might be set in the response\nwith more information about the error. See [the spec](https://datatracker.ietf.org/doc/html/rfc6750#section-3)\nfor more details about header format.",
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "public"
-        ],
+        "produces": ["application/json"],
+        "schemes": ["http", "https"],
+        "tags": ["public"],
         "summary": "OpenID Connect Userinfo",
         "operationId": "userinfo",
         "responses": {
@@ -1899,12 +1586,8 @@
     "/version": {
       "get": {
         "description": "This endpoint returns the service version typically notated using semantic versioning.\n\nIf the service supports TLS Edge Termination, this endpoint does not require the\n`X-Forwarded-Proto` header to be set.",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "admin"
-        ],
+        "produces": ["application/json"],
+        "tags": ["admin"],
         "summary": "Get Service Version",
         "operationId": "getVersion",
         "responses": {
@@ -1936,12 +1619,7 @@
     "JSONWebKey": {
       "description": "It is important that this model object is named JSONWebKey for\n\"swagger generate spec\" to generate only on definition of a\nJSONWebKey.",
       "type": "object",
-      "required": [
-        "use",
-        "kty",
-        "kid",
-        "alg"
-      ],
+      "required": ["use", "kty", "kid", "alg"],
       "properties": {
         "alg": {
           "description": "The \"alg\" (algorithm) parameter identifies the algorithm intended for\nuse with the key.  The values used should either be registered in the\nIANA \"JSON Web Signature and Encryption Algorithms\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.",
@@ -2127,12 +1805,7 @@
     "PluginConfigArgs": {
       "description": "PluginConfigArgs plugin config args",
       "type": "object",
-      "required": [
-        "Description",
-        "Name",
-        "Settable",
-        "Value"
-      ],
+      "required": ["Description", "Name", "Settable", "Value"],
       "properties": {
         "Description": {
           "description": "description",
@@ -2161,10 +1834,7 @@
     "PluginConfigInterface": {
       "description": "PluginConfigInterface The interface between Docker and the plugin",
       "type": "object",
-      "required": [
-        "Socket",
-        "Types"
-      ],
+      "required": ["Socket", "Types"],
       "properties": {
         "ProtocolScheme": {
           "description": "Protocol to use for clients connecting to the plugin.",
@@ -2186,11 +1856,7 @@
     "PluginConfigLinux": {
       "description": "PluginConfigLinux plugin config linux",
       "type": "object",
-      "required": [
-        "AllowAllDevices",
-        "Capabilities",
-        "Devices"
-      ],
+      "required": ["AllowAllDevices", "Capabilities", "Devices"],
       "properties": {
         "AllowAllDevices": {
           "description": "allow all devices",
@@ -2215,9 +1881,7 @@
     "PluginConfigNetwork": {
       "description": "PluginConfigNetwork plugin config network",
       "type": "object",
-      "required": [
-        "Type"
-      ],
+      "required": ["Type"],
       "properties": {
         "Type": {
           "description": "type",
@@ -2261,12 +1925,7 @@
     "PluginDevice": {
       "description": "PluginDevice plugin device",
       "type": "object",
-      "required": [
-        "Description",
-        "Name",
-        "Path",
-        "Settable"
-      ],
+      "required": ["Description", "Name", "Path", "Settable"],
       "properties": {
         "Description": {
           "description": "description",
@@ -2292,12 +1951,7 @@
     "PluginEnv": {
       "description": "PluginEnv plugin env",
       "type": "object",
-      "required": [
-        "Description",
-        "Name",
-        "Settable",
-        "Value"
-      ],
+      "required": ["Description", "Name", "Settable", "Value"],
       "properties": {
         "Description": {
           "description": "description",
@@ -2323,11 +1977,7 @@
     "PluginInterfaceType": {
       "description": "PluginInterfaceType plugin interface type",
       "type": "object",
-      "required": [
-        "Capability",
-        "Prefix",
-        "Version"
-      ],
+      "required": ["Capability", "Prefix", "Version"],
       "properties": {
         "Capability": {
           "description": "capability",
@@ -2395,12 +2045,7 @@
     "PluginSettings": {
       "type": "object",
       "title": "PluginSettings Settings that can be modified by users.",
-      "required": [
-        "Args",
-        "Devices",
-        "Env",
-        "Mounts"
-      ],
+      "required": ["Args", "Devices", "Env", "Mounts"],
       "properties": {
         "Args": {
           "description": "args",
@@ -2528,10 +2173,7 @@
     "VolumeUsageData": {
       "description": "VolumeUsageData Usage details about the volume. This information is used by the\n`GET /system/df` endpoint, and omitted in other endpoints.",
       "type": "object",
-      "required": [
-        "RefCount",
-        "Size"
-      ],
+      "required": ["RefCount", "Size"],
       "properties": {
         "RefCount": {
           "description": "The number of containers referencing this volume. This field\nis set to `-1` if the reference-count is not available.",
@@ -2575,9 +2217,7 @@
     "acceptLoginRequest": {
       "type": "object",
       "title": "HandledLoginRequest is the request payload used to accept a login request.",
-      "required": [
-        "subject"
-      ],
+      "required": ["subject"],
       "properties": {
         "acr": {
           "description": "ACR sets the Authentication AuthorizationContext Class Reference value for this authentication session. You can use it\nto express that, for example, a user authenticated using two factor authentication.",
@@ -2611,9 +2251,7 @@
     "completedRequest": {
       "type": "object",
       "title": "The response payload sent when accepting or rejecting a login or consent request.",
-      "required": [
-        "redirect_to"
-      ],
+      "required": ["redirect_to"],
       "properties": {
         "redirect_to": {
           "description": "RedirectURL is the URL which you should redirect the user to once the authentication process is completed.",
@@ -2624,9 +2262,7 @@
     "consentRequest": {
       "type": "object",
       "title": "Contains information on an ongoing consent request.",
-      "required": [
-        "challenge"
-      ],
+      "required": ["challenge"],
       "properties": {
         "acr": {
           "description": "ACR represents the Authentication AuthorizationContext Class Reference value for this authentication session. You can use it\nto express that, for example, a user authenticated using two factor authentication.",
@@ -2753,11 +2389,7 @@
     },
     "jsonWebKeySetGeneratorRequest": {
       "type": "object",
-      "required": [
-        "alg",
-        "use",
-        "kid"
-      ],
+      "required": ["alg", "use", "kid"],
       "properties": {
         "alg": {
           "description": "The algorithm to be used for creating the key. Supports \"RS256\", \"ES256\", \"ES512\", \"HS512\", and \"HS256\"",
@@ -2990,9 +2622,7 @@
       "description": "https://tools.ietf.org/html/rfc7662",
       "type": "object",
       "title": "Introspection contains an access token's session data as specified by IETF RFC 7662, see:",
-      "required": [
-        "active"
-      ],
+      "required": ["active"],
       "properties": {
         "active": {
           "description": "Active is a boolean indicator of whether or not the presented token\nis currently active.  The specifics of a token's \"active\" state\nwill vary depending on the implementation of the authorization\nserver and the information it keeps about its tokens, but a \"true\"\nvalue return for the \"active\" property will generally indicate\nthat a given token has been issued by this authorization server,\nhas not been revoked by the resource owner, and is within its\ngiven time window of validity (e.g., after its issuance time and\nbefore its expiration time).",
@@ -3120,10 +2750,7 @@
     "patchDocument": {
       "description": "A JSONPatch document as defined by RFC 6902",
       "type": "object",
-      "required": [
-        "op",
-        "path"
-      ],
+      "required": ["op", "path"],
       "properties": {
         "from": {
           "description": "A JSON-pointer",
@@ -3182,9 +2809,7 @@
     "requestWasHandledResponse": {
       "type": "object",
       "title": "The response payload sent when there is an attempt to access already handled request.",
-      "required": [
-        "redirect_to"
-      ],
+      "required": ["redirect_to"],
       "properties": {
         "redirect_to": {
           "description": "Original request URL to which you should redirect the user if request was already handled.",

--- a/docs/docs/guides/oauth2-public-spa-mobile.mdx
+++ b/docs/docs/guides/oauth2-public-spa-mobile.mdx
@@ -39,7 +39,7 @@ client_id=...&
 
 :::note
 
-The public clients using a non-https redirect scheme cannot skip
-consent as per OpenID Sepcification & Certification.
+The public clients using a non-https redirect scheme cannot skip consent as per
+OpenID Sepcification & Certification.
 
 :::

--- a/oauth2/oauth2_helper_test.go
+++ b/oauth2/oauth2_helper_test.go
@@ -21,6 +21,7 @@
 package oauth2_test
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -60,5 +61,21 @@ func (c *consentMock) HandleOAuth2AuthorizationRequest(w http.ResponseWriter, r 
 }
 
 func (c *consentMock) HandleOpenIDConnectLogout(w http.ResponseWriter, r *http.Request) (*consent.LogoutResult, error) {
+	panic("not implemented")
+}
+
+func (c *consentMock) ExecuteBackChannelLogoutBySession(ctx context.Context, r *http.Request, subject, sid string) error {
+	panic("not implemented")
+}
+
+func (c *consentMock) ExecuteBackChannelLogoutByClientSession(ctx context.Context, r *http.Request, subject, client, sid string) error {
+	panic("not implemented")
+}
+
+func (c *consentMock) ExecuteBackChannelLogoutByClient(ctx context.Context, r *http.Request, subject, client string) error {
+	panic("not implemented")
+}
+
+func (c *consentMock) ExecuteBackChannelLogoutBySubject(ctx context.Context, r *http.Request, subject string) error {
 	panic("not implemented")
 }


### PR DESCRIPTION
Drop FindKeyByPrefix/FindKeysByPrefix methods for finding keys by public/private prefix and use FindPublicKey/FindPrivateKey helper methods instead.

## Related issue(s)

This feature is continuation of https://github.com/ory/hydra/pull/2758 

It is also related to  https://github.com/ory/hydra/pull/2625 where it would be easer to review it, if suggest this change separately. 
In short to find keypairs from HSM I use attribute CKA_LABEL as key set id and CKA_ID as key id and they have to be 1:1 for pub/priv keys:
https://github.com/ThalesIgnite/crypto11/blob/master/keys.go#L247-L278

This helps me to get rid of https://github.com/aarmam/hydra/blob/feature/hsm/hsm/manager_hsm.go#L243-L261 where I prefix keys manually altough key id's on HSM are without prefixes.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

