### PR TITLE
feat: list consent sessions by session id

### DIFF
--- a/consent/manager.go
+++ b/consent/manager.go
@@ -33,6 +33,7 @@ type Manager interface {
 	VerifyAndInvalidateConsentRequest(ctx context.Context, verifier string) (*AcceptOAuth2ConsentRequest, error)
 	FindGrantedAndRememberedConsentRequests(ctx context.Context, client, user string) ([]AcceptOAuth2ConsentRequest, error)
 	FindSubjectsGrantedConsentRequests(ctx context.Context, user string, limit, offset int) ([]AcceptOAuth2ConsentRequest, error)
+	FindSubjectsSessionGrantedConsentRequests(ctx context.Context, user, sid string, limit, offset int) ([]AcceptOAuth2ConsentRequest, error)
 	CountSubjectsGrantedConsentRequests(ctx context.Context, user string) (int, error)
 
 	// Cookie management

--- a/consent/manager_test_helpers.go
+++ b/consent/manager_test_helpers.go
@@ -314,6 +314,7 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 				lr[k] = &LoginRequest{
 					ID:              makeID("fk-login-challenge", network, k),
 					Subject:         fmt.Sprintf("subject%s", k),
+					SessionID:       sqlxx.NullString(makeID("fk-login-session", network, k)),
 					Verifier:        makeID("fk-login-verifier", network, k),
 					Client:          &client.Client{LegacyClientID: fmt.Sprintf("fk-client-%s", k)},
 					AuthenticatedAt: sqlxx.NullTime(time.Now()),
@@ -667,6 +668,52 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 			require.NoError(t, err)
 			_, err = m.HandleConsentRequest(context.Background(), hcr2)
 			require.NoError(t, err)
+
+			for i, tc := range []struct {
+				subject    string
+				sid        string
+				challenges []string
+				clients    []string
+			}{
+				{
+					subject:    cr1.Subject,
+					sid:        makeID("fk-login-session", network, "rv1"),
+					challenges: []string{challengerv1},
+					clients:    []string{"fk-client-rv1"},
+				},
+				{
+					subject:    cr2.Subject,
+					sid:        makeID("fk-login-session", network, "rv2"),
+					challenges: []string{challengerv2},
+					clients:    []string{"fk-client-rv2"},
+				},
+				{
+					subject:    "subjectrv3",
+					sid:        makeID("fk-login-session", network, "rv2"),
+					challenges: []string{},
+					clients:    []string{},
+				},
+			} {
+				t.Run(fmt.Sprintf("case=%d/subject=%s/session=%s", i, tc.subject, tc.sid), func(t *testing.T) {
+					consents, err := m.FindSubjectsSessionGrantedConsentRequests(context.Background(), tc.subject, tc.sid, 100, 0)
+					assert.Equal(t, len(tc.challenges), len(consents))
+
+					if len(tc.challenges) == 0 {
+						assert.EqualError(t, err, ErrNoPreviousConsentFound.Error())
+					} else {
+						require.NoError(t, err)
+						for _, consent := range consents {
+							assert.Contains(t, tc.challenges, consent.ID)
+							assert.Contains(t, tc.clients, consent.ConsentRequest.Client.GetID())
+						}
+					}
+
+					n, err := m.CountSubjectsGrantedConsentRequests(context.Background(), tc.subject)
+					require.NoError(t, err)
+					assert.Equal(t, n, len(tc.challenges))
+
+				})
+			}
 
 			for i, tc := range []struct {
 				subject    string

--- a/consent/sdk_test.go
+++ b/consent/sdk_test.go
@@ -77,10 +77,10 @@ func TestSDK(t *testing.T) {
 	require.NoError(t, reg.ClientManager().CreateClient(context.Background(), cr4.Client))
 	require.NoError(t, m.CreateLoginRequest(context.Background(), &LoginRequest{ID: cr1.LoginChallenge.String(), Subject: cr1.Subject, Client: cr1.Client, Verifier: cr1.ID}))
 	require.NoError(t, m.CreateLoginRequest(context.Background(), &LoginRequest{ID: cr2.LoginChallenge.String(), Subject: cr2.Subject, Client: cr2.Client, Verifier: cr2.ID}))
-	require.NoError(t, m.CreateLoginRequest(context.Background(), &LoginRequest{ID: cr3.LoginChallenge.String(), Subject: cr3.Subject, Client: cr3.Client, Verifier: cr3.ID, RequestedAt: hcr3.RequestedAt}))
 	require.NoError(t, m.CreateLoginSession(context.Background(), &LoginSession{ID: cr3.LoginSessionID.String()}))
-	require.NoError(t, m.CreateLoginRequest(context.Background(), &LoginRequest{ID: cr4.LoginChallenge.String(), Client: cr4.Client, Verifier: cr4.ID}))
+	require.NoError(t, m.CreateLoginRequest(context.Background(), &LoginRequest{ID: cr3.LoginChallenge.String(), Subject: cr3.Subject, Client: cr3.Client, Verifier: cr3.ID, RequestedAt: hcr3.RequestedAt, SessionID: cr3.LoginSessionID}))
 	require.NoError(t, m.CreateLoginSession(context.Background(), &LoginSession{ID: cr4.LoginSessionID.String()}))
+	require.NoError(t, m.CreateLoginRequest(context.Background(), &LoginRequest{ID: cr4.LoginChallenge.String(), Client: cr4.Client, Verifier: cr4.ID, SessionID: cr4.LoginSessionID}))
 	require.NoError(t, m.CreateConsentRequest(context.Background(), cr1))
 	require.NoError(t, m.CreateConsentRequest(context.Background(), cr2))
 	require.NoError(t, m.CreateConsentRequest(context.Background(), cr3))
@@ -149,6 +149,16 @@ func TestSDK(t *testing.T) {
 	assert.Equal(t, makeID("challenge", network, "3"), cs.ConsentRequest.Challenge)
 
 	csGot, _, err = sdk.OAuth2Api.ListOAuth2ConsentSessions(ctx).Subject("subject2").Execute()
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(csGot))
+
+	csGot, _, err = sdk.V0alpha2Api.AdminListOAuth2SubjectConsentSessions(ctx).Subject("subject3").LoginSessionId("fk-login-session-t1-3").Execute()
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(csGot))
+	cs = csGot[0]
+	assert.Equal(t, makeID("challenge", network, "3"), cs.ConsentRequest.Challenge)
+
+	csGot, _, err = sdk.V0alpha2Api.AdminListOAuth2SubjectConsentSessions(ctx).Subject("subject3").LoginSessionId("fk-login-session-t1-X").Execute()
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(csGot))
 

--- a/consent/sdk_test.go
+++ b/consent/sdk_test.go
@@ -152,13 +152,13 @@ func TestSDK(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(csGot))
 
-	csGot, _, err = sdk.V0alpha2Api.AdminListOAuth2SubjectConsentSessions(ctx).Subject("subject3").LoginSessionId("fk-login-session-t1-3").Execute()
+	csGot, _, err = sdk.OAuth2Api.ListOAuth2ConsentSessions(ctx).Subject("subject3").LoginSessionId("fk-login-session-t1-3").Execute()
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(csGot))
 	cs = csGot[0]
 	assert.Equal(t, makeID("challenge", network, "3"), cs.ConsentRequest.Challenge)
 
-	csGot, _, err = sdk.V0alpha2Api.AdminListOAuth2SubjectConsentSessions(ctx).Subject("subject3").LoginSessionId("fk-login-session-t1-X").Execute()
+	csGot, _, err = sdk.OAuth2Api.ListOAuth2ConsentSessions(ctx).Subject("subject3").LoginSessionId("fk-login-session-t1-X").Execute()
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(csGot))
 

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -1104,6 +1104,14 @@ paths:
         schema:
           type: string
         style: form
