### PR TITLE
feat: allow for permanent refresh_token(s) with config

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -147,6 +147,7 @@ func RunServeAll(cmd *cobra.Command, args []string) {
 	d.PrometheusManager().RegisterRouter(admin.Router)
 	d.PrometheusManager().RegisterRouter(public.Router)
 
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -185,6 +186,8 @@ func setup(d driver.Registry, cmd *cobra.Command) (admin *x.RouterAdmin, public 
 			d.Logger().WithError(err).Fatal("Couldn't set GOMAXPROCS")
 		}
 	}
+
+	d.Config().Validate()
 
 	adminmw = negroni.New()
 	publicmw = negroni.New()

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -65,6 +65,7 @@ const (
 	KeyOAuth2LegacyErrors                        = "oauth2.include_legacy_error_fields"
 	KeyExcludeNotBeforeClaim                     = "oauth2.exclude_not_before_claim"
 	KeyAllowedTopLevelClaims                     = "oauth2.allowed_top_level_claims"
+	KeyEnableOneTimeUseRefreshToken              = "oauth2.enable_one_time_use_refresh_token"
 )
 
 const DSNMemory = "memory"
@@ -191,6 +192,10 @@ func (p *Provider) EncryptSessionData() bool {
 
 func (p *Provider) ExcludeNotBeforeClaim() bool {
 	return p.p.BoolF(KeyExcludeNotBeforeClaim, false)
+}
+
+func (p *Provider) EnableOneTimeUseRefreshToken() bool {
+	return p.p.BoolF(KeyEnableOneTimeUseRefreshToken, true)
 }
 
 func (p *Provider) DataSourcePlugin() string {

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -65,7 +65,7 @@ const (
 	KeyOAuth2LegacyErrors                        = "oauth2.include_legacy_error_fields"
 	KeyExcludeNotBeforeClaim                     = "oauth2.exclude_not_before_claim"
 	KeyAllowedTopLevelClaims                     = "oauth2.allowed_top_level_claims"
-	KeyEnableOneTimeUseRefreshToken              = "oauth2.enable_one_time_use_refresh_token"
+	KeyEnableRefreshTokenRotation                = "oauth2.refresh_token_rotation.enabled"
 )
 
 const DSNMemory = "memory"
@@ -194,8 +194,8 @@ func (p *Provider) ExcludeNotBeforeClaim() bool {
 	return p.p.BoolF(KeyExcludeNotBeforeClaim, false)
 }
 
-func (p *Provider) EnableOneTimeUseRefreshToken() bool {
-	return p.p.BoolF(KeyEnableOneTimeUseRefreshToken, true)
+func (p *Provider) EnableRefreshTokenRotation() bool {
+	return p.p.BoolF(KeyEnableRefreshTokenRotation, true)
 }
 
 func (p *Provider) DataSourcePlugin() string {

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -433,3 +433,15 @@ func (p *Provider) CGroupsV1AutoMaxProcsEnabled() bool {
 func (p *Provider) GrantAllClientCredentialsScopesPerDefault() bool {
 	return p.p.Bool(KeyGrantAllClientCredentialsScopesPerDefault)
 }
+
+// Validate validates the configuration contained within this provider
+func (p *Provider) Validate() {
+	if !p.EnableRefreshTokenRotation() {
+		refreshTokenLifespan := p.RefreshTokenLifespan()
+		if refreshTokenLifespan == 0 {
+			p.l.Fatalf("Disabling refresh token rotation (%s) must also set %s to -1",
+				KeyEnableRefreshTokenRotation,
+				KeyRefreshTokenLifespan)
+		}
+	}
+}

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -21,6 +21,7 @@
 package oauth2
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -576,8 +577,13 @@ func (h *Handler) FlushHandler(w http.ResponseWriter, r *http.Request, _ httprou
 //       400: jsonError
 //       500: jsonError
 func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
+
 	var session = NewSessionWithCustomClaims("", h.c.AllowedTopLevelClaims())
 	var ctx = r.Context()
+
+	ctx = context.WithValue(ctx,
+		fosite.EnableOneTimeUseRefreshTokenContextKey,
+		h.c.EnableOneTimeUseRefreshToken())
 
 	accessRequest, err := h.r.OAuth2Provider().NewAccessRequest(ctx, r, session)
 

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -582,8 +582,8 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	var ctx = r.Context()
 
 	ctx = context.WithValue(ctx,
-		fosite.EnableOneTimeUseRefreshTokenContextKey,
-		h.c.EnableOneTimeUseRefreshToken())
+		fosite.RefreshTokenRotationEnabledContextKey,
+		h.c.EnableRefreshTokenRotation())
 
 	accessRequest, err := h.r.OAuth2Provider().NewAccessRequest(ctx, r, session)
 

--- a/spec/config.json
+++ b/spec/config.json
@@ -425,6 +425,7 @@
       "type": "string",
       "description": "Sets the data source name. This configures the backend where ORY Hydra persists data. If dsn is \"memory\", data will be written to memory and is lost when you restart this instance. ORY Hydra supports popular SQL databases. For more detailed configuration information go to: https://www.ory.sh/docs/hydra/dependencies-environment#sql"
     },
+
     "webfinger": {
       "type": "object",
       "additionalProperties": false,
@@ -867,6 +868,11 @@
               ]
             }
           }
+        },
+        "enable_one_time_use_refresh_token": {
+          "type": "boolean",
+          "description": "Configures refresh_token behavior. By default refresh tokens are one time use.",
+          "default": true
         }
       }
     },

--- a/spec/config.json
+++ b/spec/config.json
@@ -869,10 +869,15 @@
             }
           }
         },
-        "enable_one_time_use_refresh_token": {
-          "type": "boolean",
-          "description": "Configures refresh_token behavior. By default refresh tokens are one time use.",
-          "default": true
+        "refresh_token_rotation": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Configures refresh_token rotatation behavior. By default refresh tokens are rotated on use.",
+              "default": true
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
This is a companion PR for [fosite #632](https://github.com/ory/fosite/pull/632)

The intention is that this is merged into a new branch (`v1.10.7`) from `v1.10.6`; this was branched from the `v1.10.6` tag. 

- Add new oauth2 configuration property:
  `oauth2.refresh_token_rotation.enabled` (default true)
- use new config property to set a flag in the context sent to the
  fosite library's refresh token handler


## Related issue(s)

https://github.com/ory/hydra/issues/1831

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

I was unsure how the file [`config.json`](https://github.com/bill-robbins-ss/hydra/blob/2f3cc3294933b621bdf309bbe515964892abfbad/spec/config.json) is generated so I updated it manually. It took me a bit of time to figure out that this file needed an update.
