### PR TITLE
feat: TLS certs auto-reload

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -300,7 +300,7 @@ func serve(
 	handler http.Handler,
 	address string,
 	permission *configx.UnixPermission,
-	cert []tls.Certificate,
+	getCert func(*tls.ClientHelloInfo) (*tls.Certificate, error),
 ) {
 	defer wg.Done()
 
@@ -308,7 +308,7 @@ func serve(
 		Handler: handler,
 		// #nosec G402 - This is a false positive because we use graceful.WithDefaults which sets the correct TLS settings.
 		TLSConfig: &tls.Config{
-			Certificates: cert,
+			GetCertificate: getCert,
 		},
 	})
 

--- a/driver/config/tls.go
+++ b/driver/config/tls.go
@@ -24,7 +24,7 @@ const (
 type TLSConfig interface {
 	Enabled() bool
 	AllowTerminationFrom() []string
-	Certificate() ([]tls.Certificate, error)
+	Certificate() ([]tls.Certificate, *CertLocation, error)
 }
 
 func (p *Provider) TLS(iface ServeInterface) TLSConfig {
@@ -65,8 +65,17 @@ func (c *tlsConfig) AllowTerminationFrom() []string {
 	return c.allowTerminationFrom
 }
 
-func (c *tlsConfig) Certificate() ([]tls.Certificate, error) {
-	return tlsx.Certificate(c.certString, c.keyString, c.certPath, c.keyPath)
+type CertLocation struct {
+	CertPath string
+	KeyPath  string
+}
+
+func (c *tlsConfig) Certificate() ([]tls.Certificate, *CertLocation, error) {
+	certs, err := tlsx.Certificate(c.certString, c.keyString, c.certPath, c.keyPath)
+	if c.certString != "" && c.keyString != "" {
+		return certs, nil, err
+	}
+	return certs, &CertLocation{CertPath: c.certPath, KeyPath: c.keyPath}, err
 }
 
 func (p *Provider) forcedHTTP() bool {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/ThalesIgnite/crypto11 v1.2.4
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/evanphx/json-patch v4.11.0+incompatible
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-openapi/errors v0.20.1
 	github.com/go-openapi/runtime v0.20.0


### PR DESCRIPTION
Kubernetes is able to auto-renew certificates with cert-manager and update files in the container. I would be cool if Ory Hydra could support auto certificate update on file change.

## Related issue(s)
#2568

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments
Adds dependencies to fsnotify to support Mac/Windows/Linux.

This is an example of a working PoC. I need feedback ;-)