+      - description: The login session id to list the consent sessions for.
+        explode: true
+        in: query
+        name: login_session_id
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:

--- a/internal/httpclient/api_o_auth2.go
+++ b/internal/httpclient/api_o_auth2.go
@@ -1768,11 +1768,12 @@ func (a *OAuth2ApiService) ListOAuth2ClientsExecute(r ApiListOAuth2ClientsReques
 }
 
 type ApiListOAuth2ConsentSessionsRequest struct {
-	ctx        context.Context
-	ApiService *OAuth2ApiService
-	subject    *string
-	pageSize   *int64
-	pageToken  *string
+	ctx            context.Context
+	ApiService     *OAuth2ApiService
+	subject        *string
+	pageSize       *int64
+	pageToken      *string
+	loginSessionId *string
 }
 
 // The subject to list the consent sessions for.
@@ -1790,6 +1791,12 @@ func (r ApiListOAuth2ConsentSessionsRequest) PageSize(pageSize int64) ApiListOAu
 // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination).
 func (r ApiListOAuth2ConsentSessionsRequest) PageToken(pageToken string) ApiListOAuth2ConsentSessionsRequest {
 	r.pageToken = &pageToken
+	return r
+}
+
+// The login session id to list the consent sessions for.
+func (r ApiListOAuth2ConsentSessionsRequest) LoginSessionId(loginSessionId string) ApiListOAuth2ConsentSessionsRequest {
+	r.loginSessionId = &loginSessionId
 	return r
 }
 
@@ -1846,6 +1853,9 @@ func (a *OAuth2ApiService) ListOAuth2ConsentSessionsExecute(r ApiListOAuth2Conse
 		localVarQueryParams.Add("page_token", parameterToString(*r.pageToken, ""))
 	}
 	localVarQueryParams.Add("subject", parameterToString(*r.subject, ""))
