### PR TITLE
feat: async backchannel logout

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/ory/hydra/driver/config"
@@ -696,13 +695,9 @@ func (s *DefaultStrategy) executeBackChannelLogout(ctx context.Context, r *http.
 		tasks = append(tasks, task{url: c.BackChannelLogoutURI, clientID: c.OutfacingID, token: t})
 	}
 
-	var wg sync.WaitGroup
 	hc := httpx.NewResilientClient()
-	wg.Add(len(tasks))
 
 	var execute = func(t task) {
-		defer wg.Done()
-
 		res, err := hc.PostForm(t.url, url.Values{"logout_token": {t.token}})
 		if err != nil {
 			s.r.Logger().WithRequest(r).WithError(err).
@@ -726,8 +721,6 @@ func (s *DefaultStrategy) executeBackChannelLogout(ctx context.Context, r *http.
 	for _, t := range tasks {
 		go execute(t)
 	}
-
-	wg.Wait()
 
 	return nil
 }

--- a/internal/httpclient-next/api/openapi.yaml
+++ b/internal/httpclient-next/api/openapi.yaml
@@ -1653,6 +1653,8 @@ paths:
 
         https://openid.net/specs/openid-connect-frontchannel-1_0.html
         https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+        Back-channel logout is performed asynchronously and does not affect logout flow.
       operationId: disconnectUser
       responses:
         "302":

--- a/internal/httpclient-next/api_public.go
+++ b/internal/httpclient-next/api_public.go
@@ -33,6 +33,8 @@ type PublicApi interface {
 
 		https://openid.net/specs/openid-connect-frontchannel-1_0.html
 		https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+		Back-channel logout is performed asynchronously and does not affect logout flow.
 			 * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 			 * @return PublicApiApiDisconnectUserRequest
 	*/
@@ -272,6 +274,8 @@ func (r PublicApiApiDisconnectUserRequest) Execute() (*http.Response, error) {
 
 https://openid.net/specs/openid-connect-frontchannel-1_0.html
 https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+Back-channel logout is performed asynchronously and does not affect logout flow.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return PublicApiApiDisconnectUserRequest
 */

--- a/internal/httpclient/client/public/public_client.go
+++ b/internal/httpclient/client/public/public_client.go
@@ -64,6 +64,8 @@ type ClientService interface {
 
 https://openid.net/specs/openid-connect-frontchannel-1_0.html
 https://openid.net/specs/openid-connect-backchannel-1_0.html
+
+Back-channel logout is performed asynchronously and does not affect logout flow.
 */
 func (a *Client) DisconnectUser(params *DisconnectUserParams, opts ...ClientOption) error {
 	// TODO: Validate the params before sending

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -121,6 +121,8 @@ func (h *Handler) SetRoutes(admin *x.RouterAdmin, public *x.RouterPublic, corsMi
 // - https://openid.net/specs/openid-connect-frontchannel-1_0.html
 // - https://openid.net/specs/openid-connect-backchannel-1_0.html
 //
+// Back-channel logout is performed asynchronously and does not affect logout flow.
+//
 //     Schemes: http, https
 //
 //     Responses:

--- a/spec/api.json
+++ b/spec/api.json
@@ -3411,7 +3411,7 @@
     },
     "/oauth2/sessions/logout": {
       "get": {
-        "description": "This endpoint initiates and completes user logout at Ory Hydra and initiates OpenID Connect Front-/Back-channel logout:\n\nhttps://openid.net/specs/openid-connect-frontchannel-1_0.html\nhttps://openid.net/specs/openid-connect-backchannel-1_0.html",
+        "description": "This endpoint initiates and completes user logout at Ory Hydra and initiates OpenID Connect Front-/Back-channel logout:\n\nhttps://openid.net/specs/openid-connect-frontchannel-1_0.html\nhttps://openid.net/specs/openid-connect-backchannel-1_0.html\n\nBack-channel logout is performed asynchronously and does not affect logout flow.",
         "operationId": "disconnectUser",
         "responses": {
           "302": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -1846,7 +1846,7 @@
     },
     "/oauth2/sessions/logout": {
       "get": {
-        "description": "This endpoint initiates and completes user logout at Ory Hydra and initiates OpenID Connect Front-/Back-channel logout:\n\nhttps://openid.net/specs/openid-connect-frontchannel-1_0.html\nhttps://openid.net/specs/openid-connect-backchannel-1_0.html",
+        "description": "This endpoint initiates and completes user logout at Ory Hydra and initiates OpenID Connect Front-/Back-channel logout:\n\nhttps://openid.net/specs/openid-connect-frontchannel-1_0.html\nhttps://openid.net/specs/openid-connect-backchannel-1_0.html\n\nBack-channel logout is performed asynchronously and does not affect logout flow.",
         "schemes": [
           "http",
           "https"


### PR DESCRIPTION
This pull request introduces feature to execute backchannel logout asynchronously.

**Use case**: User should not have to wait for backchannel requests to finish (4x30sec, with potential connection timeout 1min on each request), when performing logout from all applications using GET /oauth2/sessions/logout or from specific application by using DELETE /oauth2/auth/sessions/consent?trigger_backchannel_logout=true (https://github.com/ory/hydra/pull/2844)

Will add configuration option if needed.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

**Tests and documentation will be commited after inital acceptance of the proposed feature.**
