### PR TITLE
fix: patch should not reset client secret

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -199,7 +199,7 @@ func (h *Handler) Patch(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 	}
 
 	// fix for #2869
-	// GetConcreteClient returns a client with the hashed secret, however updateClient expects 
+	// GetConcreteClient returns a client with the hashed secret, however updateClient expects
 	// an empty secret if the secret hasn't changed. As such we need to check if the patch has
 	// updated the secret or not
 	if oldSecret == c.Secret {

--- a/client/handler.go
+++ b/client/handler.go
@@ -191,9 +191,19 @@ func (h *Handler) Patch(w http.ResponseWriter, r *http.Request, ps httprouter.Pa
 		return
 	}
 
+	oldSecret := c.Secret
+
 	if err := x.ApplyJSONPatch(patchJSON, c, "/id"); err != nil {
 		h.r.Writer().WriteError(w, r, err)
 		return
+	}
+
+	// fix for #2869
+	// GetConcreteClient returns a client with the hashed secret, however updateClient expects 
+	// an empty secret if the secret hasn't changed. As such we need to check if the patch has
+	// updated the secret or not
+	if oldSecret == c.Secret {
+		c.Secret = ""
 	}
 
 	if err := h.updateClient(r.Context(), c); err != nil {


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Fixes the bug reported in #2869 by checking if the PATCH actually changes the Client Secret before updating. If the secret has not changed, we clear it as expected by the `UpdateClient` function, so the original secret remains untouched.

## Related issue(s)

#2869 
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
