### PR TITLE
feat: drop methods for finding keys by public/private prefix

### DIFF
--- a/cmd/server/helper_cert.go
+++ b/cmd/server/helper_cert.go
@@ -63,7 +63,7 @@ func GetOrCreateTLSCertificate(cmd *cobra.Command, d driver.Registry, iface conf
 		d.Logger().WithError(err).Fatalf("Unable to load HTTPS TLS Certificate")
 	}
 
-	_, priv, err := jwk.AsymmetricKeypair(context.Background(), d, &jwk.RS256Generator{KeyLength: 4069}, tlsKeyName)
+	_, priv, err := jwk.GetOrGenerateKeys(context.Background(), d, &jwk.RS256Generator{KeyLength: 4069}, tlsKeyName)
 	if err != nil {
 		d.Logger().WithError(err).Fatal("Unable to fetch HTTPS TLS key pairs")
 	}

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -39,55 +39,43 @@ import (
 )
 
 func EnsureAsymmetricKeypairExists(ctx context.Context, r InternalRegistry, g KeyGenerator, set string) error {
-	_, _, err := AsymmetricKeypair(ctx, r, g, set)
+	_, _, err := GetOrGenerateKeys(ctx, r, g, set)
 	return err
 }
 
-func AsymmetricKeypair(ctx context.Context, r InternalRegistry, g KeyGenerator, set string) (public, private *jose.JSONWebKey, err error) {
-	priv, err := GetOrCreateKey(ctx, r, g, set, "private")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	pub, err := GetOrCreateKey(ctx, r, g, set, "public")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return pub, priv, nil
-}
-
-func GetOrCreateKey(ctx context.Context, r InternalRegistry, g KeyGenerator, set, prefix string) (*jose.JSONWebKey, error) {
+func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, g KeyGenerator, set string) (public, private *jose.JSONWebKey, err error) {
 	keys, err := r.KeyManager().GetKeySet(ctx, set)
 	if errors.Is(err, x.ErrNotFound) || keys != nil && len(keys.Keys) == 0 {
 		r.Logger().Warnf("JSON Web Key Set \"%s\" does not exist yet, generating new key pair...", set)
-		keys, err = createKey(ctx, r, g, set)
+		keys, err = createKeySet(ctx, r, g, set)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	} else if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	key, err := FindKeyByPrefix(keys, prefix)
-	if err != nil {
-		r.Logger().Warnf("JSON Web Key with prefix %s not found in JSON Web Key Set %s, generating new key pair...", prefix, set)
-
-		keys, err = createKey(ctx, r, g, set)
-		if err != nil {
-			return nil, err
+	pubKey, pubKeyErr := FindPublicKey(keys)
+	privKey, privKeyErr := FindPrivateKey(keys)
+	if pubKeyErr == nil && privKeyErr == nil {
+		return pubKey, privKey, nil
+	} else {
+		if pubKeyErr != nil {
+			r.Logger().Warnf("Public JSON Web Key not found in JSON Web Key Set %s, generating new key pair...", set)
+		} else {
+			r.Logger().Warnf("Private JSON Web Key not found in JSON Web Key Set %s, generating new key pair...", set)
 		}
-
-		key, err = FindKeyByPrefix(keys, prefix)
+		keys, err = createKeySet(ctx, r, g, set)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		pubKey, _ = FindPublicKey(keys)
+		privKey, _ = FindPrivateKey(keys)
+		return pubKey, privKey, nil
 	}
-
-	return key, nil
 }
 
-func createKey(ctx context.Context, r InternalRegistry, g KeyGenerator, set string) (*jose.JSONWebKeySet, error) {
+func createKeySet(ctx context.Context, r InternalRegistry, g KeyGenerator, set string) (*jose.JSONWebKeySet, error) {
 	keys, err := g.Generate(uuid.New(), "sig")
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not generate JSON Web Key Set \"%s\".", set)
@@ -112,15 +100,6 @@ func First(keys []jose.JSONWebKey) *jose.JSONWebKey {
 	return &keys[0]
 }
 
-func FindKeyByPrefix(set *jose.JSONWebKeySet, prefix string) (key *jose.JSONWebKey, err error) {
-	keys, err := FindKeysByPrefix(set, prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	return First(keys.Keys), nil
-}
-
 func FindPublicKey(set *jose.JSONWebKeySet) (key *jose.JSONWebKey, err error) {
 	keys := ExcludePrivateKeys(set)
 	if len(keys.Keys) == 0 {
@@ -128,6 +107,30 @@ func FindPublicKey(set *jose.JSONWebKeySet) (key *jose.JSONWebKey, err error) {
 	}
 
 	return First(keys.Keys), nil
+}
+
+func FindPrivateKey(set *jose.JSONWebKeySet) (key *jose.JSONWebKey, err error) {
+	keys := ExcludePublicKeys(set)
+	if len(keys.Keys) == 0 {
+		return nil, errors.New("key not found")
+	}
+
+	return First(keys.Keys), nil
+}
+
+func ExcludePublicKeys(set *jose.JSONWebKeySet) *jose.JSONWebKeySet {
+	keys := new(jose.JSONWebKeySet)
+
+	for _, k := range set.Keys {
+		_, ecdsaOk := k.Key.(*ecdsa.PublicKey)
+		_, ed25519OK := k.Key.(ed25519.PublicKey)
+		_, rsaOK := k.Key.(*rsa.PublicKey)
+
+		if !ecdsaOk && !ed25519OK && !rsaOK {
+			keys.Keys = append(keys.Keys, k)
+		}
+	}
+	return keys
 }
 
 func ExcludePrivateKeys(set *jose.JSONWebKeySet) *jose.JSONWebKeySet {
@@ -143,22 +146,6 @@ func ExcludePrivateKeys(set *jose.JSONWebKeySet) *jose.JSONWebKeySet {
 		}
 	}
 	return keys
-}
-
-func FindKeysByPrefix(set *jose.JSONWebKeySet, prefix string) (*jose.JSONWebKeySet, error) {
-	keys := new(jose.JSONWebKeySet)
-
-	for _, k := range set.Keys {
-		if len(k.KeyID) >= len(prefix)+1 && k.KeyID[:len(prefix)+1] == prefix+":" {
-			keys.Keys = append(keys.Keys, k)
-		}
-	}
-
-	if len(keys.Keys) == 0 {
-		return nil, errors.Errorf("Unable to find key with prefix %s in JSON Web Key Set", prefix)
-	}
-
-	return keys, nil
 }
 
 func PEMBlockForKey(key interface{}) (*pem.Block, error) {

--- a/jwk/jwt_strategy.go
+++ b/jwk/jwt_strategy.go
@@ -114,12 +114,12 @@ func (j *RS256JWTStrategy) refresh(ctx context.Context) error {
 		return err
 	}
 
-	public, err := FindKeyByPrefix(keys, "public")
+	public, err := FindPublicKey(keys)
 	if err != nil {
 		return err
 	}
 
-	private, err := FindKeyByPrefix(keys, "private")
+	private, err := FindPrivateKey(keys)
 	if err != nil {
 		return err
 	}

--- a/oauth2/handler_test.go
+++ b/oauth2/handler_test.go
@@ -370,7 +370,7 @@ func TestUserinfo(t *testing.T) {
 					keys, err := reg.KeyManager().GetKeySet(context.Background(), x.OpenIDConnectKeyName)
 					require.NoError(t, err)
 					t.Logf("%+v", keys)
-					key, err := jwk.FindKeyByPrefix(keys, "public")
+					key, err := jwk.FindPublicKey(keys)
 					return jwk.MustRSAPublic(key), nil
 				})
 				require.NoError(t, err)


### PR DESCRIPTION
Drop FindKeyByPrefix/FindKeysByPrefix methods for finding keys by public/private prefix and use FindPublicKey/FindPrivateKey helper methods instead.

## Related issue(s)

This feature is continuation of [#2758](https://github.com/ory/hydra/pull/2758)

It is also related to [#2625](https://github.com/ory/hydra/pull/2625) where it would be easer to review it, if suggest this change separately. In short to find keypairs from HSM we use attribute CKA_LABEL as key set id and CKA_ID as key id and they have to be 1:1 for pub/priv keys: https://github.com/ThalesIgnite/crypto11/blob/master/keys.go#L247-L278

This simplifies [hsm key manager logic](https://github.com/aarmam/hydra/blob/feature/hsm/hsm/manager_hsm.go#L293-L311) where I would otherwise have to prefix private/public keys to make it compatible with current hydra logic. 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
