### PR TITLE
feat: option to update session cookie expiry time on session refresh

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -425,7 +425,7 @@ func (s *DefaultStrategy) verifyAuthentication(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	if !session.Remember || session.LoginRequest.Skip {
+	if !session.Remember || session.LoginRequest.Skip && !session.RefreshRememberFor {
 		// If the user doesn't want to remember the session, we do not store a cookie.
 		// If login was skipped, it means an authentication cookie was present and
 		// we don't want to touch it (in order to preserve its original expiry date)

--- a/consent/strategy_oauth_test.go
+++ b/consent/strategy_oauth_test.go
@@ -364,6 +364,102 @@ func TestStrategyLoginConsentNext(t *testing.T) {
 		})
 	})
 
+	t.Run("case=should pass if both login and consent are granted and check remember flows with refresh session cookie", func(t *testing.T) {
+
+		subject := "subject-1"
+		c := createDefaultClient(t)
+		testhelpers.NewLoginConsentUI(t, reg.Config(),
+			acceptLoginHandler(t, subject, &hydra.AcceptOAuth2LoginRequest{
+				Remember: pointerx.Bool(true),
+			}),
+			acceptConsentHandler(t, &hydra.AcceptOAuth2ConsentRequest{
+				Remember:   pointerx.Bool(true),
+				GrantScope: []string{"openid"},
+				Session: &hydra.AcceptOAuth2ConsentRequestSession{
+					AccessToken: map[string]interface{}{"foo": "bar"},
+					IdToken:     map[string]interface{}{"bar": "baz"},
+				},
+			}))
+
+		hc := testhelpers.NewEmptyJarClient(t)
+
+		followUpHandler := func(refreshRememberFor bool) {
+			rememberFor := int64(12345)
+			testhelpers.NewLoginConsentUI(t, reg.Config(),
+				checkAndAcceptLoginHandler(t, adminClient, subject, func(t *testing.T, res *hydra.OAuth2LoginRequest, err error) hydra.AcceptOAuth2LoginRequest {
+					require.NoError(t, err)
+					assert.True(t, res.Skip)
+					assert.Equal(t, subject, res.Subject)
+					assert.Empty(t, res.Client.ClientSecret)
+					return hydra.AcceptOAuth2LoginRequest{
+						Subject:            subject,
+						Remember:           pointerx.Bool(true),
+						RememberFor:        pointerx.Int64(rememberFor),
+						RefreshRememberFor: pointerx.Bool(refreshRememberFor),
+						Context:            map[string]interface{}{"foo": "bar"},
+					}
+				}),
+				checkAndAcceptConsentHandler(t, adminClient, func(t *testing.T, res *hydra.OAuth2ConsentRequest, err error) hydra.AcceptOAuth2ConsentRequest {
+					require.NoError(t, err)
+					assert.True(t, *res.Skip)
+					assert.Equal(t, subject, res.Subject)
+					assert.Empty(t, res.Client.ClientSecret)
+					return hydra.AcceptOAuth2ConsentRequest{
+						Remember:   pointerx.Bool(true),
+						GrantScope: []string{"openid"},
+						Session: &hydra.AcceptOAuth2ConsentRequestSession{
+							AccessToken: map[string]interface{}{"foo": "bar"},
+							IdToken:     map[string]interface{}{"bar": "baz"},
+						},
+					}
+				}))
+
+			hc := &http.Client{
+				Jar:       hc.Jar,
+				Transport: &http.Transport{},
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+
+			_, oauthRes := makeOAuth2Request(t, reg, hc, c, url.Values{"redirect_uri": {c.RedirectURIs[0]}, "scope": {"openid"}})
+			assert.EqualValues(t, http.StatusFound, oauthRes.StatusCode)
+			loginChallengeRedirect, err := oauthRes.Location()
+			require.NoError(t, err)
+			defer oauthRes.Body.Close()
+
+			loginChallengeRes, err := hc.Get(loginChallengeRedirect.String())
+			require.NoError(t, err)
+			defer loginChallengeRes.Body.Close()
+			loginVerifierRedirect, err := loginChallengeRes.Location()
+
+			loginVerifierRes, err := hc.Get(loginVerifierRedirect.String())
+			require.NoError(t, err)
+			defer loginVerifierRes.Body.Close()
+
+			setCookieHeader := loginVerifierRes.Header.Get("set-cookie")
+			assert.NotNil(t, setCookieHeader)
+			if refreshRememberFor {
+				assert.Regexp(t, fmt.Sprintf("ory_hydra_session_dev=.*; Path=/; Expires=.*Max-Age=%d; HttpOnly; SameSite=Lax", rememberFor), setCookieHeader)
+			} else {
+				assert.NotContains(t, setCookieHeader, "ory_hydra_session_dev")
+			}
+		}
+
+		t.Run("perform first flow", func(t *testing.T) {
+			makeRequestAndExpectCode(t, hc, c, url.Values{"redirect_uri": {c.RedirectURIs[0]},
+				"scope": {"openid"}})
+		})
+
+		t.Run("perform follow up flow with refresh_remember_for=false", func(t *testing.T) {
+			followUpHandler(false)
+		})
+
+		t.Run("perform follow up flow with refresh_remember_for=true", func(t *testing.T) {
+			followUpHandler(true)
+		})
+	})
+
 	t.Run("case=should pass and check if login context is set properly", func(t *testing.T) {
 		// This should pass because login was remembered and session id should be set and session context should also work
 		subject := "aeneas-rekkas"

--- a/consent/types.go
+++ b/consent/types.go
@@ -265,6 +265,10 @@ type HandledLoginRequest struct {
 	// authorization will be remembered for the duration of the browser session (using a session cookie).
 	RememberFor int `json:"remember_for"`
 
+	// RefreshRememberFor, if set to true, session cookie expiry time will be updated when session is
+	// refreshed (login skip=true).
+	RefreshRememberFor bool `json:"refresh_remember_for"`
+
 	// ACR sets the Authentication AuthorizationContext Class Reference value for this authentication session. You can use it
 	// to express that, for example, a user authenticated using two factor authentication.
 	ACR string `json:"acr"`

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -152,6 +152,10 @@ type Flow struct {
 	// authorization will be remembered for the duration of the browser session (using a session cookie).
 	LoginRememberFor int `db:"login_remember_for"`
 
+	// LoginRefreshRememberFor, if set to true, session cookie expiry time will be updated when session is
+	// refreshed (login skip=true).
+	LoginRefreshRememberFor bool `db:"login_refresh_remember_for"`
+
 	// ACR sets the Authentication AuthorizationContext Class Reference value for this authentication session. You can use it
 	// to express that, for example, a user authenticated using two factor authentication.
 	ACR string `db:"acr"`
@@ -288,6 +292,7 @@ func (f *Flow) HandleLoginRequest(h *consent.HandledLoginRequest) error {
 
 	f.LoginRemember = h.Remember
 	f.LoginRememberFor = h.RememberFor
+	f.LoginRefreshRememberFor = h.RefreshRememberFor
 	f.ACR = h.ACR
 	f.AMR = h.AMR
 	f.Context = h.Context
@@ -301,6 +306,7 @@ func (f *Flow) GetHandledLoginRequest() consent.HandledLoginRequest {
 		ID:                     f.ID,
 		Remember:               f.LoginRemember,
 		RememberFor:            f.LoginRememberFor,
+		RefreshRememberFor:     f.LoginRefreshRememberFor,
 		ACR:                    f.ACR,
 		AMR:                    f.AMR,
 		Subject:                f.Subject,

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -40,6 +40,7 @@ func (f *Flow) setHandledLoginRequest(r *consent.HandledLoginRequest) {
 	f.ID = r.ID
 	f.LoginRemember = r.Remember
 	f.LoginRememberFor = r.RememberFor
+	f.LoginRefreshRememberFor = r.RefreshRememberFor
 	f.ACR = r.ACR
 	f.AMR = r.AMR
 	f.Subject = r.Subject

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -1881,8 +1881,7 @@ components:
             \ set might fail."
           type: string
         refresh_remember_for:
-          description: "RefreshRememberFor, if set to true, session cookie
-            expiry\
+          description: "RefreshRememberFor, if set to true, session cookie expiry\
             \ time will be updated when session is\nrefreshed (login skip=true)."
           type: boolean
         remember:

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -1880,6 +1880,11 @@ components:
             \ the proper value, then authentication processes which have id_token_hint\
             \ set might fail."
           type: string
+        refresh_remember_for:
+          description: "RefreshRememberFor, if set to true, session cookie
+            expiry\
+            \ time will be updated when session is\nrefreshed (login skip=true)."
+          type: boolean
         remember:
           description: "Remember, if set to true, tells ORY Hydra to remember this\
             \ user by telling the user agent (browser) to store\na cookie with authentication\

--- a/internal/httpclient/docs/AcceptOAuth2LoginRequest.md
+++ b/internal/httpclient/docs/AcceptOAuth2LoginRequest.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **Amr** | Pointer to **[]string** |  | [optional] 
 **Context** | Pointer to **interface{}** |  | [optional] 
 **ForceSubjectIdentifier** | Pointer to **string** | ForceSubjectIdentifier forces the \&quot;pairwise\&quot; user ID of the end-user that authenticated. The \&quot;pairwise\&quot; user ID refers to the (Pairwise Identifier Algorithm)[http://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg] of the OpenID Connect specification. It allows you to set an obfuscated subject (\&quot;user\&quot;) identifier that is unique to the client.  Please note that this changes the user ID on endpoint /userinfo and sub claim of the ID Token. It does not change the sub claim in the OAuth 2.0 Introspection.  Per default, ORY Hydra handles this value with its own algorithm. In case you want to set this yourself you can use this field. Please note that setting this field has no effect if &#x60;pairwise&#x60; is not configured in ORY Hydra or the OAuth 2.0 Client does not expect a pairwise identifier (set via &#x60;subject_type&#x60; key in the client&#39;s configuration).  Please also be aware that ORY Hydra is unable to properly compute this value during authentication. This implies that you have to compute this value on every authentication process (probably depending on the client ID or some other unique value).  If you fail to compute the proper value, then authentication processes which have id_token_hint set might fail. | [optional] 
+**RefreshRememberFor** | Pointer to **bool** | RefreshRememberFor, if set to true, session cookie expiry time will be updated when session is refreshed (login skip&#x3D;true). | [optional] 
 **Remember** | Pointer to **bool** | Remember, if set to true, tells ORY Hydra to remember this user by telling the user agent (browser) to store a cookie with authentication data. If the same user performs another OAuth 2.0 Authorization Request, he/she will not be asked to log in again. | [optional] 
 **RememberFor** | Pointer to **int64** | RememberFor sets how long the authentication should be remembered for in seconds. If set to &#x60;0&#x60;, the authorization will be remembered for the duration of the browser session (using a session cookie). | [optional] 
 **Subject** | **string** | Subject is the user ID of the end-user that authenticated. | 
@@ -140,6 +141,31 @@ SetForceSubjectIdentifier sets ForceSubjectIdentifier field to given value.
 `func (o *AcceptOAuth2LoginRequest) HasForceSubjectIdentifier() bool`
 
 HasForceSubjectIdentifier returns a boolean if a field has been set.
+
+### GetRefreshRememberFor
+
+`func (o *AcceptOAuth2LoginRequest) GetRefreshRememberFor() bool`
+
+GetRefreshRememberFor returns the RefreshRememberFor field if non-nil, zero value otherwise.
+
+### GetRefreshRememberForOk
+
+`func (o *AcceptOAuth2LoginRequest) GetRefreshRememberForOk() (*bool, bool)`
+
+GetRefreshRememberForOk returns a tuple with the RefreshRememberFor field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetRefreshRememberFor
+
+`func (o *AcceptOAuth2LoginRequest) SetRefreshRememberFor(v bool)`
+
+SetRefreshRememberFor sets RefreshRememberFor field to given value.
+
+### HasRefreshRememberFor
+
+`func (o *AcceptOAuth2LoginRequest) HasRefreshRememberFor() bool`
+
+HasRefreshRememberFor returns a boolean if a field has been set.
 
 ### GetRemember
 

--- a/internal/httpclient/model_accept_o_auth2_login_request.go
+++ b/internal/httpclient/model_accept_o_auth2_login_request.go
@@ -23,6 +23,8 @@ type AcceptOAuth2LoginRequest struct {
 	Context interface{} `json:"context,omitempty"`
 	// ForceSubjectIdentifier forces the \"pairwise\" user ID of the end-user that authenticated. The \"pairwise\" user ID refers to the (Pairwise Identifier Algorithm)[http://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg] of the OpenID Connect specification. It allows you to set an obfuscated subject (\"user\") identifier that is unique to the client.  Please note that this changes the user ID on endpoint /userinfo and sub claim of the ID Token. It does not change the sub claim in the OAuth 2.0 Introspection.  Per default, ORY Hydra handles this value with its own algorithm. In case you want to set this yourself you can use this field. Please note that setting this field has no effect if `pairwise` is not configured in ORY Hydra or the OAuth 2.0 Client does not expect a pairwise identifier (set via `subject_type` key in the client's configuration).  Please also be aware that ORY Hydra is unable to properly compute this value during authentication. This implies that you have to compute this value on every authentication process (probably depending on the client ID or some other unique value).  If you fail to compute the proper value, then authentication processes which have id_token_hint set might fail.
 	ForceSubjectIdentifier *string `json:"force_subject_identifier,omitempty"`
+	// RefreshRememberFor, if set to true, session cookie expiry time will be updated when session is refreshed (login skip=true).
+	RefreshRememberFor *bool `json:"refresh_remember_for,omitempty"`
 	// Remember, if set to true, tells ORY Hydra to remember this user by telling the user agent (browser) to store a cookie with authentication data. If the same user performs another OAuth 2.0 Authorization Request, he/she will not be asked to log in again.
 	Remember *bool `json:"remember,omitempty"`
 	// RememberFor sets how long the authentication should be remembered for in seconds. If set to `0`, the authorization will be remembered for the duration of the browser session (using a session cookie).
@@ -178,6 +180,38 @@ func (o *AcceptOAuth2LoginRequest) SetForceSubjectIdentifier(v string) {
 	o.ForceSubjectIdentifier = &v
 }
 
+// GetRefreshRememberFor returns the RefreshRememberFor field value if set, zero value otherwise.
+func (o *AcceptOAuth2LoginRequest) GetRefreshRememberFor() bool {
+	if o == nil || o.RefreshRememberFor == nil {
+		var ret bool
+		return ret
+	}
+	return *o.RefreshRememberFor
+}
+
+// GetRefreshRememberForOk returns a tuple with the RefreshRememberFor field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AcceptOAuth2LoginRequest) GetRefreshRememberForOk() (*bool, bool) {
+	if o == nil || o.RefreshRememberFor == nil {
+		return nil, false
+	}
+	return o.RefreshRememberFor, true
+}
+
+// HasRefreshRememberFor returns a boolean if a field has been set.
+func (o *AcceptOAuth2LoginRequest) HasRefreshRememberFor() bool {
+	if o != nil && o.RefreshRememberFor != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRefreshRememberFor gets a reference to the given bool and assigns it to the RefreshRememberFor field.
+func (o *AcceptOAuth2LoginRequest) SetRefreshRememberFor(v bool) {
+	o.RefreshRememberFor = &v
+}
+
 // GetRemember returns the Remember field value if set, zero value otherwise.
 func (o *AcceptOAuth2LoginRequest) GetRemember() bool {
 	if o == nil || o.Remember == nil {
@@ -279,6 +313,9 @@ func (o AcceptOAuth2LoginRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.ForceSubjectIdentifier != nil {
 		toSerialize["force_subject_identifier"] = o.ForceSubjectIdentifier
+	}
+	if o.RefreshRememberFor != nil {
+		toSerialize["refresh_remember_for"] = o.RefreshRememberFor
 	}
 	if o.Remember != nil {
 		toSerialize["remember"] = o.Remember

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0001.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0001.json
@@ -21,6 +21,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 1,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0001",
   "AMR": [],
   "ForceSubjectIdentifier": "",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0002.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0002.json
@@ -21,6 +21,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 2,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0002",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0002",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0003.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0003.json
@@ -21,6 +21,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 3,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0003",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0003",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0004.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0004.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 4,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0004",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0004",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0005.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0005.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 5,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0005",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0005",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0006.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0006.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 6,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0006",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0006",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0007.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0007.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 7,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0007",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0007",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0008.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0008.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 8,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0008",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0008",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0009.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0009.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 9,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0009",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0009",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0010.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0010.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 10,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0010",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0010",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0011.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0011.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 11,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0011",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0011",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0012.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0012.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 12,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0012",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0012",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0013.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0013.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 13,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0013",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0013",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0014.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0014.json
@@ -23,6 +23,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 14,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0014",
   "AMR": [],
   "ForceSubjectIdentifier": "force_subject_id-0014",

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0015.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_flow/challenge-0015.json
@@ -25,6 +25,7 @@
   "State": 128,
   "LoginRemember": true,
   "LoginRememberFor": 15,
+  "LoginRefreshRememberFor": false,
   "ACR": "acr-0015",
   "AMR": [
     "amr-0015-1",

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.cockroach.down.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.cockroach.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow DROP COLUMN login_refresh_remember_for;

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.cockroach.up.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.cockroach.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow ADD login_refresh_remember_for BOOLEAN NOT NULL DEFAULT FALSE;

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.mysql.down.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.mysql.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow DROP COLUMN login_refresh_remember_for;

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.mysql.up.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.mysql.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow ADD COLUMN login_refresh_remember_for BOOLEAN NOT NULL DEFAULT FALSE;

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.postgres.down.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.postgres.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow DROP COLUMN login_refresh_remember_for;

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.postgres.up.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.postgres.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow ADD login_refresh_remember_for BOOLEAN NOT NULL DEFAULT FALSE;

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.sqlite.down.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.sqlite.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow DROP COLUMN login_refresh_remember_for;

--- a/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.sqlite.up.sql
+++ b/persistence/sql/migrations/20220914000001000000_support_refresh_remember_for.sqlite.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_flow ADD login_refresh_remember_for BOOLEAN NOT NULL DEFAULT FALSE;

--- a/spec/api.json
+++ b/spec/api.json
@@ -150,6 +150,10 @@
             "description": "ForceSubjectIdentifier forces the \"pairwise\" user ID of the end-user that authenticated. The \"pairwise\" user ID refers to the\n(Pairwise Identifier Algorithm)[http://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg] of the OpenID\nConnect specification. It allows you to set an obfuscated subject (\"user\") identifier that is unique to the client.\n\nPlease note that this changes the user ID on endpoint /userinfo and sub claim of the ID Token. It does not change the\nsub claim in the OAuth 2.0 Introspection.\n\nPer default, ORY Hydra handles this value with its own algorithm. In case you want to set this yourself\nyou can use this field. Please note that setting this field has no effect if `pairwise` is not configured in\nORY Hydra or the OAuth 2.0 Client does not expect a pairwise identifier (set via `subject_type` key in the client's\nconfiguration).\n\nPlease also be aware that ORY Hydra is unable to properly compute this value during authentication. This implies\nthat you have to compute this value on every authentication process (probably depending on the client ID or some\nother unique value).\n\nIf you fail to compute the proper value, then authentication processes which have id_token_hint set might fail.",
             "type": "string"
           },
+          "refresh_remember_for": {
+            "description": "RefreshRememberFor, if set to true, session cookie expiry time will be updated when session is\nrefreshed (login skip=true).",
+            "type": "boolean"
+          },
           "remember": {
             "description": "Remember, if set to true, tells ORY Hydra to remember this user by telling the user agent (browser) to store\na cookie with authentication data. If the same user performs another OAuth 2.0 Authorization Request, he/she\nwill not be asked to log in again.",
             "type": "boolean"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -2129,6 +2129,10 @@
           "description": "ForceSubjectIdentifier forces the \"pairwise\" user ID of the end-user that authenticated. The \"pairwise\" user ID refers to the\n(Pairwise Identifier Algorithm)[http://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg] of the OpenID\nConnect specification. It allows you to set an obfuscated subject (\"user\") identifier that is unique to the client.\n\nPlease note that this changes the user ID on endpoint /userinfo and sub claim of the ID Token. It does not change the\nsub claim in the OAuth 2.0 Introspection.\n\nPer default, ORY Hydra handles this value with its own algorithm. In case you want to set this yourself\nyou can use this field. Please note that setting this field has no effect if `pairwise` is not configured in\nORY Hydra or the OAuth 2.0 Client does not expect a pairwise identifier (set via `subject_type` key in the client's\nconfiguration).\n\nPlease also be aware that ORY Hydra is unable to properly compute this value during authentication. This implies\nthat you have to compute this value on every authentication process (probably depending on the client ID or some\nother unique value).\n\nIf you fail to compute the proper value, then authentication processes which have id_token_hint set might fail.",
           "type": "string"
         },
+        "refresh_remember_for": {
+          "description": "RefreshRememberFor, if set to true, session cookie expiry time will be updated when session is\nrefreshed (login skip=true).",
+          "type": "boolean"
+        },
         "remember": {
           "description": "Remember, if set to true, tells ORY Hydra to remember this user by telling the user agent (browser) to store\na cookie with authentication data. If the same user performs another OAuth 2.0 Authorization Request, he/she\nwill not be asked to log in again.",
           "type": "boolean"


### PR DESCRIPTION
This pull request introduces feature to update session cookie expiry time on session refresh request.

**Use case**: We want to keep session duration quite short (15 minutes) and force client applications to periodically extend the session by performing authentication requests with `prompt=none`. Each subsequent authentication request produces a new identity token with lifetime of 15 minutes. But as a security measure we want that browser session cookie would not be kept alive any longer than necessary - therefore browser session cookie duration should be periodically extended, each time by 15 minutes (the same lifetime as each new identity token).

**Current situation**: Browser session cookie (`oauth2_authentication_session`) expiration is set from first [acceptLoginRequest](https://www.ory.sh/hydra/docs/reference/api/#operation/acceptLoginRequest)'s `remember_for` value.
When performing subsequent session update requests (authentication requests with `prompt=none`), then browser session cookie expiration cannot be changed.

**Proposed solution**: Add `refresh_remember_for` parameter for [PUT /oauth2/auth/requests/login/accept](https://www.ory.sh/hydra/docs/reference/api/#operation/acceptLoginRequest) request body. When `refresh_remember_for=true`, session cookie expiry will be reset.

## Related issue(s)
https://github.com/ory/hydra/issues/1690
https://github.com/ory/hydra/issues/1557
https://github.com/ory/hydra/discussions/2246

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments
**Tests and documentation will be commited after inital acceptance of the proposed feature.**