### PR TITLE
chore: bump aline to 3.14.3

### DIFF
--- a/.docker/Dockerfile-alpine
+++ b/.docker/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 
 RUN addgroup -S ory; \
     adduser -S ory -G ory -D -H -s /bin/nologin

--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -16,7 +16,7 @@ ADD . .
 
 RUN go build -tags sqlite -o /usr/bin/hydra
 
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 
 RUN addgroup -S ory; \
     adduser -S ory -G ory -D  -h /home/ory -s /bin/nologin; \

--- a/.docker/Dockerfile-scratch
+++ b/.docker/Dockerfile-scratch
@@ -1,4 +1,4 @@
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 
 RUN apk add -U --no-cache ca-certificates
 

--- a/.docker/Dockerfile-sqlite
+++ b/.docker/Dockerfile-sqlite
@@ -1,4 +1,4 @@
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 
 # Because this image is built for SQLite, we create /home/ory and /home/ory/sqlite which is owned by the ory user
 # and declare /home/ory/sqlite a volume.


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

Updated Alpine 3.14.2 to 3.14.3 to solve several security issues
CVE-2021-42374,CVE-2021-42375,CVE-2021-42378,CVE-2021-42379,CVE-2021-42380,CVE-2021-42381,CVE-2021-42382,CVE-2021-42383,CVE-2021-42384,CVE-2021-42385,CVE-2021-42386

## Checklist

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

