### PR TITLE
fix: version info nil on version api endpoint

### DIFF
--- a/driver/registry.go
+++ b/driver/registry.go
@@ -32,6 +32,7 @@ type Registry interface {
 
 	Init(ctx context.Context) error
 
+	WithBuildInfo(v, h, d string) Registry
 	WithConfig(c *config.Provider) Registry
 	WithLogger(l *logrusx.Logger) Registry
 
@@ -70,7 +71,7 @@ func NewRegistryFromDSN(ctx context.Context, c *config.Provider, l *logrusx.Logg
 		return nil, errors.Errorf("driver of type %T does not implement interface Registry", driver)
 	}
 
-	registry = registry.WithLogger(l).WithConfig(c)
+	registry = registry.WithLogger(l).WithConfig(c).WithBuildInfo(config.Version, config.Commit, config.Date)
 
 	if err := registry.Init(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
This fix resolves #2337 and ensures the proper version number is included on the `/version` api endpoint. As per the discussion in the issue, it sources this data from `driver\config\buildinfo.go` and shows "master" when run locally / in docker.

## Related issue(s)

#2337 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [-] I have added tests that prove my fix is effective or that my feature
      works.
- [-] I have added or changed [the documentation](docs/docs).

## Further Comments
I didn't add a test because I didn't see testing of the `/health` or `/version` endpoints outside of `tls_termination_test.go` but that doesn't seem like a logical place to put a simple payload validation test. Can certainly add one if an approach is recommended. No documentation changes as this is a bugfix and doesn't alter expected behaviors or processes.