+	if r.loginSessionId != nil {
+		localVarQueryParams.Add("login_session_id", parameterToString(*r.loginSessionId, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/internal/httpclient/docs/OAuth2Api.md
+++ b/internal/httpclient/docs/OAuth2Api.md
@@ -983,7 +983,7 @@ No authorization required
 
 ## ListOAuth2ConsentSessions
 
-> []OAuth2ConsentSession ListOAuth2ConsentSessions(ctx).Subject(subject).PageSize(pageSize).PageToken(pageToken).Execute()
+> []OAuth2ConsentSession ListOAuth2ConsentSessions(ctx).Subject(subject).PageSize(pageSize).PageToken(pageToken).LoginSessionId(loginSessionId).Execute()
 
 List OAuth 2.0 Consent Sessions of a Subject
 
@@ -1005,10 +1005,11 @@ func main() {
     subject := "subject_example" // string | The subject to list the consent sessions for.
     pageSize := int64(789) // int64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). (optional) (default to 250)
     pageToken := "pageToken_example" // string | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). (optional) (default to "1")
+    loginSessionId := "loginSessionId_example" // string | The login session id to list the consent sessions for. (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.OAuth2Api.ListOAuth2ConsentSessions(context.Background()).Subject(subject).PageSize(pageSize).PageToken(pageToken).Execute()
+    resp, r, err := apiClient.OAuth2Api.ListOAuth2ConsentSessions(context.Background()).Subject(subject).PageSize(pageSize).PageToken(pageToken).LoginSessionId(loginSessionId).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `OAuth2Api.ListOAuth2ConsentSessions``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -1032,6 +1033,7 @@ Name | Type | Description  | Notes
  **subject** | **string** | The subject to list the consent sessions for. | 
  **pageSize** | **int64** | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). | [default to 250]
  **pageToken** | **string** | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). | [default to &quot;1&quot;]
+ **loginSessionId** | **string** | The login session id to list the consent sessions for. | 
 
 ### Return type
 

--- a/persistence/sql/persister_consent.go
+++ b/persistence/sql/persister_consent.go
@@ -465,6 +465,41 @@ nid = ?`, flow.FlowStateConsentUsed, flow.FlowStateConsentUnused,
 	return p.filterExpiredConsentRequests(ctx, rs)
 }
 
+func (p *Persister) FindSubjectsSessionGrantedConsentRequests(ctx context.Context, subject, sid string, limit, offset int) ([]consent.AcceptOAuth2ConsentRequest, error) {
+	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.FindSubjectsSessionGrantedConsentRequests")
+	defer span.End()
+
+	var fs []flow.Flow
+	c := p.Connection(ctx)
+
+	if err := c.
+		Where(
+			strings.TrimSpace(fmt.Sprintf(`
+(state = %d OR state = %d) AND
+subject = ? AND
+login_session_id = ? AND
+consent_skip=FALSE AND
+consent_error='{}' AND
+nid = ?`, flow.FlowStateConsentUsed, flow.FlowStateConsentUnused,
+			)),
+			subject, sid, p.NetworkID(ctx)).
+		Order("requested_at DESC").
+		Paginate(offset/limit+1, limit).
+		All(&fs); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errorsx.WithStack(consent.ErrNoPreviousConsentFound)
+		}
+		return nil, sqlcon.HandleError(err)
+	}
+
+	var rs []consent.AcceptOAuth2ConsentRequest
+	for _, f := range fs {
+		rs = append(rs, *f.GetHandledConsentRequest())
+	}
+
+	return p.filterExpiredConsentRequests(ctx, rs)
+}
+
 func (p *Persister) CountSubjectsGrantedConsentRequests(ctx context.Context, subject string) (int, error) {
 	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.CountSubjectsGrantedConsentRequests")
 	defer span.End()

--- a/spec/api.json
+++ b/spec/api.json
@@ -2796,6 +2796,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "The login session id to list the consent sessions for.",
+            "in": "query",
+            "name": "login_session_id",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -1204,6 +1204,12 @@
             "name": "subject",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "The login session id to list the consent sessions for.",
+            "name": "login_session_id",
+            "in": "query"
           }
         ],
         "responses": {


### PR DESCRIPTION
This pull request introduces feature to list subject consent sessions by session id.

**Use case**:
When authentication is initiated without `prompt` parameter from **multiple** devices, we would like to distinguish in what session was the consent given.

**Current situation**:
GET [/oauth2/auth/sessions/consent](https://www.ory.sh/hydra/docs/reference/api/#operation/listSubjectConsentSessions) returns **single** consent and it references to the session id, where the consent was initially given. Furthermore if logout is performed from device initially gave the consent, the reference to login session id is cleared.
If  `prompt=consent` were to be used, separate consents with separate session id would be returned and you would not have same problems. So this endpoint behaves differently in relation to how login session id is referenced.

**Proposed solution**:
Add additional query parameter `login_session_id` for GET [/oauth2/auth/sessions/consent](https://www.ory.sh/hydra/docs/reference/api/#operation/listSubjectConsentSessions) to return consents related to requested session id.
This solution does not change how login session id is referenced in result.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

Tests and documentation will be commited after inital acceptance of the proposed feature.
