### PR TITLE
feat: add support for domain wide trust relationships

### DIFF
--- a/cypress/integration/oauth2/grant_jwtbearer.js
+++ b/cypress/integration/oauth2/grant_jwtbearer.js
@@ -79,7 +79,7 @@ describe('The OAuth 2.0 JWT Bearer (RFC 7523) Grant', function () {
   const gr = (subject, domain) => ({
     issuer: prng(),
     subject: subject,
-    domain: domain,
+    allowed_domain: domain,
     scope: ['foo', 'openid', 'offline_access'],
     jwk: testPublicJwk,
     expires_at: dayjs().utc().add(1, 'year').set('millisecond', 0).toISOString()

--- a/docs/docs/.static/api.json
+++ b/docs/docs/.static/api.json
@@ -3154,7 +3154,7 @@
     },
     "trustJwtGrantIssuerBody": {
       "type": "object",
-      "required": ["issuer", "subject", "scope", "jwk", "expires_at"],
+      "required": ["issuer", "scope", "jwk", "expires_at"],
       "properties": {
         "expires_at": {
           "description": "The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".",
@@ -3178,9 +3178,14 @@
           "example": ["openid", "offline"]
         },
         "subject": {
-          "description": "The \"subject\" identifies the principal that is the subject of the JWT.",
+          "description": "The \"subject\" identifies the principal that is the subject of the JWT. Either this or \"domain\" must be present.",
           "type": "string",
           "example": "mike@example.com"
+        },
+        "domain": {
+          "description": "The \"domain\" is used to allow any user under that domain as the subject of the JWT. Either this or \"subject\" must be present.",
+          "type": "string",
+          "example": "example.com"
         }
       }
     },

--- a/docs/docs/guides/oauth2-grant-type-jwt-bearer.mdx
+++ b/docs/docs/guides/oauth2-grant-type-jwt-bearer.mdx
@@ -48,8 +48,8 @@ Clients using this grant must be authenticated.
 ### Establishing a Trust Relationship
 
 Before using this grant type, you must establish a trust relationship in Ory
-Hydra. This involves registering the issuer, subject, and the public key at Ory
-Hydra's Admin Endpoint:
+Hydra. This involves registering the issuer, the public key and the subject or
+domain at Ory Hydra's Admin Endpoint:
 
 ```
 POST https://<admin.ory-hydra>/trust/grants/jwt-bearer/issuers
@@ -61,6 +61,9 @@ Content-Type: application/json
 
   // The "sub" field of the access token to be created.
   "subject": "alice@example.org",
+
+  //Or "domain" to allow authorising all users under that domain.
+  // "domain": "example.org",
 
   // The allowed scope of the generated access token.
   "scope": ["read"],

--- a/internal/httpclient/client/admin/accept_consent_request_parameters.go
+++ b/internal/httpclient/client/admin/accept_consent_request_parameters.go
@@ -18,58 +18,73 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewAcceptConsentRequestParams creates a new AcceptConsentRequestParams object
-// with the default values initialized.
+// NewAcceptConsentRequestParams creates a new AcceptConsentRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewAcceptConsentRequestParams() *AcceptConsentRequestParams {
-	var ()
 	return &AcceptConsentRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewAcceptConsentRequestParamsWithTimeout creates a new AcceptConsentRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewAcceptConsentRequestParamsWithTimeout(timeout time.Duration) *AcceptConsentRequestParams {
-	var ()
 	return &AcceptConsentRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewAcceptConsentRequestParamsWithContext creates a new AcceptConsentRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewAcceptConsentRequestParamsWithContext(ctx context.Context) *AcceptConsentRequestParams {
-	var ()
 	return &AcceptConsentRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewAcceptConsentRequestParamsWithHTTPClient creates a new AcceptConsentRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewAcceptConsentRequestParamsWithHTTPClient(client *http.Client) *AcceptConsentRequestParams {
-	var ()
 	return &AcceptConsentRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*AcceptConsentRequestParams contains all the parameters to send to the API endpoint
-for the accept consent request operation typically these are written to a http.Request
+/* AcceptConsentRequestParams contains all the parameters to send to the API endpoint
+   for the accept consent request operation.
+
+   Typically these are written to a http.Request.
 */
 type AcceptConsentRequestParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.AcceptConsentRequest
-	/*ConsentChallenge*/
+
+	// ConsentChallenge.
 	ConsentChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the accept consent request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *AcceptConsentRequestParams) WithDefaults() *AcceptConsentRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the accept consent request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *AcceptConsentRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the accept consent request params
@@ -134,7 +149,6 @@ func (o *AcceptConsentRequestParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err
@@ -145,6 +159,7 @@ func (o *AcceptConsentRequestParams) WriteToRequest(r runtime.ClientRequest, reg
 	qrConsentChallenge := o.ConsentChallenge
 	qConsentChallenge := qrConsentChallenge
 	if qConsentChallenge != "" {
+
 		if err := r.SetQueryParam("consent_challenge", qConsentChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/accept_consent_request_responses.go
+++ b/internal/httpclient/client/admin/accept_consent_request_responses.go
@@ -41,9 +41,8 @@ func (o *AcceptConsentRequestReader) ReadResponse(response runtime.ClientRespons
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewAcceptConsentRequestOK() *AcceptConsentRequestOK {
 	return &AcceptConsentRequestOK{}
 }
 
-/*AcceptConsentRequestOK handles this case with default header values.
+/* AcceptConsentRequestOK describes a response with status code 200, with default header values.
 
 completedRequest
 */
@@ -63,7 +62,6 @@ type AcceptConsentRequestOK struct {
 func (o *AcceptConsentRequestOK) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/consent/accept][%d] acceptConsentRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *AcceptConsentRequestOK) GetPayload() *models.CompletedRequest {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewAcceptConsentRequestNotFound() *AcceptConsentRequestNotFound {
 	return &AcceptConsentRequestNotFound{}
 }
 
-/*AcceptConsentRequestNotFound handles this case with default header values.
+/* AcceptConsentRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -96,7 +94,6 @@ type AcceptConsentRequestNotFound struct {
 func (o *AcceptConsentRequestNotFound) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/consent/accept][%d] acceptConsentRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *AcceptConsentRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewAcceptConsentRequestInternalServerError() *AcceptConsentRequestInternalS
 	return &AcceptConsentRequestInternalServerError{}
 }
 
-/*AcceptConsentRequestInternalServerError handles this case with default header values.
+/* AcceptConsentRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -129,7 +126,6 @@ type AcceptConsentRequestInternalServerError struct {
 func (o *AcceptConsentRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/consent/accept][%d] acceptConsentRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *AcceptConsentRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/accept_login_request_parameters.go
+++ b/internal/httpclient/client/admin/accept_login_request_parameters.go
@@ -18,58 +18,73 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewAcceptLoginRequestParams creates a new AcceptLoginRequestParams object
-// with the default values initialized.
+// NewAcceptLoginRequestParams creates a new AcceptLoginRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewAcceptLoginRequestParams() *AcceptLoginRequestParams {
-	var ()
 	return &AcceptLoginRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewAcceptLoginRequestParamsWithTimeout creates a new AcceptLoginRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewAcceptLoginRequestParamsWithTimeout(timeout time.Duration) *AcceptLoginRequestParams {
-	var ()
 	return &AcceptLoginRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewAcceptLoginRequestParamsWithContext creates a new AcceptLoginRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewAcceptLoginRequestParamsWithContext(ctx context.Context) *AcceptLoginRequestParams {
-	var ()
 	return &AcceptLoginRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewAcceptLoginRequestParamsWithHTTPClient creates a new AcceptLoginRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewAcceptLoginRequestParamsWithHTTPClient(client *http.Client) *AcceptLoginRequestParams {
-	var ()
 	return &AcceptLoginRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*AcceptLoginRequestParams contains all the parameters to send to the API endpoint
-for the accept login request operation typically these are written to a http.Request
+/* AcceptLoginRequestParams contains all the parameters to send to the API endpoint
+   for the accept login request operation.
+
+   Typically these are written to a http.Request.
 */
 type AcceptLoginRequestParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.AcceptLoginRequest
-	/*LoginChallenge*/
+
+	// LoginChallenge.
 	LoginChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the accept login request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *AcceptLoginRequestParams) WithDefaults() *AcceptLoginRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the accept login request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *AcceptLoginRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the accept login request params
@@ -134,7 +149,6 @@ func (o *AcceptLoginRequestParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err
@@ -145,6 +159,7 @@ func (o *AcceptLoginRequestParams) WriteToRequest(r runtime.ClientRequest, reg s
 	qrLoginChallenge := o.LoginChallenge
 	qLoginChallenge := qrLoginChallenge
 	if qLoginChallenge != "" {
+
 		if err := r.SetQueryParam("login_challenge", qLoginChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/accept_login_request_responses.go
+++ b/internal/httpclient/client/admin/accept_login_request_responses.go
@@ -53,9 +53,8 @@ func (o *AcceptLoginRequestReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -64,7 +63,7 @@ func NewAcceptLoginRequestOK() *AcceptLoginRequestOK {
 	return &AcceptLoginRequestOK{}
 }
 
-/*AcceptLoginRequestOK handles this case with default header values.
+/* AcceptLoginRequestOK describes a response with status code 200, with default header values.
 
 completedRequest
 */
@@ -75,7 +74,6 @@ type AcceptLoginRequestOK struct {
 func (o *AcceptLoginRequestOK) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/accept][%d] acceptLoginRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *AcceptLoginRequestOK) GetPayload() *models.CompletedRequest {
 	return o.Payload
 }
@@ -97,7 +95,7 @@ func NewAcceptLoginRequestBadRequest() *AcceptLoginRequestBadRequest {
 	return &AcceptLoginRequestBadRequest{}
 }
 
-/*AcceptLoginRequestBadRequest handles this case with default header values.
+/* AcceptLoginRequestBadRequest describes a response with status code 400, with default header values.
 
 jsonError
 */
@@ -108,7 +106,6 @@ type AcceptLoginRequestBadRequest struct {
 func (o *AcceptLoginRequestBadRequest) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/accept][%d] acceptLoginRequestBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *AcceptLoginRequestBadRequest) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -130,7 +127,7 @@ func NewAcceptLoginRequestUnauthorized() *AcceptLoginRequestUnauthorized {
 	return &AcceptLoginRequestUnauthorized{}
 }
 
-/*AcceptLoginRequestUnauthorized handles this case with default header values.
+/* AcceptLoginRequestUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -141,7 +138,6 @@ type AcceptLoginRequestUnauthorized struct {
 func (o *AcceptLoginRequestUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/accept][%d] acceptLoginRequestUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *AcceptLoginRequestUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -163,7 +159,7 @@ func NewAcceptLoginRequestNotFound() *AcceptLoginRequestNotFound {
 	return &AcceptLoginRequestNotFound{}
 }
 
-/*AcceptLoginRequestNotFound handles this case with default header values.
+/* AcceptLoginRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -174,7 +170,6 @@ type AcceptLoginRequestNotFound struct {
 func (o *AcceptLoginRequestNotFound) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/accept][%d] acceptLoginRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *AcceptLoginRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -196,7 +191,7 @@ func NewAcceptLoginRequestInternalServerError() *AcceptLoginRequestInternalServe
 	return &AcceptLoginRequestInternalServerError{}
 }
 
-/*AcceptLoginRequestInternalServerError handles this case with default header values.
+/* AcceptLoginRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -207,7 +202,6 @@ type AcceptLoginRequestInternalServerError struct {
 func (o *AcceptLoginRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/accept][%d] acceptLoginRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *AcceptLoginRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/accept_logout_request_parameters.go
+++ b/internal/httpclient/client/admin/accept_logout_request_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewAcceptLogoutRequestParams creates a new AcceptLogoutRequestParams object
-// with the default values initialized.
+// NewAcceptLogoutRequestParams creates a new AcceptLogoutRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewAcceptLogoutRequestParams() *AcceptLogoutRequestParams {
-	var ()
 	return &AcceptLogoutRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewAcceptLogoutRequestParamsWithTimeout creates a new AcceptLogoutRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewAcceptLogoutRequestParamsWithTimeout(timeout time.Duration) *AcceptLogoutRequestParams {
-	var ()
 	return &AcceptLogoutRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewAcceptLogoutRequestParamsWithContext creates a new AcceptLogoutRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewAcceptLogoutRequestParamsWithContext(ctx context.Context) *AcceptLogoutRequestParams {
-	var ()
 	return &AcceptLogoutRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewAcceptLogoutRequestParamsWithHTTPClient creates a new AcceptLogoutRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewAcceptLogoutRequestParamsWithHTTPClient(client *http.Client) *AcceptLogoutRequestParams {
-	var ()
 	return &AcceptLogoutRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*AcceptLogoutRequestParams contains all the parameters to send to the API endpoint
-for the accept logout request operation typically these are written to a http.Request
+/* AcceptLogoutRequestParams contains all the parameters to send to the API endpoint
+   for the accept logout request operation.
+
+   Typically these are written to a http.Request.
 */
 type AcceptLogoutRequestParams struct {
 
-	/*LogoutChallenge*/
+	// LogoutChallenge.
 	LogoutChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the accept logout request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *AcceptLogoutRequestParams) WithDefaults() *AcceptLogoutRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the accept logout request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *AcceptLogoutRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the accept logout request params
@@ -124,6 +138,7 @@ func (o *AcceptLogoutRequestParams) WriteToRequest(r runtime.ClientRequest, reg 
 	qrLogoutChallenge := o.LogoutChallenge
 	qLogoutChallenge := qrLogoutChallenge
 	if qLogoutChallenge != "" {
+
 		if err := r.SetQueryParam("logout_challenge", qLogoutChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/accept_logout_request_responses.go
+++ b/internal/httpclient/client/admin/accept_logout_request_responses.go
@@ -41,9 +41,8 @@ func (o *AcceptLogoutRequestReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewAcceptLogoutRequestOK() *AcceptLogoutRequestOK {
 	return &AcceptLogoutRequestOK{}
 }
 
-/*AcceptLogoutRequestOK handles this case with default header values.
+/* AcceptLogoutRequestOK describes a response with status code 200, with default header values.
 
 completedRequest
 */
@@ -63,7 +62,6 @@ type AcceptLogoutRequestOK struct {
 func (o *AcceptLogoutRequestOK) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/logout/accept][%d] acceptLogoutRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *AcceptLogoutRequestOK) GetPayload() *models.CompletedRequest {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewAcceptLogoutRequestNotFound() *AcceptLogoutRequestNotFound {
 	return &AcceptLogoutRequestNotFound{}
 }
 
-/*AcceptLogoutRequestNotFound handles this case with default header values.
+/* AcceptLogoutRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -96,7 +94,6 @@ type AcceptLogoutRequestNotFound struct {
 func (o *AcceptLogoutRequestNotFound) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/logout/accept][%d] acceptLogoutRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *AcceptLogoutRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewAcceptLogoutRequestInternalServerError() *AcceptLogoutRequestInternalSer
 	return &AcceptLogoutRequestInternalServerError{}
 }
 
-/*AcceptLogoutRequestInternalServerError handles this case with default header values.
+/* AcceptLogoutRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -129,7 +126,6 @@ type AcceptLogoutRequestInternalServerError struct {
 func (o *AcceptLogoutRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/logout/accept][%d] acceptLogoutRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *AcceptLogoutRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/admin_client.go
+++ b/internal/httpclient/client/admin/admin_client.go
@@ -25,75 +25,78 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	AcceptConsentRequest(params *AcceptConsentRequestParams) (*AcceptConsentRequestOK, error)
+	AcceptConsentRequest(params *AcceptConsentRequestParams, opts ...ClientOption) (*AcceptConsentRequestOK, error)
 
-	AcceptLoginRequest(params *AcceptLoginRequestParams) (*AcceptLoginRequestOK, error)
+	AcceptLoginRequest(params *AcceptLoginRequestParams, opts ...ClientOption) (*AcceptLoginRequestOK, error)
 
-	AcceptLogoutRequest(params *AcceptLogoutRequestParams) (*AcceptLogoutRequestOK, error)
+	AcceptLogoutRequest(params *AcceptLogoutRequestParams, opts ...ClientOption) (*AcceptLogoutRequestOK, error)
 
-	CreateJSONWebKeySet(params *CreateJSONWebKeySetParams) (*CreateJSONWebKeySetCreated, error)
+	CreateJSONWebKeySet(params *CreateJSONWebKeySetParams, opts ...ClientOption) (*CreateJSONWebKeySetCreated, error)
 
-	CreateOAuth2Client(params *CreateOAuth2ClientParams) (*CreateOAuth2ClientCreated, error)
+	CreateOAuth2Client(params *CreateOAuth2ClientParams, opts ...ClientOption) (*CreateOAuth2ClientCreated, error)
 
-	DeleteJSONWebKey(params *DeleteJSONWebKeyParams) (*DeleteJSONWebKeyNoContent, error)
+	DeleteJSONWebKey(params *DeleteJSONWebKeyParams, opts ...ClientOption) (*DeleteJSONWebKeyNoContent, error)
 
-	DeleteJSONWebKeySet(params *DeleteJSONWebKeySetParams) (*DeleteJSONWebKeySetNoContent, error)
+	DeleteJSONWebKeySet(params *DeleteJSONWebKeySetParams, opts ...ClientOption) (*DeleteJSONWebKeySetNoContent, error)
 
-	DeleteOAuth2Client(params *DeleteOAuth2ClientParams) (*DeleteOAuth2ClientNoContent, error)
+	DeleteOAuth2Client(params *DeleteOAuth2ClientParams, opts ...ClientOption) (*DeleteOAuth2ClientNoContent, error)
 
-	DeleteOAuth2Token(params *DeleteOAuth2TokenParams) (*DeleteOAuth2TokenNoContent, error)
+	DeleteOAuth2Token(params *DeleteOAuth2TokenParams, opts ...ClientOption) (*DeleteOAuth2TokenNoContent, error)
 
-	DeleteTrustedJwtGrantIssuer(params *DeleteTrustedJwtGrantIssuerParams) (*DeleteTrustedJwtGrantIssuerNoContent, error)
+	DeleteTrustedJwtGrantIssuer(params *DeleteTrustedJwtGrantIssuerParams, opts ...ClientOption) (*DeleteTrustedJwtGrantIssuerNoContent, error)
 
-	FlushInactiveOAuth2Tokens(params *FlushInactiveOAuth2TokensParams) (*FlushInactiveOAuth2TokensNoContent, error)
+	FlushInactiveOAuth2Tokens(params *FlushInactiveOAuth2TokensParams, opts ...ClientOption) (*FlushInactiveOAuth2TokensNoContent, error)
 
-	GetConsentRequest(params *GetConsentRequestParams) (*GetConsentRequestOK, error)
+	GetConsentRequest(params *GetConsentRequestParams, opts ...ClientOption) (*GetConsentRequestOK, error)
 
-	GetJSONWebKey(params *GetJSONWebKeyParams) (*GetJSONWebKeyOK, error)
+	GetJSONWebKey(params *GetJSONWebKeyParams, opts ...ClientOption) (*GetJSONWebKeyOK, error)
 
-	GetJSONWebKeySet(params *GetJSONWebKeySetParams) (*GetJSONWebKeySetOK, error)
+	GetJSONWebKeySet(params *GetJSONWebKeySetParams, opts ...ClientOption) (*GetJSONWebKeySetOK, error)
 
-	GetLoginRequest(params *GetLoginRequestParams) (*GetLoginRequestOK, error)
+	GetLoginRequest(params *GetLoginRequestParams, opts ...ClientOption) (*GetLoginRequestOK, error)
 
-	GetLogoutRequest(params *GetLogoutRequestParams) (*GetLogoutRequestOK, error)
+	GetLogoutRequest(params *GetLogoutRequestParams, opts ...ClientOption) (*GetLogoutRequestOK, error)
 
-	GetOAuth2Client(params *GetOAuth2ClientParams) (*GetOAuth2ClientOK, error)
+	GetOAuth2Client(params *GetOAuth2ClientParams, opts ...ClientOption) (*GetOAuth2ClientOK, error)
 
-	GetTrustedJwtGrantIssuer(params *GetTrustedJwtGrantIssuerParams) (*GetTrustedJwtGrantIssuerOK, error)
+	GetTrustedJwtGrantIssuer(params *GetTrustedJwtGrantIssuerParams, opts ...ClientOption) (*GetTrustedJwtGrantIssuerOK, error)
 
-	GetVersion(params *GetVersionParams) (*GetVersionOK, error)
+	GetVersion(params *GetVersionParams, opts ...ClientOption) (*GetVersionOK, error)
 
-	IntrospectOAuth2Token(params *IntrospectOAuth2TokenParams) (*IntrospectOAuth2TokenOK, error)
+	IntrospectOAuth2Token(params *IntrospectOAuth2TokenParams, opts ...ClientOption) (*IntrospectOAuth2TokenOK, error)
 
-	IsInstanceAlive(params *IsInstanceAliveParams) (*IsInstanceAliveOK, error)
+	IsInstanceAlive(params *IsInstanceAliveParams, opts ...ClientOption) (*IsInstanceAliveOK, error)
 
-	ListOAuth2Clients(params *ListOAuth2ClientsParams) (*ListOAuth2ClientsOK, error)
+	ListOAuth2Clients(params *ListOAuth2ClientsParams, opts ...ClientOption) (*ListOAuth2ClientsOK, error)
 
-	ListSubjectConsentSessions(params *ListSubjectConsentSessionsParams) (*ListSubjectConsentSessionsOK, error)
+	ListSubjectConsentSessions(params *ListSubjectConsentSessionsParams, opts ...ClientOption) (*ListSubjectConsentSessionsOK, error)
 
-	ListTrustedJwtGrantIssuers(params *ListTrustedJwtGrantIssuersParams) (*ListTrustedJwtGrantIssuersOK, error)
+	ListTrustedJwtGrantIssuers(params *ListTrustedJwtGrantIssuersParams, opts ...ClientOption) (*ListTrustedJwtGrantIssuersOK, error)
 
-	PatchOAuth2Client(params *PatchOAuth2ClientParams) (*PatchOAuth2ClientOK, error)
+	PatchOAuth2Client(params *PatchOAuth2ClientParams, opts ...ClientOption) (*PatchOAuth2ClientOK, error)
 
-	RejectConsentRequest(params *RejectConsentRequestParams) (*RejectConsentRequestOK, error)
+	RejectConsentRequest(params *RejectConsentRequestParams, opts ...ClientOption) (*RejectConsentRequestOK, error)
 
-	RejectLoginRequest(params *RejectLoginRequestParams) (*RejectLoginRequestOK, error)
+	RejectLoginRequest(params *RejectLoginRequestParams, opts ...ClientOption) (*RejectLoginRequestOK, error)
 
-	RejectLogoutRequest(params *RejectLogoutRequestParams) (*RejectLogoutRequestNoContent, error)
+	RejectLogoutRequest(params *RejectLogoutRequestParams, opts ...ClientOption) (*RejectLogoutRequestNoContent, error)
 
-	RevokeAuthenticationSession(params *RevokeAuthenticationSessionParams) (*RevokeAuthenticationSessionNoContent, error)
+	RevokeAuthenticationSession(params *RevokeAuthenticationSessionParams, opts ...ClientOption) (*RevokeAuthenticationSessionNoContent, error)
 
-	RevokeConsentSessions(params *RevokeConsentSessionsParams) (*RevokeConsentSessionsNoContent, error)
+	RevokeConsentSessions(params *RevokeConsentSessionsParams, opts ...ClientOption) (*RevokeConsentSessionsNoContent, error)
 
-	TrustJwtGrantIssuer(params *TrustJwtGrantIssuerParams) (*TrustJwtGrantIssuerCreated, error)
+	TrustJwtGrantIssuer(params *TrustJwtGrantIssuerParams, opts ...ClientOption) (*TrustJwtGrantIssuerCreated, error)
 
-	UpdateJSONWebKey(params *UpdateJSONWebKeyParams) (*UpdateJSONWebKeyOK, error)
+	UpdateJSONWebKey(params *UpdateJSONWebKeyParams, opts ...ClientOption) (*UpdateJSONWebKeyOK, error)
 
-	UpdateJSONWebKeySet(params *UpdateJSONWebKeySetParams) (*UpdateJSONWebKeySetOK, error)
+	UpdateJSONWebKeySet(params *UpdateJSONWebKeySetParams, opts ...ClientOption) (*UpdateJSONWebKeySetOK, error)
 
-	UpdateOAuth2Client(params *UpdateOAuth2ClientParams) (*UpdateOAuth2ClientOK, error)
+	UpdateOAuth2Client(params *UpdateOAuth2ClientParams, opts ...ClientOption) (*UpdateOAuth2ClientOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -118,13 +121,12 @@ consent request should be used as basis for future requests.
 
 The response contains a redirect URL which the consent provider should redirect the user-agent to.
 */
-func (a *Client) AcceptConsentRequest(params *AcceptConsentRequestParams) (*AcceptConsentRequestOK, error) {
+func (a *Client) AcceptConsentRequest(params *AcceptConsentRequestParams, opts ...ClientOption) (*AcceptConsentRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAcceptConsentRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "acceptConsentRequest",
 		Method:             "PUT",
 		PathPattern:        "/oauth2/auth/requests/consent/accept",
@@ -135,7 +137,12 @@ func (a *Client) AcceptConsentRequest(params *AcceptConsentRequestParams) (*Acce
 		Reader:             &AcceptConsentRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -166,13 +173,12 @@ a cookie.
 
 The response contains a redirect URL which the login provider should redirect the user-agent to.
 */
-func (a *Client) AcceptLoginRequest(params *AcceptLoginRequestParams) (*AcceptLoginRequestOK, error) {
+func (a *Client) AcceptLoginRequest(params *AcceptLoginRequestParams, opts ...ClientOption) (*AcceptLoginRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAcceptLoginRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "acceptLoginRequest",
 		Method:             "PUT",
 		PathPattern:        "/oauth2/auth/requests/login/accept",
@@ -183,7 +189,12 @@ func (a *Client) AcceptLoginRequest(params *AcceptLoginRequestParams) (*AcceptLo
 		Reader:             &AcceptLoginRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -205,13 +216,12 @@ No body is required.
 
 The response contains a redirect URL which the consent provider should redirect the user-agent to.
 */
-func (a *Client) AcceptLogoutRequest(params *AcceptLogoutRequestParams) (*AcceptLogoutRequestOK, error) {
+func (a *Client) AcceptLogoutRequest(params *AcceptLogoutRequestParams, opts ...ClientOption) (*AcceptLogoutRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewAcceptLogoutRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "acceptLogoutRequest",
 		Method:             "PUT",
 		PathPattern:        "/oauth2/auth/requests/logout/accept",
@@ -222,7 +232,12 @@ func (a *Client) AcceptLogoutRequest(params *AcceptLogoutRequestParams) (*Accept
 		Reader:             &AcceptLogoutRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -243,13 +258,12 @@ func (a *Client) AcceptLogoutRequest(params *AcceptLogoutRequestParams) (*Accept
 
 A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 */
-func (a *Client) CreateJSONWebKeySet(params *CreateJSONWebKeySetParams) (*CreateJSONWebKeySetCreated, error) {
+func (a *Client) CreateJSONWebKeySet(params *CreateJSONWebKeySetParams, opts ...ClientOption) (*CreateJSONWebKeySetCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateJSONWebKeySetParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createJsonWebKeySet",
 		Method:             "POST",
 		PathPattern:        "/keys/{set}",
@@ -260,7 +274,12 @@ func (a *Client) CreateJSONWebKeySet(params *CreateJSONWebKeySetParams) (*Create
 		Reader:             &CreateJSONWebKeySetReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -284,13 +303,12 @@ Write the secret down and keep it somwhere safe.
 OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are
 generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 */
-func (a *Client) CreateOAuth2Client(params *CreateOAuth2ClientParams) (*CreateOAuth2ClientCreated, error) {
+func (a *Client) CreateOAuth2Client(params *CreateOAuth2ClientParams, opts ...ClientOption) (*CreateOAuth2ClientCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createOAuth2Client",
 		Method:             "POST",
 		PathPattern:        "/clients",
@@ -301,7 +319,12 @@ func (a *Client) CreateOAuth2Client(params *CreateOAuth2ClientParams) (*CreateOA
 		Reader:             &CreateOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -321,13 +344,12 @@ func (a *Client) CreateOAuth2Client(params *CreateOAuth2ClientParams) (*CreateOA
 
 A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 */
-func (a *Client) DeleteJSONWebKey(params *DeleteJSONWebKeyParams) (*DeleteJSONWebKeyNoContent, error) {
+func (a *Client) DeleteJSONWebKey(params *DeleteJSONWebKeyParams, opts ...ClientOption) (*DeleteJSONWebKeyNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteJSONWebKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteJsonWebKey",
 		Method:             "DELETE",
 		PathPattern:        "/keys/{set}/{kid}",
@@ -338,7 +360,12 @@ func (a *Client) DeleteJSONWebKey(params *DeleteJSONWebKeyParams) (*DeleteJSONWe
 		Reader:             &DeleteJSONWebKeyReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -359,13 +386,12 @@ func (a *Client) DeleteJSONWebKey(params *DeleteJSONWebKeyParams) (*DeleteJSONWe
 
 A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 */
-func (a *Client) DeleteJSONWebKeySet(params *DeleteJSONWebKeySetParams) (*DeleteJSONWebKeySetNoContent, error) {
+func (a *Client) DeleteJSONWebKeySet(params *DeleteJSONWebKeySetParams, opts ...ClientOption) (*DeleteJSONWebKeySetNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteJSONWebKeySetParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteJsonWebKeySet",
 		Method:             "DELETE",
 		PathPattern:        "/keys/{set}",
@@ -376,7 +402,12 @@ func (a *Client) DeleteJSONWebKeySet(params *DeleteJSONWebKeySetParams) (*Delete
 		Reader:             &DeleteJSONWebKeySetReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -400,13 +431,12 @@ generated for applications which want to consume your OAuth 2.0 or OpenID Connec
 
 Make sure that this endpoint is well protected and only callable by first-party components.
 */
-func (a *Client) DeleteOAuth2Client(params *DeleteOAuth2ClientParams) (*DeleteOAuth2ClientNoContent, error) {
+func (a *Client) DeleteOAuth2Client(params *DeleteOAuth2ClientParams, opts ...ClientOption) (*DeleteOAuth2ClientNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteOAuth2Client",
 		Method:             "DELETE",
 		PathPattern:        "/clients/{id}",
@@ -417,7 +447,12 @@ func (a *Client) DeleteOAuth2Client(params *DeleteOAuth2ClientParams) (*DeleteOA
 		Reader:             &DeleteOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -435,13 +470,12 @@ func (a *Client) DeleteOAuth2Client(params *DeleteOAuth2ClientParams) (*DeleteOA
 
   This endpoint deletes OAuth2 access tokens issued for a client from the database
 */
-func (a *Client) DeleteOAuth2Token(params *DeleteOAuth2TokenParams) (*DeleteOAuth2TokenNoContent, error) {
+func (a *Client) DeleteOAuth2Token(params *DeleteOAuth2TokenParams, opts ...ClientOption) (*DeleteOAuth2TokenNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteOAuth2TokenParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteOAuth2Token",
 		Method:             "DELETE",
 		PathPattern:        "/oauth2/tokens",
@@ -452,7 +486,12 @@ func (a *Client) DeleteOAuth2Token(params *DeleteOAuth2TokenParams) (*DeleteOAut
 		Reader:             &DeleteOAuth2TokenReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -475,13 +514,12 @@ created the trust relationship.
 Once deleted, the associated issuer will no longer be able to perform the JSON Web Token (JWT) Profile
 for OAuth 2.0 Client Authentication and Authorization Grant.
 */
-func (a *Client) DeleteTrustedJwtGrantIssuer(params *DeleteTrustedJwtGrantIssuerParams) (*DeleteTrustedJwtGrantIssuerNoContent, error) {
+func (a *Client) DeleteTrustedJwtGrantIssuer(params *DeleteTrustedJwtGrantIssuerParams, opts ...ClientOption) (*DeleteTrustedJwtGrantIssuerNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteTrustedJwtGrantIssuerParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "deleteTrustedJwtGrantIssuer",
 		Method:             "DELETE",
 		PathPattern:        "/trust/grants/jwt-bearer/issuers/{id}",
@@ -492,7 +530,12 @@ func (a *Client) DeleteTrustedJwtGrantIssuer(params *DeleteTrustedJwtGrantIssuer
 		Reader:             &DeleteTrustedJwtGrantIssuerReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -513,13 +556,12 @@ func (a *Client) DeleteTrustedJwtGrantIssuer(params *DeleteTrustedJwtGrantIssuer
 not be touched, in case you want to keep recent tokens for auditing. Refresh tokens can not be flushed as they are deleted
 automatically when performing the refresh flow.
 */
-func (a *Client) FlushInactiveOAuth2Tokens(params *FlushInactiveOAuth2TokensParams) (*FlushInactiveOAuth2TokensNoContent, error) {
+func (a *Client) FlushInactiveOAuth2Tokens(params *FlushInactiveOAuth2TokensParams, opts ...ClientOption) (*FlushInactiveOAuth2TokensNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewFlushInactiveOAuth2TokensParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "flushInactiveOAuth2Tokens",
 		Method:             "POST",
 		PathPattern:        "/oauth2/flush",
@@ -530,7 +572,12 @@ func (a *Client) FlushInactiveOAuth2Tokens(params *FlushInactiveOAuth2TokensPara
 		Reader:             &FlushInactiveOAuth2TokensReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -558,13 +605,12 @@ The consent challenge is appended to the consent provider's URL to which the sub
 provider uses that challenge to fetch information on the OAuth2 request and then tells ORY Hydra if the subject accepted
 or rejected the request.
 */
-func (a *Client) GetConsentRequest(params *GetConsentRequestParams) (*GetConsentRequestOK, error) {
+func (a *Client) GetConsentRequest(params *GetConsentRequestParams, opts ...ClientOption) (*GetConsentRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetConsentRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getConsentRequest",
 		Method:             "GET",
 		PathPattern:        "/oauth2/auth/requests/consent",
@@ -575,7 +621,12 @@ func (a *Client) GetConsentRequest(params *GetConsentRequestParams) (*GetConsent
 		Reader:             &GetConsentRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -594,13 +645,12 @@ func (a *Client) GetConsentRequest(params *GetConsentRequestParams) (*GetConsent
 
   This endpoint returns a singular JSON Web Key, identified by the set and the specific key ID (kid).
 */
-func (a *Client) GetJSONWebKey(params *GetJSONWebKeyParams) (*GetJSONWebKeyOK, error) {
+func (a *Client) GetJSONWebKey(params *GetJSONWebKeyParams, opts ...ClientOption) (*GetJSONWebKeyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetJSONWebKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getJsonWebKey",
 		Method:             "GET",
 		PathPattern:        "/keys/{set}/{kid}",
@@ -611,7 +661,12 @@ func (a *Client) GetJSONWebKey(params *GetJSONWebKeyParams) (*GetJSONWebKeyOK, e
 		Reader:             &GetJSONWebKeyReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -632,13 +687,12 @@ func (a *Client) GetJSONWebKey(params *GetJSONWebKeyParams) (*GetJSONWebKeyOK, e
 
 A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 */
-func (a *Client) GetJSONWebKeySet(params *GetJSONWebKeySetParams) (*GetJSONWebKeySetOK, error) {
+func (a *Client) GetJSONWebKeySet(params *GetJSONWebKeySetParams, opts ...ClientOption) (*GetJSONWebKeySetOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetJSONWebKeySetParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getJsonWebKeySet",
 		Method:             "GET",
 		PathPattern:        "/keys/{set}",
@@ -649,7 +703,12 @@ func (a *Client) GetJSONWebKeySet(params *GetJSONWebKeySetParams) (*GetJSONWebKe
 		Reader:             &GetJSONWebKeySetReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -674,13 +733,12 @@ a subject (in OAuth2 the proper name for subject is "resource owner").
 The authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login
 provider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.
 */
-func (a *Client) GetLoginRequest(params *GetLoginRequestParams) (*GetLoginRequestOK, error) {
+func (a *Client) GetLoginRequest(params *GetLoginRequestParams, opts ...ClientOption) (*GetLoginRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLoginRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLoginRequest",
 		Method:             "GET",
 		PathPattern:        "/oauth2/auth/requests/login",
@@ -691,7 +749,12 @@ func (a *Client) GetLoginRequest(params *GetLoginRequestParams) (*GetLoginReques
 		Reader:             &GetLoginRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -710,13 +773,12 @@ func (a *Client) GetLoginRequest(params *GetLoginRequestParams) (*GetLoginReques
 
   Use this endpoint to fetch a logout request.
 */
-func (a *Client) GetLogoutRequest(params *GetLogoutRequestParams) (*GetLogoutRequestOK, error) {
+func (a *Client) GetLogoutRequest(params *GetLogoutRequestParams, opts ...ClientOption) (*GetLogoutRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLogoutRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLogoutRequest",
 		Method:             "GET",
 		PathPattern:        "/oauth2/auth/requests/logout",
@@ -727,7 +789,12 @@ func (a *Client) GetLogoutRequest(params *GetLogoutRequestParams) (*GetLogoutReq
 		Reader:             &GetLogoutRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -749,13 +816,12 @@ func (a *Client) GetLogoutRequest(params *GetLogoutRequestParams) (*GetLogoutReq
 OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are
 generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 */
-func (a *Client) GetOAuth2Client(params *GetOAuth2ClientParams) (*GetOAuth2ClientOK, error) {
+func (a *Client) GetOAuth2Client(params *GetOAuth2ClientParams, opts ...ClientOption) (*GetOAuth2ClientOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getOAuth2Client",
 		Method:             "GET",
 		PathPattern:        "/clients/{id}",
@@ -766,7 +832,12 @@ func (a *Client) GetOAuth2Client(params *GetOAuth2ClientParams) (*GetOAuth2Clien
 		Reader:             &GetOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -785,13 +856,12 @@ func (a *Client) GetOAuth2Client(params *GetOAuth2ClientParams) (*GetOAuth2Clien
   Use this endpoint to get a trusted JWT Bearer Grant Type Issuer. The ID is the one returned when you
 created the trust relationship.
 */
-func (a *Client) GetTrustedJwtGrantIssuer(params *GetTrustedJwtGrantIssuerParams) (*GetTrustedJwtGrantIssuerOK, error) {
+func (a *Client) GetTrustedJwtGrantIssuer(params *GetTrustedJwtGrantIssuerParams, opts ...ClientOption) (*GetTrustedJwtGrantIssuerOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetTrustedJwtGrantIssuerParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getTrustedJwtGrantIssuer",
 		Method:             "GET",
 		PathPattern:        "/trust/grants/jwt-bearer/issuers/{id}",
@@ -802,7 +872,12 @@ func (a *Client) GetTrustedJwtGrantIssuer(params *GetTrustedJwtGrantIssuerParams
 		Reader:             &GetTrustedJwtGrantIssuerReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -824,13 +899,12 @@ func (a *Client) GetTrustedJwtGrantIssuer(params *GetTrustedJwtGrantIssuerParams
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 */
-func (a *Client) GetVersion(params *GetVersionParams) (*GetVersionOK, error) {
+func (a *Client) GetVersion(params *GetVersionParams, opts ...ClientOption) (*GetVersionOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetVersionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getVersion",
 		Method:             "GET",
 		PathPattern:        "/version",
@@ -841,7 +915,12 @@ func (a *Client) GetVersion(params *GetVersionParams) (*GetVersionOK, error) {
 		Reader:             &GetVersionReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -864,13 +943,12 @@ set additional data for a token by setting `accessTokenExtra` during the consent
 
 For more information [read this blog post](https://www.oauth.com/oauth2-servers/token-introspection-endpoint/).
 */
-func (a *Client) IntrospectOAuth2Token(params *IntrospectOAuth2TokenParams) (*IntrospectOAuth2TokenOK, error) {
+func (a *Client) IntrospectOAuth2Token(params *IntrospectOAuth2TokenParams, opts ...ClientOption) (*IntrospectOAuth2TokenOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewIntrospectOAuth2TokenParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "introspectOAuth2Token",
 		Method:             "POST",
 		PathPattern:        "/oauth2/introspect",
@@ -881,7 +959,12 @@ func (a *Client) IntrospectOAuth2Token(params *IntrospectOAuth2TokenParams) (*In
 		Reader:             &IntrospectOAuth2TokenReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -907,13 +990,12 @@ If the service supports TLS Edge Termination, this endpoint does not require the
 Be aware that if you are running multiple nodes of this service, the health status will never
 refer to the cluster state, only to a single instance.
 */
-func (a *Client) IsInstanceAlive(params *IsInstanceAliveParams) (*IsInstanceAliveOK, error) {
+func (a *Client) IsInstanceAlive(params *IsInstanceAliveParams, opts ...ClientOption) (*IsInstanceAliveOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewIsInstanceAliveParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "isInstanceAlive",
 		Method:             "GET",
 		PathPattern:        "/health/alive",
@@ -924,7 +1006,12 @@ func (a *Client) IsInstanceAlive(params *IsInstanceAliveParams) (*IsInstanceAliv
 		Reader:             &IsInstanceAliveReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -951,13 +1038,12 @@ generated for applications which want to consume your OAuth 2.0 or OpenID Connec
 The "Link" header is also included in successful responses, which contains one or more links for pagination, formatted like so: '<https://hydra-url/admin/clients?limit={limit}&offset={offset}>; rel="{page}"', where page is one of the following applicable pages: 'first', 'next', 'last', and 'previous'.
 Multiple links can be included in this header, and will be separated by a comma.
 */
-func (a *Client) ListOAuth2Clients(params *ListOAuth2ClientsParams) (*ListOAuth2ClientsOK, error) {
+func (a *Client) ListOAuth2Clients(params *ListOAuth2ClientsParams, opts ...ClientOption) (*ListOAuth2ClientsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListOAuth2ClientsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listOAuth2Clients",
 		Method:             "GET",
 		PathPattern:        "/clients",
@@ -968,7 +1054,12 @@ func (a *Client) ListOAuth2Clients(params *ListOAuth2ClientsParams) (*ListOAuth2
 		Reader:             &ListOAuth2ClientsReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -992,13 +1083,12 @@ empty JSON array with status code 200 OK.
 The "Link" header is also included in successful responses, which contains one or more links for pagination, formatted like so: '<https://hydra-url/admin/oauth2/auth/sessions/consent?subject={user}&limit={limit}&offset={offset}>; rel="{page}"', where page is one of the following applicable pages: 'first', 'next', 'last', and 'previous'.
 Multiple links can be included in this header, and will be separated by a comma.
 */
-func (a *Client) ListSubjectConsentSessions(params *ListSubjectConsentSessionsParams) (*ListSubjectConsentSessionsOK, error) {
+func (a *Client) ListSubjectConsentSessions(params *ListSubjectConsentSessionsParams, opts ...ClientOption) (*ListSubjectConsentSessionsOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListSubjectConsentSessionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listSubjectConsentSessions",
 		Method:             "GET",
 		PathPattern:        "/oauth2/auth/sessions/consent",
@@ -1009,7 +1099,12 @@ func (a *Client) ListSubjectConsentSessions(params *ListSubjectConsentSessionsPa
 		Reader:             &ListSubjectConsentSessionsReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1028,13 +1123,12 @@ func (a *Client) ListSubjectConsentSessions(params *ListSubjectConsentSessionsPa
 
   Use this endpoint to list all trusted JWT Bearer Grant Type Issuers.
 */
-func (a *Client) ListTrustedJwtGrantIssuers(params *ListTrustedJwtGrantIssuersParams) (*ListTrustedJwtGrantIssuersOK, error) {
+func (a *Client) ListTrustedJwtGrantIssuers(params *ListTrustedJwtGrantIssuersParams, opts ...ClientOption) (*ListTrustedJwtGrantIssuersOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewListTrustedJwtGrantIssuersParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "listTrustedJwtGrantIssuers",
 		Method:             "GET",
 		PathPattern:        "/trust/grants/jwt-bearer/issuers",
@@ -1045,7 +1139,12 @@ func (a *Client) ListTrustedJwtGrantIssuers(params *ListTrustedJwtGrantIssuersPa
 		Reader:             &ListTrustedJwtGrantIssuersReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,13 +1168,12 @@ only time you will be able to retrieve the client secret, so write it down and k
 OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are
 generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 */
-func (a *Client) PatchOAuth2Client(params *PatchOAuth2ClientParams) (*PatchOAuth2ClientOK, error) {
+func (a *Client) PatchOAuth2Client(params *PatchOAuth2ClientParams, opts ...ClientOption) (*PatchOAuth2ClientOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPatchOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "patchOAuth2Client",
 		Method:             "PATCH",
 		PathPattern:        "/clients/{id}",
@@ -1086,7 +1184,12 @@ func (a *Client) PatchOAuth2Client(params *PatchOAuth2ClientParams) (*PatchOAuth
 		Reader:             &PatchOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1118,13 +1221,12 @@ The consent provider must include a reason why the consent was not granted.
 
 The response contains a redirect URL which the consent provider should redirect the user-agent to.
 */
-func (a *Client) RejectConsentRequest(params *RejectConsentRequestParams) (*RejectConsentRequestOK, error) {
+func (a *Client) RejectConsentRequest(params *RejectConsentRequestParams, opts ...ClientOption) (*RejectConsentRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRejectConsentRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "rejectConsentRequest",
 		Method:             "PUT",
 		PathPattern:        "/oauth2/auth/requests/consent/reject",
@@ -1135,7 +1237,12 @@ func (a *Client) RejectConsentRequest(params *RejectConsentRequestParams) (*Reje
 		Reader:             &RejectConsentRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1165,13 +1272,12 @@ was be denied.
 
 The response contains a redirect URL which the login provider should redirect the user-agent to.
 */
-func (a *Client) RejectLoginRequest(params *RejectLoginRequestParams) (*RejectLoginRequestOK, error) {
+func (a *Client) RejectLoginRequest(params *RejectLoginRequestParams, opts ...ClientOption) (*RejectLoginRequestOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRejectLoginRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "rejectLoginRequest",
 		Method:             "PUT",
 		PathPattern:        "/oauth2/auth/requests/login/reject",
@@ -1182,7 +1288,12 @@ func (a *Client) RejectLoginRequest(params *RejectLoginRequestParams) (*RejectLo
 		Reader:             &RejectLoginRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1204,13 +1315,12 @@ No body is required.
 
 The response is empty as the logout provider has to chose what action to perform next.
 */
-func (a *Client) RejectLogoutRequest(params *RejectLogoutRequestParams) (*RejectLogoutRequestNoContent, error) {
+func (a *Client) RejectLogoutRequest(params *RejectLogoutRequestParams, opts ...ClientOption) (*RejectLogoutRequestNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRejectLogoutRequestParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "rejectLogoutRequest",
 		Method:             "PUT",
 		PathPattern:        "/oauth2/auth/requests/logout/reject",
@@ -1221,7 +1331,12 @@ func (a *Client) RejectLogoutRequest(params *RejectLogoutRequestParams) (*Reject
 		Reader:             &RejectLogoutRequestReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1242,13 +1357,12 @@ func (a *Client) RejectLogoutRequest(params *RejectLogoutRequestParams) (*Reject
 has to re-authenticate at ORY Hydra. This endpoint does not invalidate any tokens and does not work with OpenID Connect
 Front- or Back-channel logout.
 */
-func (a *Client) RevokeAuthenticationSession(params *RevokeAuthenticationSessionParams) (*RevokeAuthenticationSessionNoContent, error) {
+func (a *Client) RevokeAuthenticationSession(params *RevokeAuthenticationSessionParams, opts ...ClientOption) (*RevokeAuthenticationSessionNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRevokeAuthenticationSessionParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "revokeAuthenticationSession",
 		Method:             "DELETE",
 		PathPattern:        "/oauth2/auth/sessions/login",
@@ -1259,7 +1373,12 @@ func (a *Client) RevokeAuthenticationSession(params *RevokeAuthenticationSession
 		Reader:             &RevokeAuthenticationSessionReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1279,13 +1398,12 @@ func (a *Client) RevokeAuthenticationSession(params *RevokeAuthenticationSession
   This endpoint revokes a subject's granted consent sessions for a specific OAuth 2.0 Client and invalidates all
 associated OAuth 2.0 Access Tokens.
 */
-func (a *Client) RevokeConsentSessions(params *RevokeConsentSessionsParams) (*RevokeConsentSessionsNoContent, error) {
+func (a *Client) RevokeConsentSessions(params *RevokeConsentSessionsParams, opts ...ClientOption) (*RevokeConsentSessionsNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRevokeConsentSessionsParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "revokeConsentSessions",
 		Method:             "DELETE",
 		PathPattern:        "/oauth2/auth/sessions/consent",
@@ -1296,7 +1414,12 @@ func (a *Client) RevokeConsentSessions(params *RevokeConsentSessionsParams) (*Re
 		Reader:             &RevokeConsentSessionsReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1317,13 +1440,12 @@ func (a *Client) RevokeConsentSessions(params *RevokeConsentSessionsParams) (*Re
 to perform JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication
 and Authorization Grants [RFC7523](https://datatracker.ietf.org/doc/html/rfc7523).
 */
-func (a *Client) TrustJwtGrantIssuer(params *TrustJwtGrantIssuerParams) (*TrustJwtGrantIssuerCreated, error) {
+func (a *Client) TrustJwtGrantIssuer(params *TrustJwtGrantIssuerParams, opts ...ClientOption) (*TrustJwtGrantIssuerCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewTrustJwtGrantIssuerParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "trustJwtGrantIssuer",
 		Method:             "POST",
 		PathPattern:        "/trust/grants/jwt-bearer/issuers",
@@ -1334,7 +1456,12 @@ func (a *Client) TrustJwtGrantIssuer(params *TrustJwtGrantIssuerParams) (*TrustJ
 		Reader:             &TrustJwtGrantIssuerReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1355,13 +1482,12 @@ func (a *Client) TrustJwtGrantIssuer(params *TrustJwtGrantIssuerParams) (*TrustJ
 
 A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 */
-func (a *Client) UpdateJSONWebKey(params *UpdateJSONWebKeyParams) (*UpdateJSONWebKeyOK, error) {
+func (a *Client) UpdateJSONWebKey(params *UpdateJSONWebKeyParams, opts ...ClientOption) (*UpdateJSONWebKeyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateJSONWebKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateJsonWebKey",
 		Method:             "PUT",
 		PathPattern:        "/keys/{set}/{kid}",
@@ -1372,7 +1498,12 @@ func (a *Client) UpdateJSONWebKey(params *UpdateJSONWebKeyParams) (*UpdateJSONWe
 		Reader:             &UpdateJSONWebKeyReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1393,13 +1524,12 @@ func (a *Client) UpdateJSONWebKey(params *UpdateJSONWebKeyParams) (*UpdateJSONWe
 
 A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 */
-func (a *Client) UpdateJSONWebKeySet(params *UpdateJSONWebKeySetParams) (*UpdateJSONWebKeySetOK, error) {
+func (a *Client) UpdateJSONWebKeySet(params *UpdateJSONWebKeySetParams, opts ...ClientOption) (*UpdateJSONWebKeySetOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateJSONWebKeySetParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateJsonWebKeySet",
 		Method:             "PUT",
 		PathPattern:        "/keys/{set}",
@@ -1410,7 +1540,12 @@ func (a *Client) UpdateJSONWebKeySet(params *UpdateJSONWebKeySetParams) (*Update
 		Reader:             &UpdateJSONWebKeySetReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -1433,13 +1568,12 @@ This is the only time you will be able to retrieve the client secret, so write i
 OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are
 generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 */
-func (a *Client) UpdateOAuth2Client(params *UpdateOAuth2ClientParams) (*UpdateOAuth2ClientOK, error) {
+func (a *Client) UpdateOAuth2Client(params *UpdateOAuth2ClientParams, opts ...ClientOption) (*UpdateOAuth2ClientOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUpdateOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "updateOAuth2Client",
 		Method:             "PUT",
 		PathPattern:        "/clients/{id}",
@@ -1450,7 +1584,12 @@ func (a *Client) UpdateOAuth2Client(params *UpdateOAuth2ClientParams) (*UpdateOA
 		Reader:             &UpdateOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpclient/client/admin/create_json_web_key_set_parameters.go
+++ b/internal/httpclient/client/admin/create_json_web_key_set_parameters.go
@@ -18,61 +18,76 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewCreateJSONWebKeySetParams creates a new CreateJSONWebKeySetParams object
-// with the default values initialized.
+// NewCreateJSONWebKeySetParams creates a new CreateJSONWebKeySetParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewCreateJSONWebKeySetParams() *CreateJSONWebKeySetParams {
-	var ()
 	return &CreateJSONWebKeySetParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewCreateJSONWebKeySetParamsWithTimeout creates a new CreateJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewCreateJSONWebKeySetParamsWithTimeout(timeout time.Duration) *CreateJSONWebKeySetParams {
-	var ()
 	return &CreateJSONWebKeySetParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewCreateJSONWebKeySetParamsWithContext creates a new CreateJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewCreateJSONWebKeySetParamsWithContext(ctx context.Context) *CreateJSONWebKeySetParams {
-	var ()
 	return &CreateJSONWebKeySetParams{
-
 		Context: ctx,
 	}
 }
 
 // NewCreateJSONWebKeySetParamsWithHTTPClient creates a new CreateJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewCreateJSONWebKeySetParamsWithHTTPClient(client *http.Client) *CreateJSONWebKeySetParams {
-	var ()
 	return &CreateJSONWebKeySetParams{
 		HTTPClient: client,
 	}
 }
 
-/*CreateJSONWebKeySetParams contains all the parameters to send to the API endpoint
-for the create Json web key set operation typically these are written to a http.Request
+/* CreateJSONWebKeySetParams contains all the parameters to send to the API endpoint
+   for the create Json web key set operation.
+
+   Typically these are written to a http.Request.
 */
 type CreateJSONWebKeySetParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.JSONWebKeySetGeneratorRequest
-	/*Set
-	  The set
 
+	/* Set.
+
+	   The set
 	*/
 	Set string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the create Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *CreateJSONWebKeySetParams) WithDefaults() *CreateJSONWebKeySetParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the create Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *CreateJSONWebKeySetParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the create Json web key set params
@@ -137,7 +152,6 @@ func (o *CreateJSONWebKeySetParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/create_json_web_key_set_responses.go
+++ b/internal/httpclient/client/admin/create_json_web_key_set_responses.go
@@ -47,9 +47,8 @@ func (o *CreateJSONWebKeySetReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewCreateJSONWebKeySetCreated() *CreateJSONWebKeySetCreated {
 	return &CreateJSONWebKeySetCreated{}
 }
 
-/*CreateJSONWebKeySetCreated handles this case with default header values.
+/* CreateJSONWebKeySetCreated describes a response with status code 201, with default header values.
 
 JSONWebKeySet
 */
@@ -69,7 +68,6 @@ type CreateJSONWebKeySetCreated struct {
 func (o *CreateJSONWebKeySetCreated) Error() string {
 	return fmt.Sprintf("[POST /keys/{set}][%d] createJsonWebKeySetCreated  %+v", 201, o.Payload)
 }
-
 func (o *CreateJSONWebKeySetCreated) GetPayload() *models.JSONWebKeySet {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewCreateJSONWebKeySetUnauthorized() *CreateJSONWebKeySetUnauthorized {
 	return &CreateJSONWebKeySetUnauthorized{}
 }
 
-/*CreateJSONWebKeySetUnauthorized handles this case with default header values.
+/* CreateJSONWebKeySetUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -102,7 +100,6 @@ type CreateJSONWebKeySetUnauthorized struct {
 func (o *CreateJSONWebKeySetUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /keys/{set}][%d] createJsonWebKeySetUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *CreateJSONWebKeySetUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewCreateJSONWebKeySetForbidden() *CreateJSONWebKeySetForbidden {
 	return &CreateJSONWebKeySetForbidden{}
 }
 
-/*CreateJSONWebKeySetForbidden handles this case with default header values.
+/* CreateJSONWebKeySetForbidden describes a response with status code 403, with default header values.
 
 jsonError
 */
@@ -135,7 +132,6 @@ type CreateJSONWebKeySetForbidden struct {
 func (o *CreateJSONWebKeySetForbidden) Error() string {
 	return fmt.Sprintf("[POST /keys/{set}][%d] createJsonWebKeySetForbidden  %+v", 403, o.Payload)
 }
-
 func (o *CreateJSONWebKeySetForbidden) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewCreateJSONWebKeySetInternalServerError() *CreateJSONWebKeySetInternalSer
 	return &CreateJSONWebKeySetInternalServerError{}
 }
 
-/*CreateJSONWebKeySetInternalServerError handles this case with default header values.
+/* CreateJSONWebKeySetInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -168,7 +164,6 @@ type CreateJSONWebKeySetInternalServerError struct {
 func (o *CreateJSONWebKeySetInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /keys/{set}][%d] createJsonWebKeySetInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *CreateJSONWebKeySetInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/create_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/admin/create_o_auth2_client_parameters.go
@@ -18,56 +18,70 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewCreateOAuth2ClientParams creates a new CreateOAuth2ClientParams object
-// with the default values initialized.
+// NewCreateOAuth2ClientParams creates a new CreateOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewCreateOAuth2ClientParams() *CreateOAuth2ClientParams {
-	var ()
 	return &CreateOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewCreateOAuth2ClientParamsWithTimeout creates a new CreateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewCreateOAuth2ClientParamsWithTimeout(timeout time.Duration) *CreateOAuth2ClientParams {
-	var ()
 	return &CreateOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewCreateOAuth2ClientParamsWithContext creates a new CreateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewCreateOAuth2ClientParamsWithContext(ctx context.Context) *CreateOAuth2ClientParams {
-	var ()
 	return &CreateOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewCreateOAuth2ClientParamsWithHTTPClient creates a new CreateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewCreateOAuth2ClientParamsWithHTTPClient(client *http.Client) *CreateOAuth2ClientParams {
-	var ()
 	return &CreateOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*CreateOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the create o auth2 client operation typically these are written to a http.Request
+/* CreateOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the create o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type CreateOAuth2ClientParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.OAuth2Client
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the create o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *CreateOAuth2ClientParams) WithDefaults() *CreateOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the create o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *CreateOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the create o auth2 client params
@@ -121,7 +135,6 @@ func (o *CreateOAuth2ClientParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/create_o_auth2_client_responses.go
+++ b/internal/httpclient/client/admin/create_o_auth2_client_responses.go
@@ -46,7 +46,7 @@ func NewCreateOAuth2ClientCreated() *CreateOAuth2ClientCreated {
 	return &CreateOAuth2ClientCreated{}
 }
 
-/*CreateOAuth2ClientCreated handles this case with default header values.
+/* CreateOAuth2ClientCreated describes a response with status code 201, with default header values.
 
 oAuth2Client
 */
@@ -57,7 +57,6 @@ type CreateOAuth2ClientCreated struct {
 func (o *CreateOAuth2ClientCreated) Error() string {
 	return fmt.Sprintf("[POST /clients][%d] createOAuth2ClientCreated  %+v", 201, o.Payload)
 }
-
 func (o *CreateOAuth2ClientCreated) GetPayload() *models.OAuth2Client {
 	return o.Payload
 }
@@ -81,7 +80,7 @@ func NewCreateOAuth2ClientDefault(code int) *CreateOAuth2ClientDefault {
 	}
 }
 
-/*CreateOAuth2ClientDefault handles this case with default header values.
+/* CreateOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -99,7 +98,6 @@ func (o *CreateOAuth2ClientDefault) Code() int {
 func (o *CreateOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[POST /clients][%d] createOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *CreateOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/delete_json_web_key_parameters.go
+++ b/internal/httpclient/client/admin/delete_json_web_key_parameters.go
@@ -16,64 +16,79 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDeleteJSONWebKeyParams creates a new DeleteJSONWebKeyParams object
-// with the default values initialized.
+// NewDeleteJSONWebKeyParams creates a new DeleteJSONWebKeyParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDeleteJSONWebKeyParams() *DeleteJSONWebKeyParams {
-	var ()
 	return &DeleteJSONWebKeyParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDeleteJSONWebKeyParamsWithTimeout creates a new DeleteJSONWebKeyParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDeleteJSONWebKeyParamsWithTimeout(timeout time.Duration) *DeleteJSONWebKeyParams {
-	var ()
 	return &DeleteJSONWebKeyParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDeleteJSONWebKeyParamsWithContext creates a new DeleteJSONWebKeyParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDeleteJSONWebKeyParamsWithContext(ctx context.Context) *DeleteJSONWebKeyParams {
-	var ()
 	return &DeleteJSONWebKeyParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDeleteJSONWebKeyParamsWithHTTPClient creates a new DeleteJSONWebKeyParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDeleteJSONWebKeyParamsWithHTTPClient(client *http.Client) *DeleteJSONWebKeyParams {
-	var ()
 	return &DeleteJSONWebKeyParams{
 		HTTPClient: client,
 	}
 }
 
-/*DeleteJSONWebKeyParams contains all the parameters to send to the API endpoint
-for the delete Json web key operation typically these are written to a http.Request
+/* DeleteJSONWebKeyParams contains all the parameters to send to the API endpoint
+   for the delete Json web key operation.
+
+   Typically these are written to a http.Request.
 */
 type DeleteJSONWebKeyParams struct {
 
-	/*Kid
-	  The kid of the desired key
+	/* Kid.
 
+	   The kid of the desired key
 	*/
 	Kid string
-	/*Set
-	  The set
 
+	/* Set.
+
+	   The set
 	*/
 	Set string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the delete Json web key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteJSONWebKeyParams) WithDefaults() *DeleteJSONWebKeyParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the delete Json web key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteJSONWebKeyParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the delete Json web key params

--- a/internal/httpclient/client/admin/delete_json_web_key_responses.go
+++ b/internal/httpclient/client/admin/delete_json_web_key_responses.go
@@ -47,9 +47,8 @@ func (o *DeleteJSONWebKeyReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,9 +57,9 @@ func NewDeleteJSONWebKeyNoContent() *DeleteJSONWebKeyNoContent {
 	return &DeleteJSONWebKeyNoContent{}
 }
 
-/*DeleteJSONWebKeyNoContent handles this case with default header values.
+/* DeleteJSONWebKeyNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type DeleteJSONWebKeyNoContent struct {
@@ -80,7 +79,7 @@ func NewDeleteJSONWebKeyUnauthorized() *DeleteJSONWebKeyUnauthorized {
 	return &DeleteJSONWebKeyUnauthorized{}
 }
 
-/*DeleteJSONWebKeyUnauthorized handles this case with default header values.
+/* DeleteJSONWebKeyUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -91,7 +90,6 @@ type DeleteJSONWebKeyUnauthorized struct {
 func (o *DeleteJSONWebKeyUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /keys/{set}/{kid}][%d] deleteJsonWebKeyUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *DeleteJSONWebKeyUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -113,7 +111,7 @@ func NewDeleteJSONWebKeyForbidden() *DeleteJSONWebKeyForbidden {
 	return &DeleteJSONWebKeyForbidden{}
 }
 
-/*DeleteJSONWebKeyForbidden handles this case with default header values.
+/* DeleteJSONWebKeyForbidden describes a response with status code 403, with default header values.
 
 jsonError
 */
@@ -124,7 +122,6 @@ type DeleteJSONWebKeyForbidden struct {
 func (o *DeleteJSONWebKeyForbidden) Error() string {
 	return fmt.Sprintf("[DELETE /keys/{set}/{kid}][%d] deleteJsonWebKeyForbidden  %+v", 403, o.Payload)
 }
-
 func (o *DeleteJSONWebKeyForbidden) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -146,7 +143,7 @@ func NewDeleteJSONWebKeyInternalServerError() *DeleteJSONWebKeyInternalServerErr
 	return &DeleteJSONWebKeyInternalServerError{}
 }
 
-/*DeleteJSONWebKeyInternalServerError handles this case with default header values.
+/* DeleteJSONWebKeyInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -157,7 +154,6 @@ type DeleteJSONWebKeyInternalServerError struct {
 func (o *DeleteJSONWebKeyInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /keys/{set}/{kid}][%d] deleteJsonWebKeyInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *DeleteJSONWebKeyInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/delete_json_web_key_set_parameters.go
+++ b/internal/httpclient/client/admin/delete_json_web_key_set_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDeleteJSONWebKeySetParams creates a new DeleteJSONWebKeySetParams object
-// with the default values initialized.
+// NewDeleteJSONWebKeySetParams creates a new DeleteJSONWebKeySetParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDeleteJSONWebKeySetParams() *DeleteJSONWebKeySetParams {
-	var ()
 	return &DeleteJSONWebKeySetParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDeleteJSONWebKeySetParamsWithTimeout creates a new DeleteJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDeleteJSONWebKeySetParamsWithTimeout(timeout time.Duration) *DeleteJSONWebKeySetParams {
-	var ()
 	return &DeleteJSONWebKeySetParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDeleteJSONWebKeySetParamsWithContext creates a new DeleteJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDeleteJSONWebKeySetParamsWithContext(ctx context.Context) *DeleteJSONWebKeySetParams {
-	var ()
 	return &DeleteJSONWebKeySetParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDeleteJSONWebKeySetParamsWithHTTPClient creates a new DeleteJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDeleteJSONWebKeySetParamsWithHTTPClient(client *http.Client) *DeleteJSONWebKeySetParams {
-	var ()
 	return &DeleteJSONWebKeySetParams{
 		HTTPClient: client,
 	}
 }
 
-/*DeleteJSONWebKeySetParams contains all the parameters to send to the API endpoint
-for the delete Json web key set operation typically these are written to a http.Request
+/* DeleteJSONWebKeySetParams contains all the parameters to send to the API endpoint
+   for the delete Json web key set operation.
+
+   Typically these are written to a http.Request.
 */
 type DeleteJSONWebKeySetParams struct {
 
-	/*Set
-	  The set
+	/* Set.
 
+	   The set
 	*/
 	Set string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the delete Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteJSONWebKeySetParams) WithDefaults() *DeleteJSONWebKeySetParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the delete Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteJSONWebKeySetParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the delete Json web key set params

--- a/internal/httpclient/client/admin/delete_json_web_key_set_responses.go
+++ b/internal/httpclient/client/admin/delete_json_web_key_set_responses.go
@@ -47,9 +47,8 @@ func (o *DeleteJSONWebKeySetReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,9 +57,9 @@ func NewDeleteJSONWebKeySetNoContent() *DeleteJSONWebKeySetNoContent {
 	return &DeleteJSONWebKeySetNoContent{}
 }
 
-/*DeleteJSONWebKeySetNoContent handles this case with default header values.
+/* DeleteJSONWebKeySetNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type DeleteJSONWebKeySetNoContent struct {
@@ -80,7 +79,7 @@ func NewDeleteJSONWebKeySetUnauthorized() *DeleteJSONWebKeySetUnauthorized {
 	return &DeleteJSONWebKeySetUnauthorized{}
 }
 
-/*DeleteJSONWebKeySetUnauthorized handles this case with default header values.
+/* DeleteJSONWebKeySetUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -91,7 +90,6 @@ type DeleteJSONWebKeySetUnauthorized struct {
 func (o *DeleteJSONWebKeySetUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /keys/{set}][%d] deleteJsonWebKeySetUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *DeleteJSONWebKeySetUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -113,7 +111,7 @@ func NewDeleteJSONWebKeySetForbidden() *DeleteJSONWebKeySetForbidden {
 	return &DeleteJSONWebKeySetForbidden{}
 }
 
-/*DeleteJSONWebKeySetForbidden handles this case with default header values.
+/* DeleteJSONWebKeySetForbidden describes a response with status code 403, with default header values.
 
 jsonError
 */
@@ -124,7 +122,6 @@ type DeleteJSONWebKeySetForbidden struct {
 func (o *DeleteJSONWebKeySetForbidden) Error() string {
 	return fmt.Sprintf("[DELETE /keys/{set}][%d] deleteJsonWebKeySetForbidden  %+v", 403, o.Payload)
 }
-
 func (o *DeleteJSONWebKeySetForbidden) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -146,7 +143,7 @@ func NewDeleteJSONWebKeySetInternalServerError() *DeleteJSONWebKeySetInternalSer
 	return &DeleteJSONWebKeySetInternalServerError{}
 }
 
-/*DeleteJSONWebKeySetInternalServerError handles this case with default header values.
+/* DeleteJSONWebKeySetInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -157,7 +154,6 @@ type DeleteJSONWebKeySetInternalServerError struct {
 func (o *DeleteJSONWebKeySetInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /keys/{set}][%d] deleteJsonWebKeySetInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *DeleteJSONWebKeySetInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/delete_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/admin/delete_o_auth2_client_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDeleteOAuth2ClientParams creates a new DeleteOAuth2ClientParams object
-// with the default values initialized.
+// NewDeleteOAuth2ClientParams creates a new DeleteOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDeleteOAuth2ClientParams() *DeleteOAuth2ClientParams {
-	var ()
 	return &DeleteOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDeleteOAuth2ClientParamsWithTimeout creates a new DeleteOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDeleteOAuth2ClientParamsWithTimeout(timeout time.Duration) *DeleteOAuth2ClientParams {
-	var ()
 	return &DeleteOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDeleteOAuth2ClientParamsWithContext creates a new DeleteOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDeleteOAuth2ClientParamsWithContext(ctx context.Context) *DeleteOAuth2ClientParams {
-	var ()
 	return &DeleteOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDeleteOAuth2ClientParamsWithHTTPClient creates a new DeleteOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDeleteOAuth2ClientParamsWithHTTPClient(client *http.Client) *DeleteOAuth2ClientParams {
-	var ()
 	return &DeleteOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*DeleteOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the delete o auth2 client operation typically these are written to a http.Request
+/* DeleteOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the delete o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type DeleteOAuth2ClientParams struct {
 
-	/*ID
-	  The id of the OAuth 2.0 Client.
+	/* ID.
 
+	   The id of the OAuth 2.0 Client.
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the delete o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteOAuth2ClientParams) WithDefaults() *DeleteOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the delete o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the delete o auth2 client params

--- a/internal/httpclient/client/admin/delete_o_auth2_client_responses.go
+++ b/internal/httpclient/client/admin/delete_o_auth2_client_responses.go
@@ -46,9 +46,9 @@ func NewDeleteOAuth2ClientNoContent() *DeleteOAuth2ClientNoContent {
 	return &DeleteOAuth2ClientNoContent{}
 }
 
-/*DeleteOAuth2ClientNoContent handles this case with default header values.
+/* DeleteOAuth2ClientNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type DeleteOAuth2ClientNoContent struct {
@@ -70,7 +70,7 @@ func NewDeleteOAuth2ClientDefault(code int) *DeleteOAuth2ClientDefault {
 	}
 }
 
-/*DeleteOAuth2ClientDefault handles this case with default header values.
+/* DeleteOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -88,7 +88,6 @@ func (o *DeleteOAuth2ClientDefault) Code() int {
 func (o *DeleteOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[DELETE /clients/{id}][%d] deleteOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *DeleteOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/delete_o_auth2_token_parameters.go
+++ b/internal/httpclient/client/admin/delete_o_auth2_token_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDeleteOAuth2TokenParams creates a new DeleteOAuth2TokenParams object
-// with the default values initialized.
+// NewDeleteOAuth2TokenParams creates a new DeleteOAuth2TokenParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDeleteOAuth2TokenParams() *DeleteOAuth2TokenParams {
-	var ()
 	return &DeleteOAuth2TokenParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDeleteOAuth2TokenParamsWithTimeout creates a new DeleteOAuth2TokenParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDeleteOAuth2TokenParamsWithTimeout(timeout time.Duration) *DeleteOAuth2TokenParams {
-	var ()
 	return &DeleteOAuth2TokenParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDeleteOAuth2TokenParamsWithContext creates a new DeleteOAuth2TokenParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDeleteOAuth2TokenParamsWithContext(ctx context.Context) *DeleteOAuth2TokenParams {
-	var ()
 	return &DeleteOAuth2TokenParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDeleteOAuth2TokenParamsWithHTTPClient creates a new DeleteOAuth2TokenParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDeleteOAuth2TokenParamsWithHTTPClient(client *http.Client) *DeleteOAuth2TokenParams {
-	var ()
 	return &DeleteOAuth2TokenParams{
 		HTTPClient: client,
 	}
 }
 
-/*DeleteOAuth2TokenParams contains all the parameters to send to the API endpoint
-for the delete o auth2 token operation typically these are written to a http.Request
+/* DeleteOAuth2TokenParams contains all the parameters to send to the API endpoint
+   for the delete o auth2 token operation.
+
+   Typically these are written to a http.Request.
 */
 type DeleteOAuth2TokenParams struct {
 
-	/*ClientID*/
+	// ClientID.
 	ClientID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the delete o auth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteOAuth2TokenParams) WithDefaults() *DeleteOAuth2TokenParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the delete o auth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteOAuth2TokenParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the delete o auth2 token params
@@ -124,6 +138,7 @@ func (o *DeleteOAuth2TokenParams) WriteToRequest(r runtime.ClientRequest, reg st
 	qrClientID := o.ClientID
 	qClientID := qrClientID
 	if qClientID != "" {
+
 		if err := r.SetQueryParam("client_id", qClientID); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/delete_o_auth2_token_responses.go
+++ b/internal/httpclient/client/admin/delete_o_auth2_token_responses.go
@@ -41,9 +41,8 @@ func (o *DeleteOAuth2TokenReader) ReadResponse(response runtime.ClientResponse, 
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewDeleteOAuth2TokenNoContent() *DeleteOAuth2TokenNoContent {
 	return &DeleteOAuth2TokenNoContent{}
 }
 
-/*DeleteOAuth2TokenNoContent handles this case with default header values.
+/* DeleteOAuth2TokenNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type DeleteOAuth2TokenNoContent struct {
@@ -74,7 +73,7 @@ func NewDeleteOAuth2TokenUnauthorized() *DeleteOAuth2TokenUnauthorized {
 	return &DeleteOAuth2TokenUnauthorized{}
 }
 
-/*DeleteOAuth2TokenUnauthorized handles this case with default header values.
+/* DeleteOAuth2TokenUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -85,7 +84,6 @@ type DeleteOAuth2TokenUnauthorized struct {
 func (o *DeleteOAuth2TokenUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /oauth2/tokens][%d] deleteOAuth2TokenUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *DeleteOAuth2TokenUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewDeleteOAuth2TokenInternalServerError() *DeleteOAuth2TokenInternalServerE
 	return &DeleteOAuth2TokenInternalServerError{}
 }
 
-/*DeleteOAuth2TokenInternalServerError handles this case with default header values.
+/* DeleteOAuth2TokenInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -118,7 +116,6 @@ type DeleteOAuth2TokenInternalServerError struct {
 func (o *DeleteOAuth2TokenInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /oauth2/tokens][%d] deleteOAuth2TokenInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *DeleteOAuth2TokenInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/delete_trusted_jwt_grant_issuer_parameters.go
+++ b/internal/httpclient/client/admin/delete_trusted_jwt_grant_issuer_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDeleteTrustedJwtGrantIssuerParams creates a new DeleteTrustedJwtGrantIssuerParams object
-// with the default values initialized.
+// NewDeleteTrustedJwtGrantIssuerParams creates a new DeleteTrustedJwtGrantIssuerParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDeleteTrustedJwtGrantIssuerParams() *DeleteTrustedJwtGrantIssuerParams {
-	var ()
 	return &DeleteTrustedJwtGrantIssuerParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDeleteTrustedJwtGrantIssuerParamsWithTimeout creates a new DeleteTrustedJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDeleteTrustedJwtGrantIssuerParamsWithTimeout(timeout time.Duration) *DeleteTrustedJwtGrantIssuerParams {
-	var ()
 	return &DeleteTrustedJwtGrantIssuerParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDeleteTrustedJwtGrantIssuerParamsWithContext creates a new DeleteTrustedJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDeleteTrustedJwtGrantIssuerParamsWithContext(ctx context.Context) *DeleteTrustedJwtGrantIssuerParams {
-	var ()
 	return &DeleteTrustedJwtGrantIssuerParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDeleteTrustedJwtGrantIssuerParamsWithHTTPClient creates a new DeleteTrustedJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDeleteTrustedJwtGrantIssuerParamsWithHTTPClient(client *http.Client) *DeleteTrustedJwtGrantIssuerParams {
-	var ()
 	return &DeleteTrustedJwtGrantIssuerParams{
 		HTTPClient: client,
 	}
 }
 
-/*DeleteTrustedJwtGrantIssuerParams contains all the parameters to send to the API endpoint
-for the delete trusted jwt grant issuer operation typically these are written to a http.Request
+/* DeleteTrustedJwtGrantIssuerParams contains all the parameters to send to the API endpoint
+   for the delete trusted jwt grant issuer operation.
+
+   Typically these are written to a http.Request.
 */
 type DeleteTrustedJwtGrantIssuerParams struct {
 
-	/*ID
-	  The id of the desired grant
+	/* ID.
 
+	   The id of the desired grant
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the delete trusted jwt grant issuer params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteTrustedJwtGrantIssuerParams) WithDefaults() *DeleteTrustedJwtGrantIssuerParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the delete trusted jwt grant issuer params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DeleteTrustedJwtGrantIssuerParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the delete trusted jwt grant issuer params

--- a/internal/httpclient/client/admin/delete_trusted_jwt_grant_issuer_responses.go
+++ b/internal/httpclient/client/admin/delete_trusted_jwt_grant_issuer_responses.go
@@ -41,9 +41,8 @@ func (o *DeleteTrustedJwtGrantIssuerReader) ReadResponse(response runtime.Client
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewDeleteTrustedJwtGrantIssuerNoContent() *DeleteTrustedJwtGrantIssuerNoCon
 	return &DeleteTrustedJwtGrantIssuerNoContent{}
 }
 
-/*DeleteTrustedJwtGrantIssuerNoContent handles this case with default header values.
+/* DeleteTrustedJwtGrantIssuerNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type DeleteTrustedJwtGrantIssuerNoContent struct {
@@ -74,7 +73,7 @@ func NewDeleteTrustedJwtGrantIssuerNotFound() *DeleteTrustedJwtGrantIssuerNotFou
 	return &DeleteTrustedJwtGrantIssuerNotFound{}
 }
 
-/*DeleteTrustedJwtGrantIssuerNotFound handles this case with default header values.
+/* DeleteTrustedJwtGrantIssuerNotFound describes a response with status code 404, with default header values.
 
 genericError
 */
@@ -85,7 +84,6 @@ type DeleteTrustedJwtGrantIssuerNotFound struct {
 func (o *DeleteTrustedJwtGrantIssuerNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /trust/grants/jwt-bearer/issuers/{id}][%d] deleteTrustedJwtGrantIssuerNotFound  %+v", 404, o.Payload)
 }
-
 func (o *DeleteTrustedJwtGrantIssuerNotFound) GetPayload() *models.GenericError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewDeleteTrustedJwtGrantIssuerInternalServerError() *DeleteTrustedJwtGrantI
 	return &DeleteTrustedJwtGrantIssuerInternalServerError{}
 }
 
-/*DeleteTrustedJwtGrantIssuerInternalServerError handles this case with default header values.
+/* DeleteTrustedJwtGrantIssuerInternalServerError describes a response with status code 500, with default header values.
 
 genericError
 */
@@ -118,7 +116,6 @@ type DeleteTrustedJwtGrantIssuerInternalServerError struct {
 func (o *DeleteTrustedJwtGrantIssuerInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /trust/grants/jwt-bearer/issuers/{id}][%d] deleteTrustedJwtGrantIssuerInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *DeleteTrustedJwtGrantIssuerInternalServerError) GetPayload() *models.GenericError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/flush_inactive_o_auth2_tokens_parameters.go
+++ b/internal/httpclient/client/admin/flush_inactive_o_auth2_tokens_parameters.go
@@ -18,56 +18,70 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewFlushInactiveOAuth2TokensParams creates a new FlushInactiveOAuth2TokensParams object
-// with the default values initialized.
+// NewFlushInactiveOAuth2TokensParams creates a new FlushInactiveOAuth2TokensParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewFlushInactiveOAuth2TokensParams() *FlushInactiveOAuth2TokensParams {
-	var ()
 	return &FlushInactiveOAuth2TokensParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewFlushInactiveOAuth2TokensParamsWithTimeout creates a new FlushInactiveOAuth2TokensParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewFlushInactiveOAuth2TokensParamsWithTimeout(timeout time.Duration) *FlushInactiveOAuth2TokensParams {
-	var ()
 	return &FlushInactiveOAuth2TokensParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewFlushInactiveOAuth2TokensParamsWithContext creates a new FlushInactiveOAuth2TokensParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewFlushInactiveOAuth2TokensParamsWithContext(ctx context.Context) *FlushInactiveOAuth2TokensParams {
-	var ()
 	return &FlushInactiveOAuth2TokensParams{
-
 		Context: ctx,
 	}
 }
 
 // NewFlushInactiveOAuth2TokensParamsWithHTTPClient creates a new FlushInactiveOAuth2TokensParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewFlushInactiveOAuth2TokensParamsWithHTTPClient(client *http.Client) *FlushInactiveOAuth2TokensParams {
-	var ()
 	return &FlushInactiveOAuth2TokensParams{
 		HTTPClient: client,
 	}
 }
 
-/*FlushInactiveOAuth2TokensParams contains all the parameters to send to the API endpoint
-for the flush inactive o auth2 tokens operation typically these are written to a http.Request
+/* FlushInactiveOAuth2TokensParams contains all the parameters to send to the API endpoint
+   for the flush inactive o auth2 tokens operation.
+
+   Typically these are written to a http.Request.
 */
 type FlushInactiveOAuth2TokensParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.FlushInactiveOAuth2TokensRequest
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the flush inactive o auth2 tokens params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *FlushInactiveOAuth2TokensParams) WithDefaults() *FlushInactiveOAuth2TokensParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the flush inactive o auth2 tokens params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *FlushInactiveOAuth2TokensParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the flush inactive o auth2 tokens params
@@ -121,7 +135,6 @@ func (o *FlushInactiveOAuth2TokensParams) WriteToRequest(r runtime.ClientRequest
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/flush_inactive_o_auth2_tokens_responses.go
+++ b/internal/httpclient/client/admin/flush_inactive_o_auth2_tokens_responses.go
@@ -41,9 +41,8 @@ func (o *FlushInactiveOAuth2TokensReader) ReadResponse(response runtime.ClientRe
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewFlushInactiveOAuth2TokensNoContent() *FlushInactiveOAuth2TokensNoContent
 	return &FlushInactiveOAuth2TokensNoContent{}
 }
 
-/*FlushInactiveOAuth2TokensNoContent handles this case with default header values.
+/* FlushInactiveOAuth2TokensNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type FlushInactiveOAuth2TokensNoContent struct {
@@ -74,7 +73,7 @@ func NewFlushInactiveOAuth2TokensUnauthorized() *FlushInactiveOAuth2TokensUnauth
 	return &FlushInactiveOAuth2TokensUnauthorized{}
 }
 
-/*FlushInactiveOAuth2TokensUnauthorized handles this case with default header values.
+/* FlushInactiveOAuth2TokensUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -85,7 +84,6 @@ type FlushInactiveOAuth2TokensUnauthorized struct {
 func (o *FlushInactiveOAuth2TokensUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /oauth2/flush][%d] flushInactiveOAuth2TokensUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *FlushInactiveOAuth2TokensUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewFlushInactiveOAuth2TokensInternalServerError() *FlushInactiveOAuth2Token
 	return &FlushInactiveOAuth2TokensInternalServerError{}
 }
 
-/*FlushInactiveOAuth2TokensInternalServerError handles this case with default header values.
+/* FlushInactiveOAuth2TokensInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -118,7 +116,6 @@ type FlushInactiveOAuth2TokensInternalServerError struct {
 func (o *FlushInactiveOAuth2TokensInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /oauth2/flush][%d] flushInactiveOAuth2TokensInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *FlushInactiveOAuth2TokensInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_consent_request_parameters.go
+++ b/internal/httpclient/client/admin/get_consent_request_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetConsentRequestParams creates a new GetConsentRequestParams object
-// with the default values initialized.
+// NewGetConsentRequestParams creates a new GetConsentRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetConsentRequestParams() *GetConsentRequestParams {
-	var ()
 	return &GetConsentRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetConsentRequestParamsWithTimeout creates a new GetConsentRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetConsentRequestParamsWithTimeout(timeout time.Duration) *GetConsentRequestParams {
-	var ()
 	return &GetConsentRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetConsentRequestParamsWithContext creates a new GetConsentRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetConsentRequestParamsWithContext(ctx context.Context) *GetConsentRequestParams {
-	var ()
 	return &GetConsentRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetConsentRequestParamsWithHTTPClient creates a new GetConsentRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetConsentRequestParamsWithHTTPClient(client *http.Client) *GetConsentRequestParams {
-	var ()
 	return &GetConsentRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetConsentRequestParams contains all the parameters to send to the API endpoint
-for the get consent request operation typically these are written to a http.Request
+/* GetConsentRequestParams contains all the parameters to send to the API endpoint
+   for the get consent request operation.
+
+   Typically these are written to a http.Request.
 */
 type GetConsentRequestParams struct {
 
-	/*ConsentChallenge*/
+	// ConsentChallenge.
 	ConsentChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get consent request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetConsentRequestParams) WithDefaults() *GetConsentRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get consent request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetConsentRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get consent request params
@@ -124,6 +138,7 @@ func (o *GetConsentRequestParams) WriteToRequest(r runtime.ClientRequest, reg st
 	qrConsentChallenge := o.ConsentChallenge
 	qConsentChallenge := qrConsentChallenge
 	if qConsentChallenge != "" {
+
 		if err := r.SetQueryParam("consent_challenge", qConsentChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/get_consent_request_responses.go
+++ b/internal/httpclient/client/admin/get_consent_request_responses.go
@@ -47,9 +47,8 @@ func (o *GetConsentRequestReader) ReadResponse(response runtime.ClientResponse, 
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewGetConsentRequestOK() *GetConsentRequestOK {
 	return &GetConsentRequestOK{}
 }
 
-/*GetConsentRequestOK handles this case with default header values.
+/* GetConsentRequestOK describes a response with status code 200, with default header values.
 
 consentRequest
 */
@@ -69,7 +68,6 @@ type GetConsentRequestOK struct {
 func (o *GetConsentRequestOK) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/consent][%d] getConsentRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *GetConsentRequestOK) GetPayload() *models.ConsentRequest {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewGetConsentRequestNotFound() *GetConsentRequestNotFound {
 	return &GetConsentRequestNotFound{}
 }
 
-/*GetConsentRequestNotFound handles this case with default header values.
+/* GetConsentRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -102,7 +100,6 @@ type GetConsentRequestNotFound struct {
 func (o *GetConsentRequestNotFound) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/consent][%d] getConsentRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *GetConsentRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewGetConsentRequestGone() *GetConsentRequestGone {
 	return &GetConsentRequestGone{}
 }
 
-/*GetConsentRequestGone handles this case with default header values.
+/* GetConsentRequestGone describes a response with status code 410, with default header values.
 
 requestWasHandledResponse
 */
@@ -135,7 +132,6 @@ type GetConsentRequestGone struct {
 func (o *GetConsentRequestGone) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/consent][%d] getConsentRequestGone  %+v", 410, o.Payload)
 }
-
 func (o *GetConsentRequestGone) GetPayload() *models.RequestWasHandledResponse {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewGetConsentRequestInternalServerError() *GetConsentRequestInternalServerE
 	return &GetConsentRequestInternalServerError{}
 }
 
-/*GetConsentRequestInternalServerError handles this case with default header values.
+/* GetConsentRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -168,7 +164,6 @@ type GetConsentRequestInternalServerError struct {
 func (o *GetConsentRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/consent][%d] getConsentRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *GetConsentRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_json_web_key_parameters.go
+++ b/internal/httpclient/client/admin/get_json_web_key_parameters.go
@@ -16,64 +16,79 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetJSONWebKeyParams creates a new GetJSONWebKeyParams object
-// with the default values initialized.
+// NewGetJSONWebKeyParams creates a new GetJSONWebKeyParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetJSONWebKeyParams() *GetJSONWebKeyParams {
-	var ()
 	return &GetJSONWebKeyParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetJSONWebKeyParamsWithTimeout creates a new GetJSONWebKeyParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetJSONWebKeyParamsWithTimeout(timeout time.Duration) *GetJSONWebKeyParams {
-	var ()
 	return &GetJSONWebKeyParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetJSONWebKeyParamsWithContext creates a new GetJSONWebKeyParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetJSONWebKeyParamsWithContext(ctx context.Context) *GetJSONWebKeyParams {
-	var ()
 	return &GetJSONWebKeyParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetJSONWebKeyParamsWithHTTPClient creates a new GetJSONWebKeyParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetJSONWebKeyParamsWithHTTPClient(client *http.Client) *GetJSONWebKeyParams {
-	var ()
 	return &GetJSONWebKeyParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetJSONWebKeyParams contains all the parameters to send to the API endpoint
-for the get Json web key operation typically these are written to a http.Request
+/* GetJSONWebKeyParams contains all the parameters to send to the API endpoint
+   for the get Json web key operation.
+
+   Typically these are written to a http.Request.
 */
 type GetJSONWebKeyParams struct {
 
-	/*Kid
-	  The kid of the desired key
+	/* Kid.
 
+	   The kid of the desired key
 	*/
 	Kid string
-	/*Set
-	  The set
 
+	/* Set.
+
+	   The set
 	*/
 	Set string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get Json web key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetJSONWebKeyParams) WithDefaults() *GetJSONWebKeyParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get Json web key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetJSONWebKeyParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get Json web key params

--- a/internal/httpclient/client/admin/get_json_web_key_responses.go
+++ b/internal/httpclient/client/admin/get_json_web_key_responses.go
@@ -41,9 +41,8 @@ func (o *GetJSONWebKeyReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewGetJSONWebKeyOK() *GetJSONWebKeyOK {
 	return &GetJSONWebKeyOK{}
 }
 
-/*GetJSONWebKeyOK handles this case with default header values.
+/* GetJSONWebKeyOK describes a response with status code 200, with default header values.
 
 JSONWebKeySet
 */
@@ -63,7 +62,6 @@ type GetJSONWebKeyOK struct {
 func (o *GetJSONWebKeyOK) Error() string {
 	return fmt.Sprintf("[GET /keys/{set}/{kid}][%d] getJsonWebKeyOK  %+v", 200, o.Payload)
 }
-
 func (o *GetJSONWebKeyOK) GetPayload() *models.JSONWebKeySet {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewGetJSONWebKeyNotFound() *GetJSONWebKeyNotFound {
 	return &GetJSONWebKeyNotFound{}
 }
 
-/*GetJSONWebKeyNotFound handles this case with default header values.
+/* GetJSONWebKeyNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -96,7 +94,6 @@ type GetJSONWebKeyNotFound struct {
 func (o *GetJSONWebKeyNotFound) Error() string {
 	return fmt.Sprintf("[GET /keys/{set}/{kid}][%d] getJsonWebKeyNotFound  %+v", 404, o.Payload)
 }
-
 func (o *GetJSONWebKeyNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewGetJSONWebKeyInternalServerError() *GetJSONWebKeyInternalServerError {
 	return &GetJSONWebKeyInternalServerError{}
 }
 
-/*GetJSONWebKeyInternalServerError handles this case with default header values.
+/* GetJSONWebKeyInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -129,7 +126,6 @@ type GetJSONWebKeyInternalServerError struct {
 func (o *GetJSONWebKeyInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /keys/{set}/{kid}][%d] getJsonWebKeyInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *GetJSONWebKeyInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_json_web_key_set_parameters.go
+++ b/internal/httpclient/client/admin/get_json_web_key_set_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetJSONWebKeySetParams creates a new GetJSONWebKeySetParams object
-// with the default values initialized.
+// NewGetJSONWebKeySetParams creates a new GetJSONWebKeySetParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetJSONWebKeySetParams() *GetJSONWebKeySetParams {
-	var ()
 	return &GetJSONWebKeySetParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetJSONWebKeySetParamsWithTimeout creates a new GetJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetJSONWebKeySetParamsWithTimeout(timeout time.Duration) *GetJSONWebKeySetParams {
-	var ()
 	return &GetJSONWebKeySetParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetJSONWebKeySetParamsWithContext creates a new GetJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetJSONWebKeySetParamsWithContext(ctx context.Context) *GetJSONWebKeySetParams {
-	var ()
 	return &GetJSONWebKeySetParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetJSONWebKeySetParamsWithHTTPClient creates a new GetJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetJSONWebKeySetParamsWithHTTPClient(client *http.Client) *GetJSONWebKeySetParams {
-	var ()
 	return &GetJSONWebKeySetParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetJSONWebKeySetParams contains all the parameters to send to the API endpoint
-for the get Json web key set operation typically these are written to a http.Request
+/* GetJSONWebKeySetParams contains all the parameters to send to the API endpoint
+   for the get Json web key set operation.
+
+   Typically these are written to a http.Request.
 */
 type GetJSONWebKeySetParams struct {
 
-	/*Set
-	  The set
+	/* Set.
 
+	   The set
 	*/
 	Set string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetJSONWebKeySetParams) WithDefaults() *GetJSONWebKeySetParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetJSONWebKeySetParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get Json web key set params

--- a/internal/httpclient/client/admin/get_json_web_key_set_responses.go
+++ b/internal/httpclient/client/admin/get_json_web_key_set_responses.go
@@ -47,9 +47,8 @@ func (o *GetJSONWebKeySetReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewGetJSONWebKeySetOK() *GetJSONWebKeySetOK {
 	return &GetJSONWebKeySetOK{}
 }
 
-/*GetJSONWebKeySetOK handles this case with default header values.
+/* GetJSONWebKeySetOK describes a response with status code 200, with default header values.
 
 JSONWebKeySet
 */
@@ -69,7 +68,6 @@ type GetJSONWebKeySetOK struct {
 func (o *GetJSONWebKeySetOK) Error() string {
 	return fmt.Sprintf("[GET /keys/{set}][%d] getJsonWebKeySetOK  %+v", 200, o.Payload)
 }
-
 func (o *GetJSONWebKeySetOK) GetPayload() *models.JSONWebKeySet {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewGetJSONWebKeySetUnauthorized() *GetJSONWebKeySetUnauthorized {
 	return &GetJSONWebKeySetUnauthorized{}
 }
 
-/*GetJSONWebKeySetUnauthorized handles this case with default header values.
+/* GetJSONWebKeySetUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -102,7 +100,6 @@ type GetJSONWebKeySetUnauthorized struct {
 func (o *GetJSONWebKeySetUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /keys/{set}][%d] getJsonWebKeySetUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *GetJSONWebKeySetUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewGetJSONWebKeySetForbidden() *GetJSONWebKeySetForbidden {
 	return &GetJSONWebKeySetForbidden{}
 }
 
-/*GetJSONWebKeySetForbidden handles this case with default header values.
+/* GetJSONWebKeySetForbidden describes a response with status code 403, with default header values.
 
 jsonError
 */
@@ -135,7 +132,6 @@ type GetJSONWebKeySetForbidden struct {
 func (o *GetJSONWebKeySetForbidden) Error() string {
 	return fmt.Sprintf("[GET /keys/{set}][%d] getJsonWebKeySetForbidden  %+v", 403, o.Payload)
 }
-
 func (o *GetJSONWebKeySetForbidden) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewGetJSONWebKeySetInternalServerError() *GetJSONWebKeySetInternalServerErr
 	return &GetJSONWebKeySetInternalServerError{}
 }
 
-/*GetJSONWebKeySetInternalServerError handles this case with default header values.
+/* GetJSONWebKeySetInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -168,7 +164,6 @@ type GetJSONWebKeySetInternalServerError struct {
 func (o *GetJSONWebKeySetInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /keys/{set}][%d] getJsonWebKeySetInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *GetJSONWebKeySetInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_login_request_parameters.go
+++ b/internal/httpclient/client/admin/get_login_request_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetLoginRequestParams creates a new GetLoginRequestParams object
-// with the default values initialized.
+// NewGetLoginRequestParams creates a new GetLoginRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetLoginRequestParams() *GetLoginRequestParams {
-	var ()
 	return &GetLoginRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetLoginRequestParamsWithTimeout creates a new GetLoginRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetLoginRequestParamsWithTimeout(timeout time.Duration) *GetLoginRequestParams {
-	var ()
 	return &GetLoginRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetLoginRequestParamsWithContext creates a new GetLoginRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetLoginRequestParamsWithContext(ctx context.Context) *GetLoginRequestParams {
-	var ()
 	return &GetLoginRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetLoginRequestParamsWithHTTPClient creates a new GetLoginRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetLoginRequestParamsWithHTTPClient(client *http.Client) *GetLoginRequestParams {
-	var ()
 	return &GetLoginRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetLoginRequestParams contains all the parameters to send to the API endpoint
-for the get login request operation typically these are written to a http.Request
+/* GetLoginRequestParams contains all the parameters to send to the API endpoint
+   for the get login request operation.
+
+   Typically these are written to a http.Request.
 */
 type GetLoginRequestParams struct {
 
-	/*LoginChallenge*/
+	// LoginChallenge.
 	LoginChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get login request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLoginRequestParams) WithDefaults() *GetLoginRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get login request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLoginRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get login request params
@@ -124,6 +138,7 @@ func (o *GetLoginRequestParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	qrLoginChallenge := o.LoginChallenge
 	qLoginChallenge := qrLoginChallenge
 	if qLoginChallenge != "" {
+
 		if err := r.SetQueryParam("login_challenge", qLoginChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/get_login_request_responses.go
+++ b/internal/httpclient/client/admin/get_login_request_responses.go
@@ -53,9 +53,8 @@ func (o *GetLoginRequestReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -64,7 +63,7 @@ func NewGetLoginRequestOK() *GetLoginRequestOK {
 	return &GetLoginRequestOK{}
 }
 
-/*GetLoginRequestOK handles this case with default header values.
+/* GetLoginRequestOK describes a response with status code 200, with default header values.
 
 loginRequest
 */
@@ -75,7 +74,6 @@ type GetLoginRequestOK struct {
 func (o *GetLoginRequestOK) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/login][%d] getLoginRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *GetLoginRequestOK) GetPayload() *models.LoginRequest {
 	return o.Payload
 }
@@ -97,7 +95,7 @@ func NewGetLoginRequestBadRequest() *GetLoginRequestBadRequest {
 	return &GetLoginRequestBadRequest{}
 }
 
-/*GetLoginRequestBadRequest handles this case with default header values.
+/* GetLoginRequestBadRequest describes a response with status code 400, with default header values.
 
 jsonError
 */
@@ -108,7 +106,6 @@ type GetLoginRequestBadRequest struct {
 func (o *GetLoginRequestBadRequest) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/login][%d] getLoginRequestBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *GetLoginRequestBadRequest) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -130,7 +127,7 @@ func NewGetLoginRequestNotFound() *GetLoginRequestNotFound {
 	return &GetLoginRequestNotFound{}
 }
 
-/*GetLoginRequestNotFound handles this case with default header values.
+/* GetLoginRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -141,7 +138,6 @@ type GetLoginRequestNotFound struct {
 func (o *GetLoginRequestNotFound) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/login][%d] getLoginRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *GetLoginRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -163,7 +159,7 @@ func NewGetLoginRequestGone() *GetLoginRequestGone {
 	return &GetLoginRequestGone{}
 }
 
-/*GetLoginRequestGone handles this case with default header values.
+/* GetLoginRequestGone describes a response with status code 410, with default header values.
 
 requestWasHandledResponse
 */
@@ -174,7 +170,6 @@ type GetLoginRequestGone struct {
 func (o *GetLoginRequestGone) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/login][%d] getLoginRequestGone  %+v", 410, o.Payload)
 }
-
 func (o *GetLoginRequestGone) GetPayload() *models.RequestWasHandledResponse {
 	return o.Payload
 }
@@ -196,7 +191,7 @@ func NewGetLoginRequestInternalServerError() *GetLoginRequestInternalServerError
 	return &GetLoginRequestInternalServerError{}
 }
 
-/*GetLoginRequestInternalServerError handles this case with default header values.
+/* GetLoginRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -207,7 +202,6 @@ type GetLoginRequestInternalServerError struct {
 func (o *GetLoginRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/login][%d] getLoginRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *GetLoginRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_logout_request_parameters.go
+++ b/internal/httpclient/client/admin/get_logout_request_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetLogoutRequestParams creates a new GetLogoutRequestParams object
-// with the default values initialized.
+// NewGetLogoutRequestParams creates a new GetLogoutRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetLogoutRequestParams() *GetLogoutRequestParams {
-	var ()
 	return &GetLogoutRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetLogoutRequestParamsWithTimeout creates a new GetLogoutRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetLogoutRequestParamsWithTimeout(timeout time.Duration) *GetLogoutRequestParams {
-	var ()
 	return &GetLogoutRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetLogoutRequestParamsWithContext creates a new GetLogoutRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetLogoutRequestParamsWithContext(ctx context.Context) *GetLogoutRequestParams {
-	var ()
 	return &GetLogoutRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetLogoutRequestParamsWithHTTPClient creates a new GetLogoutRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetLogoutRequestParamsWithHTTPClient(client *http.Client) *GetLogoutRequestParams {
-	var ()
 	return &GetLogoutRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetLogoutRequestParams contains all the parameters to send to the API endpoint
-for the get logout request operation typically these are written to a http.Request
+/* GetLogoutRequestParams contains all the parameters to send to the API endpoint
+   for the get logout request operation.
+
+   Typically these are written to a http.Request.
 */
 type GetLogoutRequestParams struct {
 
-	/*LogoutChallenge*/
+	// LogoutChallenge.
 	LogoutChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get logout request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogoutRequestParams) WithDefaults() *GetLogoutRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get logout request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogoutRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get logout request params
@@ -124,6 +138,7 @@ func (o *GetLogoutRequestParams) WriteToRequest(r runtime.ClientRequest, reg str
 	qrLogoutChallenge := o.LogoutChallenge
 	qLogoutChallenge := qrLogoutChallenge
 	if qLogoutChallenge != "" {
+
 		if err := r.SetQueryParam("logout_challenge", qLogoutChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/get_logout_request_responses.go
+++ b/internal/httpclient/client/admin/get_logout_request_responses.go
@@ -47,9 +47,8 @@ func (o *GetLogoutRequestReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewGetLogoutRequestOK() *GetLogoutRequestOK {
 	return &GetLogoutRequestOK{}
 }
 
-/*GetLogoutRequestOK handles this case with default header values.
+/* GetLogoutRequestOK describes a response with status code 200, with default header values.
 
 logoutRequest
 */
@@ -69,7 +68,6 @@ type GetLogoutRequestOK struct {
 func (o *GetLogoutRequestOK) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/logout][%d] getLogoutRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *GetLogoutRequestOK) GetPayload() *models.LogoutRequest {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewGetLogoutRequestNotFound() *GetLogoutRequestNotFound {
 	return &GetLogoutRequestNotFound{}
 }
 
-/*GetLogoutRequestNotFound handles this case with default header values.
+/* GetLogoutRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -102,7 +100,6 @@ type GetLogoutRequestNotFound struct {
 func (o *GetLogoutRequestNotFound) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/logout][%d] getLogoutRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *GetLogoutRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewGetLogoutRequestGone() *GetLogoutRequestGone {
 	return &GetLogoutRequestGone{}
 }
 
-/*GetLogoutRequestGone handles this case with default header values.
+/* GetLogoutRequestGone describes a response with status code 410, with default header values.
 
 requestWasHandledResponse
 */
@@ -135,7 +132,6 @@ type GetLogoutRequestGone struct {
 func (o *GetLogoutRequestGone) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/logout][%d] getLogoutRequestGone  %+v", 410, o.Payload)
 }
-
 func (o *GetLogoutRequestGone) GetPayload() *models.RequestWasHandledResponse {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewGetLogoutRequestInternalServerError() *GetLogoutRequestInternalServerErr
 	return &GetLogoutRequestInternalServerError{}
 }
 
-/*GetLogoutRequestInternalServerError handles this case with default header values.
+/* GetLogoutRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -168,7 +164,6 @@ type GetLogoutRequestInternalServerError struct {
 func (o *GetLogoutRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/requests/logout][%d] getLogoutRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *GetLogoutRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/admin/get_o_auth2_client_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetOAuth2ClientParams creates a new GetOAuth2ClientParams object
-// with the default values initialized.
+// NewGetOAuth2ClientParams creates a new GetOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetOAuth2ClientParams() *GetOAuth2ClientParams {
-	var ()
 	return &GetOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetOAuth2ClientParamsWithTimeout creates a new GetOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetOAuth2ClientParamsWithTimeout(timeout time.Duration) *GetOAuth2ClientParams {
-	var ()
 	return &GetOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetOAuth2ClientParamsWithContext creates a new GetOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetOAuth2ClientParamsWithContext(ctx context.Context) *GetOAuth2ClientParams {
-	var ()
 	return &GetOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetOAuth2ClientParamsWithHTTPClient creates a new GetOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetOAuth2ClientParamsWithHTTPClient(client *http.Client) *GetOAuth2ClientParams {
-	var ()
 	return &GetOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the get o auth2 client operation typically these are written to a http.Request
+/* GetOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the get o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type GetOAuth2ClientParams struct {
 
-	/*ID
-	  The id of the OAuth 2.0 Client.
+	/* ID.
 
+	   The id of the OAuth 2.0 Client.
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetOAuth2ClientParams) WithDefaults() *GetOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get o auth2 client params

--- a/internal/httpclient/client/admin/get_o_auth2_client_responses.go
+++ b/internal/httpclient/client/admin/get_o_auth2_client_responses.go
@@ -46,7 +46,7 @@ func NewGetOAuth2ClientOK() *GetOAuth2ClientOK {
 	return &GetOAuth2ClientOK{}
 }
 
-/*GetOAuth2ClientOK handles this case with default header values.
+/* GetOAuth2ClientOK describes a response with status code 200, with default header values.
 
 oAuth2Client
 */
@@ -57,7 +57,6 @@ type GetOAuth2ClientOK struct {
 func (o *GetOAuth2ClientOK) Error() string {
 	return fmt.Sprintf("[GET /clients/{id}][%d] getOAuth2ClientOK  %+v", 200, o.Payload)
 }
-
 func (o *GetOAuth2ClientOK) GetPayload() *models.OAuth2Client {
 	return o.Payload
 }
@@ -81,7 +80,7 @@ func NewGetOAuth2ClientDefault(code int) *GetOAuth2ClientDefault {
 	}
 }
 
-/*GetOAuth2ClientDefault handles this case with default header values.
+/* GetOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -99,7 +98,6 @@ func (o *GetOAuth2ClientDefault) Code() int {
 func (o *GetOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[GET /clients/{id}][%d] getOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *GetOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_trusted_jwt_grant_issuer_parameters.go
+++ b/internal/httpclient/client/admin/get_trusted_jwt_grant_issuer_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetTrustedJwtGrantIssuerParams creates a new GetTrustedJwtGrantIssuerParams object
-// with the default values initialized.
+// NewGetTrustedJwtGrantIssuerParams creates a new GetTrustedJwtGrantIssuerParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetTrustedJwtGrantIssuerParams() *GetTrustedJwtGrantIssuerParams {
-	var ()
 	return &GetTrustedJwtGrantIssuerParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetTrustedJwtGrantIssuerParamsWithTimeout creates a new GetTrustedJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetTrustedJwtGrantIssuerParamsWithTimeout(timeout time.Duration) *GetTrustedJwtGrantIssuerParams {
-	var ()
 	return &GetTrustedJwtGrantIssuerParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetTrustedJwtGrantIssuerParamsWithContext creates a new GetTrustedJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetTrustedJwtGrantIssuerParamsWithContext(ctx context.Context) *GetTrustedJwtGrantIssuerParams {
-	var ()
 	return &GetTrustedJwtGrantIssuerParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetTrustedJwtGrantIssuerParamsWithHTTPClient creates a new GetTrustedJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetTrustedJwtGrantIssuerParamsWithHTTPClient(client *http.Client) *GetTrustedJwtGrantIssuerParams {
-	var ()
 	return &GetTrustedJwtGrantIssuerParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetTrustedJwtGrantIssuerParams contains all the parameters to send to the API endpoint
-for the get trusted jwt grant issuer operation typically these are written to a http.Request
+/* GetTrustedJwtGrantIssuerParams contains all the parameters to send to the API endpoint
+   for the get trusted jwt grant issuer operation.
+
+   Typically these are written to a http.Request.
 */
 type GetTrustedJwtGrantIssuerParams struct {
 
-	/*ID
-	  The id of the desired grant
+	/* ID.
 
+	   The id of the desired grant
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get trusted jwt grant issuer params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetTrustedJwtGrantIssuerParams) WithDefaults() *GetTrustedJwtGrantIssuerParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get trusted jwt grant issuer params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetTrustedJwtGrantIssuerParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get trusted jwt grant issuer params

--- a/internal/httpclient/client/admin/get_trusted_jwt_grant_issuer_responses.go
+++ b/internal/httpclient/client/admin/get_trusted_jwt_grant_issuer_responses.go
@@ -41,9 +41,8 @@ func (o *GetTrustedJwtGrantIssuerReader) ReadResponse(response runtime.ClientRes
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewGetTrustedJwtGrantIssuerOK() *GetTrustedJwtGrantIssuerOK {
 	return &GetTrustedJwtGrantIssuerOK{}
 }
 
-/*GetTrustedJwtGrantIssuerOK handles this case with default header values.
+/* GetTrustedJwtGrantIssuerOK describes a response with status code 200, with default header values.
 
 trustedJwtGrantIssuer
 */
@@ -63,7 +62,6 @@ type GetTrustedJwtGrantIssuerOK struct {
 func (o *GetTrustedJwtGrantIssuerOK) Error() string {
 	return fmt.Sprintf("[GET /trust/grants/jwt-bearer/issuers/{id}][%d] getTrustedJwtGrantIssuerOK  %+v", 200, o.Payload)
 }
-
 func (o *GetTrustedJwtGrantIssuerOK) GetPayload() *models.TrustedJwtGrantIssuer {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewGetTrustedJwtGrantIssuerNotFound() *GetTrustedJwtGrantIssuerNotFound {
 	return &GetTrustedJwtGrantIssuerNotFound{}
 }
 
-/*GetTrustedJwtGrantIssuerNotFound handles this case with default header values.
+/* GetTrustedJwtGrantIssuerNotFound describes a response with status code 404, with default header values.
 
 genericError
 */
@@ -96,7 +94,6 @@ type GetTrustedJwtGrantIssuerNotFound struct {
 func (o *GetTrustedJwtGrantIssuerNotFound) Error() string {
 	return fmt.Sprintf("[GET /trust/grants/jwt-bearer/issuers/{id}][%d] getTrustedJwtGrantIssuerNotFound  %+v", 404, o.Payload)
 }
-
 func (o *GetTrustedJwtGrantIssuerNotFound) GetPayload() *models.GenericError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewGetTrustedJwtGrantIssuerInternalServerError() *GetTrustedJwtGrantIssuerI
 	return &GetTrustedJwtGrantIssuerInternalServerError{}
 }
 
-/*GetTrustedJwtGrantIssuerInternalServerError handles this case with default header values.
+/* GetTrustedJwtGrantIssuerInternalServerError describes a response with status code 500, with default header values.
 
 genericError
 */
@@ -129,7 +126,6 @@ type GetTrustedJwtGrantIssuerInternalServerError struct {
 func (o *GetTrustedJwtGrantIssuerInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /trust/grants/jwt-bearer/issuers/{id}][%d] getTrustedJwtGrantIssuerInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *GetTrustedJwtGrantIssuerInternalServerError) GetPayload() *models.GenericError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/get_version_parameters.go
+++ b/internal/httpclient/client/admin/get_version_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetVersionParams creates a new GetVersionParams object
-// with the default values initialized.
+// NewGetVersionParams creates a new GetVersionParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetVersionParams() *GetVersionParams {
-
 	return &GetVersionParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetVersionParamsWithTimeout creates a new GetVersionParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetVersionParamsWithTimeout(timeout time.Duration) *GetVersionParams {
-
 	return &GetVersionParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetVersionParamsWithContext creates a new GetVersionParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetVersionParamsWithContext(ctx context.Context) *GetVersionParams {
-
 	return &GetVersionParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetVersionParamsWithHTTPClient creates a new GetVersionParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetVersionParamsWithHTTPClient(client *http.Client) *GetVersionParams {
-
 	return &GetVersionParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetVersionParams contains all the parameters to send to the API endpoint
-for the get version operation typically these are written to a http.Request
+/* GetVersionParams contains all the parameters to send to the API endpoint
+   for the get version operation.
+
+   Typically these are written to a http.Request.
 */
 type GetVersionParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get version params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetVersionParams) WithDefaults() *GetVersionParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get version params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetVersionParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get version params

--- a/internal/httpclient/client/admin/get_version_responses.go
+++ b/internal/httpclient/client/admin/get_version_responses.go
@@ -29,9 +29,8 @@ func (o *GetVersionReader) ReadResponse(response runtime.ClientResponse, consume
 			return nil, err
 		}
 		return result, nil
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -40,7 +39,7 @@ func NewGetVersionOK() *GetVersionOK {
 	return &GetVersionOK{}
 }
 
-/*GetVersionOK handles this case with default header values.
+/* GetVersionOK describes a response with status code 200, with default header values.
 
 version
 */
@@ -51,7 +50,6 @@ type GetVersionOK struct {
 func (o *GetVersionOK) Error() string {
 	return fmt.Sprintf("[GET /version][%d] getVersionOK  %+v", 200, o.Payload)
 }
-
 func (o *GetVersionOK) GetPayload() *models.Version {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/introspect_o_auth2_token_parameters.go
+++ b/internal/httpclient/client/admin/introspect_o_auth2_token_parameters.go
@@ -16,68 +16,83 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewIntrospectOAuth2TokenParams creates a new IntrospectOAuth2TokenParams object
-// with the default values initialized.
+// NewIntrospectOAuth2TokenParams creates a new IntrospectOAuth2TokenParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewIntrospectOAuth2TokenParams() *IntrospectOAuth2TokenParams {
-	var ()
 	return &IntrospectOAuth2TokenParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewIntrospectOAuth2TokenParamsWithTimeout creates a new IntrospectOAuth2TokenParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewIntrospectOAuth2TokenParamsWithTimeout(timeout time.Duration) *IntrospectOAuth2TokenParams {
-	var ()
 	return &IntrospectOAuth2TokenParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewIntrospectOAuth2TokenParamsWithContext creates a new IntrospectOAuth2TokenParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewIntrospectOAuth2TokenParamsWithContext(ctx context.Context) *IntrospectOAuth2TokenParams {
-	var ()
 	return &IntrospectOAuth2TokenParams{
-
 		Context: ctx,
 	}
 }
 
 // NewIntrospectOAuth2TokenParamsWithHTTPClient creates a new IntrospectOAuth2TokenParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewIntrospectOAuth2TokenParamsWithHTTPClient(client *http.Client) *IntrospectOAuth2TokenParams {
-	var ()
 	return &IntrospectOAuth2TokenParams{
 		HTTPClient: client,
 	}
 }
 
-/*IntrospectOAuth2TokenParams contains all the parameters to send to the API endpoint
-for the introspect o auth2 token operation typically these are written to a http.Request
+/* IntrospectOAuth2TokenParams contains all the parameters to send to the API endpoint
+   for the introspect o auth2 token operation.
+
+   Typically these are written to a http.Request.
 */
 type IntrospectOAuth2TokenParams struct {
 
-	/*Scope
-	  An optional, space separated list of required scopes. If the access token was not granted one of the
-	scopes, the result of active will be false.
+	/* Scope.
 
+	     An optional, space separated list of required scopes. If the access token was not granted one of the
+	scopes, the result of active will be false.
 	*/
 	Scope *string
-	/*Token
-	  The string value of the token. For access tokens, this
+
+	/* Token.
+
+	     The string value of the token. For access tokens, this
 	is the "access_token" value returned from the token endpoint
 	defined in OAuth 2.0. For refresh tokens, this is the "refresh_token"
 	value returned.
-
 	*/
 	Token string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the introspect o auth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *IntrospectOAuth2TokenParams) WithDefaults() *IntrospectOAuth2TokenParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the introspect o auth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *IntrospectOAuth2TokenParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the introspect o auth2 token params
@@ -156,7 +171,6 @@ func (o *IntrospectOAuth2TokenParams) WriteToRequest(r runtime.ClientRequest, re
 				return err
 			}
 		}
-
 	}
 
 	// form param token

--- a/internal/httpclient/client/admin/introspect_o_auth2_token_responses.go
+++ b/internal/httpclient/client/admin/introspect_o_auth2_token_responses.go
@@ -41,9 +41,8 @@ func (o *IntrospectOAuth2TokenReader) ReadResponse(response runtime.ClientRespon
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewIntrospectOAuth2TokenOK() *IntrospectOAuth2TokenOK {
 	return &IntrospectOAuth2TokenOK{}
 }
 
-/*IntrospectOAuth2TokenOK handles this case with default header values.
+/* IntrospectOAuth2TokenOK describes a response with status code 200, with default header values.
 
 oAuth2TokenIntrospection
 */
@@ -63,7 +62,6 @@ type IntrospectOAuth2TokenOK struct {
 func (o *IntrospectOAuth2TokenOK) Error() string {
 	return fmt.Sprintf("[POST /oauth2/introspect][%d] introspectOAuth2TokenOK  %+v", 200, o.Payload)
 }
-
 func (o *IntrospectOAuth2TokenOK) GetPayload() *models.OAuth2TokenIntrospection {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewIntrospectOAuth2TokenUnauthorized() *IntrospectOAuth2TokenUnauthorized {
 	return &IntrospectOAuth2TokenUnauthorized{}
 }
 
-/*IntrospectOAuth2TokenUnauthorized handles this case with default header values.
+/* IntrospectOAuth2TokenUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -96,7 +94,6 @@ type IntrospectOAuth2TokenUnauthorized struct {
 func (o *IntrospectOAuth2TokenUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /oauth2/introspect][%d] introspectOAuth2TokenUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *IntrospectOAuth2TokenUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewIntrospectOAuth2TokenInternalServerError() *IntrospectOAuth2TokenInterna
 	return &IntrospectOAuth2TokenInternalServerError{}
 }
 
-/*IntrospectOAuth2TokenInternalServerError handles this case with default header values.
+/* IntrospectOAuth2TokenInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -129,7 +126,6 @@ type IntrospectOAuth2TokenInternalServerError struct {
 func (o *IntrospectOAuth2TokenInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /oauth2/introspect][%d] introspectOAuth2TokenInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *IntrospectOAuth2TokenInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/is_instance_alive_parameters.go
+++ b/internal/httpclient/client/admin/is_instance_alive_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewIsInstanceAliveParams creates a new IsInstanceAliveParams object
-// with the default values initialized.
+// NewIsInstanceAliveParams creates a new IsInstanceAliveParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewIsInstanceAliveParams() *IsInstanceAliveParams {
-
 	return &IsInstanceAliveParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewIsInstanceAliveParamsWithTimeout creates a new IsInstanceAliveParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewIsInstanceAliveParamsWithTimeout(timeout time.Duration) *IsInstanceAliveParams {
-
 	return &IsInstanceAliveParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewIsInstanceAliveParamsWithContext creates a new IsInstanceAliveParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewIsInstanceAliveParamsWithContext(ctx context.Context) *IsInstanceAliveParams {
-
 	return &IsInstanceAliveParams{
-
 		Context: ctx,
 	}
 }
 
 // NewIsInstanceAliveParamsWithHTTPClient creates a new IsInstanceAliveParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewIsInstanceAliveParamsWithHTTPClient(client *http.Client) *IsInstanceAliveParams {
-
 	return &IsInstanceAliveParams{
 		HTTPClient: client,
 	}
 }
 
-/*IsInstanceAliveParams contains all the parameters to send to the API endpoint
-for the is instance alive operation typically these are written to a http.Request
+/* IsInstanceAliveParams contains all the parameters to send to the API endpoint
+   for the is instance alive operation.
+
+   Typically these are written to a http.Request.
 */
 type IsInstanceAliveParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the is instance alive params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *IsInstanceAliveParams) WithDefaults() *IsInstanceAliveParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the is instance alive params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *IsInstanceAliveParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the is instance alive params

--- a/internal/httpclient/client/admin/is_instance_alive_responses.go
+++ b/internal/httpclient/client/admin/is_instance_alive_responses.go
@@ -35,9 +35,8 @@ func (o *IsInstanceAliveReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -46,7 +45,7 @@ func NewIsInstanceAliveOK() *IsInstanceAliveOK {
 	return &IsInstanceAliveOK{}
 }
 
-/*IsInstanceAliveOK handles this case with default header values.
+/* IsInstanceAliveOK describes a response with status code 200, with default header values.
 
 healthStatus
 */
@@ -57,7 +56,6 @@ type IsInstanceAliveOK struct {
 func (o *IsInstanceAliveOK) Error() string {
 	return fmt.Sprintf("[GET /health/alive][%d] isInstanceAliveOK  %+v", 200, o.Payload)
 }
-
 func (o *IsInstanceAliveOK) GetPayload() *models.HealthStatus {
 	return o.Payload
 }
@@ -79,7 +77,7 @@ func NewIsInstanceAliveInternalServerError() *IsInstanceAliveInternalServerError
 	return &IsInstanceAliveInternalServerError{}
 }
 
-/*IsInstanceAliveInternalServerError handles this case with default header values.
+/* IsInstanceAliveInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -90,7 +88,6 @@ type IsInstanceAliveInternalServerError struct {
 func (o *IsInstanceAliveInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /health/alive][%d] isInstanceAliveInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *IsInstanceAliveInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/list_o_auth2_clients_parameters.go
+++ b/internal/httpclient/client/admin/list_o_auth2_clients_parameters.go
@@ -17,74 +17,95 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// NewListOAuth2ClientsParams creates a new ListOAuth2ClientsParams object
-// with the default values initialized.
+// NewListOAuth2ClientsParams creates a new ListOAuth2ClientsParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewListOAuth2ClientsParams() *ListOAuth2ClientsParams {
-	var ()
 	return &ListOAuth2ClientsParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewListOAuth2ClientsParamsWithTimeout creates a new ListOAuth2ClientsParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewListOAuth2ClientsParamsWithTimeout(timeout time.Duration) *ListOAuth2ClientsParams {
-	var ()
 	return &ListOAuth2ClientsParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewListOAuth2ClientsParamsWithContext creates a new ListOAuth2ClientsParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewListOAuth2ClientsParamsWithContext(ctx context.Context) *ListOAuth2ClientsParams {
-	var ()
 	return &ListOAuth2ClientsParams{
-
 		Context: ctx,
 	}
 }
 
 // NewListOAuth2ClientsParamsWithHTTPClient creates a new ListOAuth2ClientsParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewListOAuth2ClientsParamsWithHTTPClient(client *http.Client) *ListOAuth2ClientsParams {
-	var ()
 	return &ListOAuth2ClientsParams{
 		HTTPClient: client,
 	}
 }
 
-/*ListOAuth2ClientsParams contains all the parameters to send to the API endpoint
-for the list o auth2 clients operation typically these are written to a http.Request
+/* ListOAuth2ClientsParams contains all the parameters to send to the API endpoint
+   for the list o auth2 clients operation.
+
+   Typically these are written to a http.Request.
 */
 type ListOAuth2ClientsParams struct {
 
-	/*ClientName
-	  The name of the clients to filter by.
+	/* ClientName.
 
+	   The name of the clients to filter by.
 	*/
 	ClientName *string
-	/*Limit
-	  The maximum amount of clients to returned, upper bound is 500 clients.
 
+	/* Limit.
+
+	   The maximum amount of clients to returned, upper bound is 500 clients.
+
+	   Format: int64
 	*/
 	Limit *int64
-	/*Offset
-	  The offset from where to start looking.
 
+	/* Offset.
+
+	   The offset from where to start looking.
+
+	   Format: int64
 	*/
 	Offset *int64
-	/*Owner
-	  The owner of the clients to filter by.
 
+	/* Owner.
+
+	   The owner of the clients to filter by.
 	*/
 	Owner *string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the list o auth2 clients params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *ListOAuth2ClientsParams) WithDefaults() *ListOAuth2ClientsParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the list o auth2 clients params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *ListOAuth2ClientsParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the list o auth2 clients params
@@ -176,64 +197,68 @@ func (o *ListOAuth2ClientsParams) WriteToRequest(r runtime.ClientRequest, reg st
 
 		// query param client_name
 		var qrClientName string
+
 		if o.ClientName != nil {
 			qrClientName = *o.ClientName
 		}
 		qClientName := qrClientName
 		if qClientName != "" {
+
 			if err := r.SetQueryParam("client_name", qClientName); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Limit != nil {
 
 		// query param limit
 		var qrLimit int64
+
 		if o.Limit != nil {
 			qrLimit = *o.Limit
 		}
 		qLimit := swag.FormatInt64(qrLimit)
 		if qLimit != "" {
+
 			if err := r.SetQueryParam("limit", qLimit); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Offset != nil {
 
 		// query param offset
 		var qrOffset int64
+
 		if o.Offset != nil {
 			qrOffset = *o.Offset
 		}
 		qOffset := swag.FormatInt64(qrOffset)
 		if qOffset != "" {
+
 			if err := r.SetQueryParam("offset", qOffset); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Owner != nil {
 
 		// query param owner
 		var qrOwner string
+
 		if o.Owner != nil {
 			qrOwner = *o.Owner
 		}
 		qOwner := qrOwner
 		if qOwner != "" {
+
 			if err := r.SetQueryParam("owner", qOwner); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/internal/httpclient/client/admin/list_o_auth2_clients_responses.go
+++ b/internal/httpclient/client/admin/list_o_auth2_clients_responses.go
@@ -46,7 +46,7 @@ func NewListOAuth2ClientsOK() *ListOAuth2ClientsOK {
 	return &ListOAuth2ClientsOK{}
 }
 
-/*ListOAuth2ClientsOK handles this case with default header values.
+/* ListOAuth2ClientsOK describes a response with status code 200, with default header values.
 
 A list of clients.
 */
@@ -57,7 +57,6 @@ type ListOAuth2ClientsOK struct {
 func (o *ListOAuth2ClientsOK) Error() string {
 	return fmt.Sprintf("[GET /clients][%d] listOAuth2ClientsOK  %+v", 200, o.Payload)
 }
-
 func (o *ListOAuth2ClientsOK) GetPayload() []*models.OAuth2Client {
 	return o.Payload
 }
@@ -79,7 +78,7 @@ func NewListOAuth2ClientsDefault(code int) *ListOAuth2ClientsDefault {
 	}
 }
 
-/*ListOAuth2ClientsDefault handles this case with default header values.
+/* ListOAuth2ClientsDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -97,7 +96,6 @@ func (o *ListOAuth2ClientsDefault) Code() int {
 func (o *ListOAuth2ClientsDefault) Error() string {
 	return fmt.Sprintf("[GET /clients][%d] listOAuth2Clients default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *ListOAuth2ClientsDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/list_subject_consent_sessions_parameters.go
+++ b/internal/httpclient/client/admin/list_subject_consent_sessions_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewListSubjectConsentSessionsParams creates a new ListSubjectConsentSessionsParams object
-// with the default values initialized.
+// NewListSubjectConsentSessionsParams creates a new ListSubjectConsentSessionsParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewListSubjectConsentSessionsParams() *ListSubjectConsentSessionsParams {
-	var ()
 	return &ListSubjectConsentSessionsParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewListSubjectConsentSessionsParamsWithTimeout creates a new ListSubjectConsentSessionsParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewListSubjectConsentSessionsParamsWithTimeout(timeout time.Duration) *ListSubjectConsentSessionsParams {
-	var ()
 	return &ListSubjectConsentSessionsParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewListSubjectConsentSessionsParamsWithContext creates a new ListSubjectConsentSessionsParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewListSubjectConsentSessionsParamsWithContext(ctx context.Context) *ListSubjectConsentSessionsParams {
-	var ()
 	return &ListSubjectConsentSessionsParams{
-
 		Context: ctx,
 	}
 }
 
 // NewListSubjectConsentSessionsParamsWithHTTPClient creates a new ListSubjectConsentSessionsParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewListSubjectConsentSessionsParamsWithHTTPClient(client *http.Client) *ListSubjectConsentSessionsParams {
-	var ()
 	return &ListSubjectConsentSessionsParams{
 		HTTPClient: client,
 	}
 }
 
-/*ListSubjectConsentSessionsParams contains all the parameters to send to the API endpoint
-for the list subject consent sessions operation typically these are written to a http.Request
+/* ListSubjectConsentSessionsParams contains all the parameters to send to the API endpoint
+   for the list subject consent sessions operation.
+
+   Typically these are written to a http.Request.
 */
 type ListSubjectConsentSessionsParams struct {
 
-	/*Subject*/
+	// Subject.
 	Subject string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the list subject consent sessions params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *ListSubjectConsentSessionsParams) WithDefaults() *ListSubjectConsentSessionsParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the list subject consent sessions params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *ListSubjectConsentSessionsParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the list subject consent sessions params
@@ -124,6 +138,7 @@ func (o *ListSubjectConsentSessionsParams) WriteToRequest(r runtime.ClientReques
 	qrSubject := o.Subject
 	qSubject := qrSubject
 	if qSubject != "" {
+
 		if err := r.SetQueryParam("subject", qSubject); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/list_subject_consent_sessions_responses.go
+++ b/internal/httpclient/client/admin/list_subject_consent_sessions_responses.go
@@ -41,9 +41,8 @@ func (o *ListSubjectConsentSessionsReader) ReadResponse(response runtime.ClientR
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewListSubjectConsentSessionsOK() *ListSubjectConsentSessionsOK {
 	return &ListSubjectConsentSessionsOK{}
 }
 
-/*ListSubjectConsentSessionsOK handles this case with default header values.
+/* ListSubjectConsentSessionsOK describes a response with status code 200, with default header values.
 
 A list of used consent requests.
 */
@@ -63,7 +62,6 @@ type ListSubjectConsentSessionsOK struct {
 func (o *ListSubjectConsentSessionsOK) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/sessions/consent][%d] listSubjectConsentSessionsOK  %+v", 200, o.Payload)
 }
-
 func (o *ListSubjectConsentSessionsOK) GetPayload() []*models.PreviousConsentSession {
 	return o.Payload
 }
@@ -83,7 +81,7 @@ func NewListSubjectConsentSessionsBadRequest() *ListSubjectConsentSessionsBadReq
 	return &ListSubjectConsentSessionsBadRequest{}
 }
 
-/*ListSubjectConsentSessionsBadRequest handles this case with default header values.
+/* ListSubjectConsentSessionsBadRequest describes a response with status code 400, with default header values.
 
 jsonError
 */
@@ -94,7 +92,6 @@ type ListSubjectConsentSessionsBadRequest struct {
 func (o *ListSubjectConsentSessionsBadRequest) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/sessions/consent][%d] listSubjectConsentSessionsBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *ListSubjectConsentSessionsBadRequest) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -116,7 +113,7 @@ func NewListSubjectConsentSessionsInternalServerError() *ListSubjectConsentSessi
 	return &ListSubjectConsentSessionsInternalServerError{}
 }
 
-/*ListSubjectConsentSessionsInternalServerError handles this case with default header values.
+/* ListSubjectConsentSessionsInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -127,7 +124,6 @@ type ListSubjectConsentSessionsInternalServerError struct {
 func (o *ListSubjectConsentSessionsInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth/sessions/consent][%d] listSubjectConsentSessionsInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *ListSubjectConsentSessionsInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/list_trusted_jwt_grant_issuers_parameters.go
+++ b/internal/httpclient/client/admin/list_trusted_jwt_grant_issuers_parameters.go
@@ -17,69 +17,89 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// NewListTrustedJwtGrantIssuersParams creates a new ListTrustedJwtGrantIssuersParams object
-// with the default values initialized.
+// NewListTrustedJwtGrantIssuersParams creates a new ListTrustedJwtGrantIssuersParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewListTrustedJwtGrantIssuersParams() *ListTrustedJwtGrantIssuersParams {
-	var ()
 	return &ListTrustedJwtGrantIssuersParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewListTrustedJwtGrantIssuersParamsWithTimeout creates a new ListTrustedJwtGrantIssuersParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewListTrustedJwtGrantIssuersParamsWithTimeout(timeout time.Duration) *ListTrustedJwtGrantIssuersParams {
-	var ()
 	return &ListTrustedJwtGrantIssuersParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewListTrustedJwtGrantIssuersParamsWithContext creates a new ListTrustedJwtGrantIssuersParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewListTrustedJwtGrantIssuersParamsWithContext(ctx context.Context) *ListTrustedJwtGrantIssuersParams {
-	var ()
 	return &ListTrustedJwtGrantIssuersParams{
-
 		Context: ctx,
 	}
 }
 
 // NewListTrustedJwtGrantIssuersParamsWithHTTPClient creates a new ListTrustedJwtGrantIssuersParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewListTrustedJwtGrantIssuersParamsWithHTTPClient(client *http.Client) *ListTrustedJwtGrantIssuersParams {
-	var ()
 	return &ListTrustedJwtGrantIssuersParams{
 		HTTPClient: client,
 	}
 }
 
-/*ListTrustedJwtGrantIssuersParams contains all the parameters to send to the API endpoint
-for the list trusted jwt grant issuers operation typically these are written to a http.Request
+/* ListTrustedJwtGrantIssuersParams contains all the parameters to send to the API endpoint
+   for the list trusted jwt grant issuers operation.
+
+   Typically these are written to a http.Request.
 */
 type ListTrustedJwtGrantIssuersParams struct {
 
-	/*Issuer
-	  If optional "issuer" is supplied, only jwt-bearer grants with this issuer will be returned.
+	/* Issuer.
 
+	   If optional "issuer" is supplied, only jwt-bearer grants with this issuer will be returned.
 	*/
 	Issuer *string
-	/*Limit
-	  The maximum amount of policies returned, upper bound is 500 policies
 
+	/* Limit.
+
+	   The maximum amount of policies returned, upper bound is 500 policies
+
+	   Format: int64
 	*/
 	Limit *int64
-	/*Offset
-	  The offset from where to start looking.
 
+	/* Offset.
+
+	   The offset from where to start looking.
+
+	   Format: int64
 	*/
 	Offset *int64
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the list trusted jwt grant issuers params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *ListTrustedJwtGrantIssuersParams) WithDefaults() *ListTrustedJwtGrantIssuersParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the list trusted jwt grant issuers params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *ListTrustedJwtGrantIssuersParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the list trusted jwt grant issuers params
@@ -160,48 +180,51 @@ func (o *ListTrustedJwtGrantIssuersParams) WriteToRequest(r runtime.ClientReques
 
 		// query param issuer
 		var qrIssuer string
+
 		if o.Issuer != nil {
 			qrIssuer = *o.Issuer
 		}
 		qIssuer := qrIssuer
 		if qIssuer != "" {
+
 			if err := r.SetQueryParam("issuer", qIssuer); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Limit != nil {
 
 		// query param limit
 		var qrLimit int64
+
 		if o.Limit != nil {
 			qrLimit = *o.Limit
 		}
 		qLimit := swag.FormatInt64(qrLimit)
 		if qLimit != "" {
+
 			if err := r.SetQueryParam("limit", qLimit); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Offset != nil {
 
 		// query param offset
 		var qrOffset int64
+
 		if o.Offset != nil {
 			qrOffset = *o.Offset
 		}
 		qOffset := swag.FormatInt64(qrOffset)
 		if qOffset != "" {
+
 			if err := r.SetQueryParam("offset", qOffset); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/internal/httpclient/client/admin/list_trusted_jwt_grant_issuers_responses.go
+++ b/internal/httpclient/client/admin/list_trusted_jwt_grant_issuers_responses.go
@@ -35,9 +35,8 @@ func (o *ListTrustedJwtGrantIssuersReader) ReadResponse(response runtime.ClientR
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -46,7 +45,7 @@ func NewListTrustedJwtGrantIssuersOK() *ListTrustedJwtGrantIssuersOK {
 	return &ListTrustedJwtGrantIssuersOK{}
 }
 
-/*ListTrustedJwtGrantIssuersOK handles this case with default header values.
+/* ListTrustedJwtGrantIssuersOK describes a response with status code 200, with default header values.
 
 trustedJwtGrantIssuers
 */
@@ -57,7 +56,6 @@ type ListTrustedJwtGrantIssuersOK struct {
 func (o *ListTrustedJwtGrantIssuersOK) Error() string {
 	return fmt.Sprintf("[GET /trust/grants/jwt-bearer/issuers][%d] listTrustedJwtGrantIssuersOK  %+v", 200, o.Payload)
 }
-
 func (o *ListTrustedJwtGrantIssuersOK) GetPayload() models.TrustedJwtGrantIssuers {
 	return o.Payload
 }
@@ -77,7 +75,7 @@ func NewListTrustedJwtGrantIssuersInternalServerError() *ListTrustedJwtGrantIssu
 	return &ListTrustedJwtGrantIssuersInternalServerError{}
 }
 
-/*ListTrustedJwtGrantIssuersInternalServerError handles this case with default header values.
+/* ListTrustedJwtGrantIssuersInternalServerError describes a response with status code 500, with default header values.
 
 genericError
 */
@@ -88,7 +86,6 @@ type ListTrustedJwtGrantIssuersInternalServerError struct {
 func (o *ListTrustedJwtGrantIssuersInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /trust/grants/jwt-bearer/issuers][%d] listTrustedJwtGrantIssuersInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *ListTrustedJwtGrantIssuersInternalServerError) GetPayload() *models.GenericError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/patch_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/admin/patch_o_auth2_client_parameters.go
@@ -18,61 +18,76 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewPatchOAuth2ClientParams creates a new PatchOAuth2ClientParams object
-// with the default values initialized.
+// NewPatchOAuth2ClientParams creates a new PatchOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewPatchOAuth2ClientParams() *PatchOAuth2ClientParams {
-	var ()
 	return &PatchOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewPatchOAuth2ClientParamsWithTimeout creates a new PatchOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewPatchOAuth2ClientParamsWithTimeout(timeout time.Duration) *PatchOAuth2ClientParams {
-	var ()
 	return &PatchOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewPatchOAuth2ClientParamsWithContext creates a new PatchOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewPatchOAuth2ClientParamsWithContext(ctx context.Context) *PatchOAuth2ClientParams {
-	var ()
 	return &PatchOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewPatchOAuth2ClientParamsWithHTTPClient creates a new PatchOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewPatchOAuth2ClientParamsWithHTTPClient(client *http.Client) *PatchOAuth2ClientParams {
-	var ()
 	return &PatchOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*PatchOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the patch o auth2 client operation typically these are written to a http.Request
+/* PatchOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the patch o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type PatchOAuth2ClientParams struct {
 
-	/*Body*/
+	// Body.
 	Body models.PatchRequest
-	/*ID
-	  The id of the OAuth 2.0 Client.
 
+	/* ID.
+
+	   The id of the OAuth 2.0 Client.
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the patch o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *PatchOAuth2ClientParams) WithDefaults() *PatchOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the patch o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *PatchOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the patch o auth2 client params
@@ -137,7 +152,6 @@ func (o *PatchOAuth2ClientParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/patch_o_auth2_client_responses.go
+++ b/internal/httpclient/client/admin/patch_o_auth2_client_responses.go
@@ -46,7 +46,7 @@ func NewPatchOAuth2ClientOK() *PatchOAuth2ClientOK {
 	return &PatchOAuth2ClientOK{}
 }
 
-/*PatchOAuth2ClientOK handles this case with default header values.
+/* PatchOAuth2ClientOK describes a response with status code 200, with default header values.
 
 oAuth2Client
 */
@@ -57,7 +57,6 @@ type PatchOAuth2ClientOK struct {
 func (o *PatchOAuth2ClientOK) Error() string {
 	return fmt.Sprintf("[PATCH /clients/{id}][%d] patchOAuth2ClientOK  %+v", 200, o.Payload)
 }
-
 func (o *PatchOAuth2ClientOK) GetPayload() *models.OAuth2Client {
 	return o.Payload
 }
@@ -81,7 +80,7 @@ func NewPatchOAuth2ClientDefault(code int) *PatchOAuth2ClientDefault {
 	}
 }
 
-/*PatchOAuth2ClientDefault handles this case with default header values.
+/* PatchOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -99,7 +98,6 @@ func (o *PatchOAuth2ClientDefault) Code() int {
 func (o *PatchOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[PATCH /clients/{id}][%d] patchOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *PatchOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/reject_consent_request_parameters.go
+++ b/internal/httpclient/client/admin/reject_consent_request_parameters.go
@@ -18,58 +18,73 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewRejectConsentRequestParams creates a new RejectConsentRequestParams object
-// with the default values initialized.
+// NewRejectConsentRequestParams creates a new RejectConsentRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewRejectConsentRequestParams() *RejectConsentRequestParams {
-	var ()
 	return &RejectConsentRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewRejectConsentRequestParamsWithTimeout creates a new RejectConsentRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewRejectConsentRequestParamsWithTimeout(timeout time.Duration) *RejectConsentRequestParams {
-	var ()
 	return &RejectConsentRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewRejectConsentRequestParamsWithContext creates a new RejectConsentRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewRejectConsentRequestParamsWithContext(ctx context.Context) *RejectConsentRequestParams {
-	var ()
 	return &RejectConsentRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewRejectConsentRequestParamsWithHTTPClient creates a new RejectConsentRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewRejectConsentRequestParamsWithHTTPClient(client *http.Client) *RejectConsentRequestParams {
-	var ()
 	return &RejectConsentRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*RejectConsentRequestParams contains all the parameters to send to the API endpoint
-for the reject consent request operation typically these are written to a http.Request
+/* RejectConsentRequestParams contains all the parameters to send to the API endpoint
+   for the reject consent request operation.
+
+   Typically these are written to a http.Request.
 */
 type RejectConsentRequestParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.RejectRequest
-	/*ConsentChallenge*/
+
+	// ConsentChallenge.
 	ConsentChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the reject consent request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RejectConsentRequestParams) WithDefaults() *RejectConsentRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the reject consent request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RejectConsentRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the reject consent request params
@@ -134,7 +149,6 @@ func (o *RejectConsentRequestParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err
@@ -145,6 +159,7 @@ func (o *RejectConsentRequestParams) WriteToRequest(r runtime.ClientRequest, reg
 	qrConsentChallenge := o.ConsentChallenge
 	qConsentChallenge := qrConsentChallenge
 	if qConsentChallenge != "" {
+
 		if err := r.SetQueryParam("consent_challenge", qConsentChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/reject_consent_request_responses.go
+++ b/internal/httpclient/client/admin/reject_consent_request_responses.go
@@ -41,9 +41,8 @@ func (o *RejectConsentRequestReader) ReadResponse(response runtime.ClientRespons
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewRejectConsentRequestOK() *RejectConsentRequestOK {
 	return &RejectConsentRequestOK{}
 }
 
-/*RejectConsentRequestOK handles this case with default header values.
+/* RejectConsentRequestOK describes a response with status code 200, with default header values.
 
 completedRequest
 */
@@ -63,7 +62,6 @@ type RejectConsentRequestOK struct {
 func (o *RejectConsentRequestOK) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/consent/reject][%d] rejectConsentRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *RejectConsentRequestOK) GetPayload() *models.CompletedRequest {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewRejectConsentRequestNotFound() *RejectConsentRequestNotFound {
 	return &RejectConsentRequestNotFound{}
 }
 
-/*RejectConsentRequestNotFound handles this case with default header values.
+/* RejectConsentRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -96,7 +94,6 @@ type RejectConsentRequestNotFound struct {
 func (o *RejectConsentRequestNotFound) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/consent/reject][%d] rejectConsentRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *RejectConsentRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewRejectConsentRequestInternalServerError() *RejectConsentRequestInternalS
 	return &RejectConsentRequestInternalServerError{}
 }
 
-/*RejectConsentRequestInternalServerError handles this case with default header values.
+/* RejectConsentRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -129,7 +126,6 @@ type RejectConsentRequestInternalServerError struct {
 func (o *RejectConsentRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/consent/reject][%d] rejectConsentRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *RejectConsentRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/reject_login_request_parameters.go
+++ b/internal/httpclient/client/admin/reject_login_request_parameters.go
@@ -18,58 +18,73 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewRejectLoginRequestParams creates a new RejectLoginRequestParams object
-// with the default values initialized.
+// NewRejectLoginRequestParams creates a new RejectLoginRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewRejectLoginRequestParams() *RejectLoginRequestParams {
-	var ()
 	return &RejectLoginRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewRejectLoginRequestParamsWithTimeout creates a new RejectLoginRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewRejectLoginRequestParamsWithTimeout(timeout time.Duration) *RejectLoginRequestParams {
-	var ()
 	return &RejectLoginRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewRejectLoginRequestParamsWithContext creates a new RejectLoginRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewRejectLoginRequestParamsWithContext(ctx context.Context) *RejectLoginRequestParams {
-	var ()
 	return &RejectLoginRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewRejectLoginRequestParamsWithHTTPClient creates a new RejectLoginRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewRejectLoginRequestParamsWithHTTPClient(client *http.Client) *RejectLoginRequestParams {
-	var ()
 	return &RejectLoginRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*RejectLoginRequestParams contains all the parameters to send to the API endpoint
-for the reject login request operation typically these are written to a http.Request
+/* RejectLoginRequestParams contains all the parameters to send to the API endpoint
+   for the reject login request operation.
+
+   Typically these are written to a http.Request.
 */
 type RejectLoginRequestParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.RejectRequest
-	/*LoginChallenge*/
+
+	// LoginChallenge.
 	LoginChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the reject login request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RejectLoginRequestParams) WithDefaults() *RejectLoginRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the reject login request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RejectLoginRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the reject login request params
@@ -134,7 +149,6 @@ func (o *RejectLoginRequestParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err
@@ -145,6 +159,7 @@ func (o *RejectLoginRequestParams) WriteToRequest(r runtime.ClientRequest, reg s
 	qrLoginChallenge := o.LoginChallenge
 	qLoginChallenge := qrLoginChallenge
 	if qLoginChallenge != "" {
+
 		if err := r.SetQueryParam("login_challenge", qLoginChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/reject_login_request_responses.go
+++ b/internal/httpclient/client/admin/reject_login_request_responses.go
@@ -53,9 +53,8 @@ func (o *RejectLoginRequestReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -64,7 +63,7 @@ func NewRejectLoginRequestOK() *RejectLoginRequestOK {
 	return &RejectLoginRequestOK{}
 }
 
-/*RejectLoginRequestOK handles this case with default header values.
+/* RejectLoginRequestOK describes a response with status code 200, with default header values.
 
 completedRequest
 */
@@ -75,7 +74,6 @@ type RejectLoginRequestOK struct {
 func (o *RejectLoginRequestOK) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/reject][%d] rejectLoginRequestOK  %+v", 200, o.Payload)
 }
-
 func (o *RejectLoginRequestOK) GetPayload() *models.CompletedRequest {
 	return o.Payload
 }
@@ -97,7 +95,7 @@ func NewRejectLoginRequestBadRequest() *RejectLoginRequestBadRequest {
 	return &RejectLoginRequestBadRequest{}
 }
 
-/*RejectLoginRequestBadRequest handles this case with default header values.
+/* RejectLoginRequestBadRequest describes a response with status code 400, with default header values.
 
 jsonError
 */
@@ -108,7 +106,6 @@ type RejectLoginRequestBadRequest struct {
 func (o *RejectLoginRequestBadRequest) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/reject][%d] rejectLoginRequestBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *RejectLoginRequestBadRequest) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -130,7 +127,7 @@ func NewRejectLoginRequestUnauthorized() *RejectLoginRequestUnauthorized {
 	return &RejectLoginRequestUnauthorized{}
 }
 
-/*RejectLoginRequestUnauthorized handles this case with default header values.
+/* RejectLoginRequestUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -141,7 +138,6 @@ type RejectLoginRequestUnauthorized struct {
 func (o *RejectLoginRequestUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/reject][%d] rejectLoginRequestUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *RejectLoginRequestUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -163,7 +159,7 @@ func NewRejectLoginRequestNotFound() *RejectLoginRequestNotFound {
 	return &RejectLoginRequestNotFound{}
 }
 
-/*RejectLoginRequestNotFound handles this case with default header values.
+/* RejectLoginRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -174,7 +170,6 @@ type RejectLoginRequestNotFound struct {
 func (o *RejectLoginRequestNotFound) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/reject][%d] rejectLoginRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *RejectLoginRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -196,7 +191,7 @@ func NewRejectLoginRequestInternalServerError() *RejectLoginRequestInternalServe
 	return &RejectLoginRequestInternalServerError{}
 }
 
-/*RejectLoginRequestInternalServerError handles this case with default header values.
+/* RejectLoginRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -207,7 +202,6 @@ type RejectLoginRequestInternalServerError struct {
 func (o *RejectLoginRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/login/reject][%d] rejectLoginRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *RejectLoginRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/reject_logout_request_parameters.go
+++ b/internal/httpclient/client/admin/reject_logout_request_parameters.go
@@ -18,58 +18,73 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewRejectLogoutRequestParams creates a new RejectLogoutRequestParams object
-// with the default values initialized.
+// NewRejectLogoutRequestParams creates a new RejectLogoutRequestParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewRejectLogoutRequestParams() *RejectLogoutRequestParams {
-	var ()
 	return &RejectLogoutRequestParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewRejectLogoutRequestParamsWithTimeout creates a new RejectLogoutRequestParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewRejectLogoutRequestParamsWithTimeout(timeout time.Duration) *RejectLogoutRequestParams {
-	var ()
 	return &RejectLogoutRequestParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewRejectLogoutRequestParamsWithContext creates a new RejectLogoutRequestParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewRejectLogoutRequestParamsWithContext(ctx context.Context) *RejectLogoutRequestParams {
-	var ()
 	return &RejectLogoutRequestParams{
-
 		Context: ctx,
 	}
 }
 
 // NewRejectLogoutRequestParamsWithHTTPClient creates a new RejectLogoutRequestParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewRejectLogoutRequestParamsWithHTTPClient(client *http.Client) *RejectLogoutRequestParams {
-	var ()
 	return &RejectLogoutRequestParams{
 		HTTPClient: client,
 	}
 }
 
-/*RejectLogoutRequestParams contains all the parameters to send to the API endpoint
-for the reject logout request operation typically these are written to a http.Request
+/* RejectLogoutRequestParams contains all the parameters to send to the API endpoint
+   for the reject logout request operation.
+
+   Typically these are written to a http.Request.
 */
 type RejectLogoutRequestParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.RejectRequest
-	/*LogoutChallenge*/
+
+	// LogoutChallenge.
 	LogoutChallenge string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the reject logout request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RejectLogoutRequestParams) WithDefaults() *RejectLogoutRequestParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the reject logout request params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RejectLogoutRequestParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the reject logout request params
@@ -134,7 +149,6 @@ func (o *RejectLogoutRequestParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err
@@ -145,6 +159,7 @@ func (o *RejectLogoutRequestParams) WriteToRequest(r runtime.ClientRequest, reg 
 	qrLogoutChallenge := o.LogoutChallenge
 	qLogoutChallenge := qrLogoutChallenge
 	if qLogoutChallenge != "" {
+
 		if err := r.SetQueryParam("logout_challenge", qLogoutChallenge); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/reject_logout_request_responses.go
+++ b/internal/httpclient/client/admin/reject_logout_request_responses.go
@@ -41,9 +41,8 @@ func (o *RejectLogoutRequestReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewRejectLogoutRequestNoContent() *RejectLogoutRequestNoContent {
 	return &RejectLogoutRequestNoContent{}
 }
 
-/*RejectLogoutRequestNoContent handles this case with default header values.
+/* RejectLogoutRequestNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type RejectLogoutRequestNoContent struct {
@@ -74,7 +73,7 @@ func NewRejectLogoutRequestNotFound() *RejectLogoutRequestNotFound {
 	return &RejectLogoutRequestNotFound{}
 }
 
-/*RejectLogoutRequestNotFound handles this case with default header values.
+/* RejectLogoutRequestNotFound describes a response with status code 404, with default header values.
 
 jsonError
 */
@@ -85,7 +84,6 @@ type RejectLogoutRequestNotFound struct {
 func (o *RejectLogoutRequestNotFound) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/logout/reject][%d] rejectLogoutRequestNotFound  %+v", 404, o.Payload)
 }
-
 func (o *RejectLogoutRequestNotFound) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewRejectLogoutRequestInternalServerError() *RejectLogoutRequestInternalSer
 	return &RejectLogoutRequestInternalServerError{}
 }
 
-/*RejectLogoutRequestInternalServerError handles this case with default header values.
+/* RejectLogoutRequestInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -118,7 +116,6 @@ type RejectLogoutRequestInternalServerError struct {
 func (o *RejectLogoutRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /oauth2/auth/requests/logout/reject][%d] rejectLogoutRequestInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *RejectLogoutRequestInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/revoke_authentication_session_parameters.go
+++ b/internal/httpclient/client/admin/revoke_authentication_session_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewRevokeAuthenticationSessionParams creates a new RevokeAuthenticationSessionParams object
-// with the default values initialized.
+// NewRevokeAuthenticationSessionParams creates a new RevokeAuthenticationSessionParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewRevokeAuthenticationSessionParams() *RevokeAuthenticationSessionParams {
-	var ()
 	return &RevokeAuthenticationSessionParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewRevokeAuthenticationSessionParamsWithTimeout creates a new RevokeAuthenticationSessionParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewRevokeAuthenticationSessionParamsWithTimeout(timeout time.Duration) *RevokeAuthenticationSessionParams {
-	var ()
 	return &RevokeAuthenticationSessionParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewRevokeAuthenticationSessionParamsWithContext creates a new RevokeAuthenticationSessionParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewRevokeAuthenticationSessionParamsWithContext(ctx context.Context) *RevokeAuthenticationSessionParams {
-	var ()
 	return &RevokeAuthenticationSessionParams{
-
 		Context: ctx,
 	}
 }
 
 // NewRevokeAuthenticationSessionParamsWithHTTPClient creates a new RevokeAuthenticationSessionParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewRevokeAuthenticationSessionParamsWithHTTPClient(client *http.Client) *RevokeAuthenticationSessionParams {
-	var ()
 	return &RevokeAuthenticationSessionParams{
 		HTTPClient: client,
 	}
 }
 
-/*RevokeAuthenticationSessionParams contains all the parameters to send to the API endpoint
-for the revoke authentication session operation typically these are written to a http.Request
+/* RevokeAuthenticationSessionParams contains all the parameters to send to the API endpoint
+   for the revoke authentication session operation.
+
+   Typically these are written to a http.Request.
 */
 type RevokeAuthenticationSessionParams struct {
 
-	/*Subject*/
+	// Subject.
 	Subject string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the revoke authentication session params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RevokeAuthenticationSessionParams) WithDefaults() *RevokeAuthenticationSessionParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the revoke authentication session params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RevokeAuthenticationSessionParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the revoke authentication session params
@@ -124,6 +138,7 @@ func (o *RevokeAuthenticationSessionParams) WriteToRequest(r runtime.ClientReque
 	qrSubject := o.Subject
 	qSubject := qrSubject
 	if qSubject != "" {
+
 		if err := r.SetQueryParam("subject", qSubject); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/revoke_authentication_session_responses.go
+++ b/internal/httpclient/client/admin/revoke_authentication_session_responses.go
@@ -41,9 +41,8 @@ func (o *RevokeAuthenticationSessionReader) ReadResponse(response runtime.Client
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewRevokeAuthenticationSessionNoContent() *RevokeAuthenticationSessionNoCon
 	return &RevokeAuthenticationSessionNoContent{}
 }
 
-/*RevokeAuthenticationSessionNoContent handles this case with default header values.
+/* RevokeAuthenticationSessionNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type RevokeAuthenticationSessionNoContent struct {
@@ -74,7 +73,7 @@ func NewRevokeAuthenticationSessionBadRequest() *RevokeAuthenticationSessionBadR
 	return &RevokeAuthenticationSessionBadRequest{}
 }
 
-/*RevokeAuthenticationSessionBadRequest handles this case with default header values.
+/* RevokeAuthenticationSessionBadRequest describes a response with status code 400, with default header values.
 
 jsonError
 */
@@ -85,7 +84,6 @@ type RevokeAuthenticationSessionBadRequest struct {
 func (o *RevokeAuthenticationSessionBadRequest) Error() string {
 	return fmt.Sprintf("[DELETE /oauth2/auth/sessions/login][%d] revokeAuthenticationSessionBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *RevokeAuthenticationSessionBadRequest) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewRevokeAuthenticationSessionInternalServerError() *RevokeAuthenticationSe
 	return &RevokeAuthenticationSessionInternalServerError{}
 }
 
-/*RevokeAuthenticationSessionInternalServerError handles this case with default header values.
+/* RevokeAuthenticationSessionInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -118,7 +116,6 @@ type RevokeAuthenticationSessionInternalServerError struct {
 func (o *RevokeAuthenticationSessionInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /oauth2/auth/sessions/login][%d] revokeAuthenticationSessionInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *RevokeAuthenticationSessionInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
+++ b/internal/httpclient/client/admin/revoke_consent_sessions_parameters.go
@@ -17,69 +17,85 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// NewRevokeConsentSessionsParams creates a new RevokeConsentSessionsParams object
-// with the default values initialized.
+// NewRevokeConsentSessionsParams creates a new RevokeConsentSessionsParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewRevokeConsentSessionsParams() *RevokeConsentSessionsParams {
-	var ()
 	return &RevokeConsentSessionsParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewRevokeConsentSessionsParamsWithTimeout creates a new RevokeConsentSessionsParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewRevokeConsentSessionsParamsWithTimeout(timeout time.Duration) *RevokeConsentSessionsParams {
-	var ()
 	return &RevokeConsentSessionsParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewRevokeConsentSessionsParamsWithContext creates a new RevokeConsentSessionsParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewRevokeConsentSessionsParamsWithContext(ctx context.Context) *RevokeConsentSessionsParams {
-	var ()
 	return &RevokeConsentSessionsParams{
-
 		Context: ctx,
 	}
 }
 
 // NewRevokeConsentSessionsParamsWithHTTPClient creates a new RevokeConsentSessionsParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewRevokeConsentSessionsParamsWithHTTPClient(client *http.Client) *RevokeConsentSessionsParams {
-	var ()
 	return &RevokeConsentSessionsParams{
 		HTTPClient: client,
 	}
 }
 
-/*RevokeConsentSessionsParams contains all the parameters to send to the API endpoint
-for the revoke consent sessions operation typically these are written to a http.Request
+/* RevokeConsentSessionsParams contains all the parameters to send to the API endpoint
+   for the revoke consent sessions operation.
+
+   Typically these are written to a http.Request.
 */
 type RevokeConsentSessionsParams struct {
 
-	/*All
-	  If set to `?all=true`, deletes all consent sessions by the Subject that have been granted.
+	/* All.
 
+	   If set to `?all=true`, deletes all consent sessions by the Subject that have been granted.
 	*/
 	All *bool
-	/*Client
-	  If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID
 
+	/* Client.
+
+	   If set, deletes only those consent sessions by the Subject that have been granted to the specified OAuth 2.0 Client ID
 	*/
 	Client *string
-	/*Subject
-	  The subject (Subject) who's consent sessions should be deleted.
 
+	/* Subject.
+
+	   The subject (Subject) who's consent sessions should be deleted.
 	*/
 	Subject string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the revoke consent sessions params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RevokeConsentSessionsParams) WithDefaults() *RevokeConsentSessionsParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the revoke consent sessions params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RevokeConsentSessionsParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the revoke consent sessions params
@@ -160,38 +176,41 @@ func (o *RevokeConsentSessionsParams) WriteToRequest(r runtime.ClientRequest, re
 
 		// query param all
 		var qrAll bool
+
 		if o.All != nil {
 			qrAll = *o.All
 		}
 		qAll := swag.FormatBool(qrAll)
 		if qAll != "" {
+
 			if err := r.SetQueryParam("all", qAll); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	if o.Client != nil {
 
 		// query param client
 		var qrClient string
+
 		if o.Client != nil {
 			qrClient = *o.Client
 		}
 		qClient := qrClient
 		if qClient != "" {
+
 			if err := r.SetQueryParam("client", qClient); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	// query param subject
 	qrSubject := o.Subject
 	qSubject := qrSubject
 	if qSubject != "" {
+
 		if err := r.SetQueryParam("subject", qSubject); err != nil {
 			return err
 		}

--- a/internal/httpclient/client/admin/revoke_consent_sessions_responses.go
+++ b/internal/httpclient/client/admin/revoke_consent_sessions_responses.go
@@ -41,9 +41,8 @@ func (o *RevokeConsentSessionsReader) ReadResponse(response runtime.ClientRespon
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewRevokeConsentSessionsNoContent() *RevokeConsentSessionsNoContent {
 	return &RevokeConsentSessionsNoContent{}
 }
 
-/*RevokeConsentSessionsNoContent handles this case with default header values.
+/* RevokeConsentSessionsNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type RevokeConsentSessionsNoContent struct {
@@ -74,7 +73,7 @@ func NewRevokeConsentSessionsBadRequest() *RevokeConsentSessionsBadRequest {
 	return &RevokeConsentSessionsBadRequest{}
 }
 
-/*RevokeConsentSessionsBadRequest handles this case with default header values.
+/* RevokeConsentSessionsBadRequest describes a response with status code 400, with default header values.
 
 jsonError
 */
@@ -85,7 +84,6 @@ type RevokeConsentSessionsBadRequest struct {
 func (o *RevokeConsentSessionsBadRequest) Error() string {
 	return fmt.Sprintf("[DELETE /oauth2/auth/sessions/consent][%d] revokeConsentSessionsBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *RevokeConsentSessionsBadRequest) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewRevokeConsentSessionsInternalServerError() *RevokeConsentSessionsInterna
 	return &RevokeConsentSessionsInternalServerError{}
 }
 
-/*RevokeConsentSessionsInternalServerError handles this case with default header values.
+/* RevokeConsentSessionsInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -118,7 +116,6 @@ type RevokeConsentSessionsInternalServerError struct {
 func (o *RevokeConsentSessionsInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /oauth2/auth/sessions/consent][%d] revokeConsentSessionsInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *RevokeConsentSessionsInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/trust_jwt_grant_issuer_parameters.go
+++ b/internal/httpclient/client/admin/trust_jwt_grant_issuer_parameters.go
@@ -18,56 +18,70 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewTrustJwtGrantIssuerParams creates a new TrustJwtGrantIssuerParams object
-// with the default values initialized.
+// NewTrustJwtGrantIssuerParams creates a new TrustJwtGrantIssuerParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewTrustJwtGrantIssuerParams() *TrustJwtGrantIssuerParams {
-	var ()
 	return &TrustJwtGrantIssuerParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewTrustJwtGrantIssuerParamsWithTimeout creates a new TrustJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewTrustJwtGrantIssuerParamsWithTimeout(timeout time.Duration) *TrustJwtGrantIssuerParams {
-	var ()
 	return &TrustJwtGrantIssuerParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewTrustJwtGrantIssuerParamsWithContext creates a new TrustJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewTrustJwtGrantIssuerParamsWithContext(ctx context.Context) *TrustJwtGrantIssuerParams {
-	var ()
 	return &TrustJwtGrantIssuerParams{
-
 		Context: ctx,
 	}
 }
 
 // NewTrustJwtGrantIssuerParamsWithHTTPClient creates a new TrustJwtGrantIssuerParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewTrustJwtGrantIssuerParamsWithHTTPClient(client *http.Client) *TrustJwtGrantIssuerParams {
-	var ()
 	return &TrustJwtGrantIssuerParams{
 		HTTPClient: client,
 	}
 }
 
-/*TrustJwtGrantIssuerParams contains all the parameters to send to the API endpoint
-for the trust jwt grant issuer operation typically these are written to a http.Request
+/* TrustJwtGrantIssuerParams contains all the parameters to send to the API endpoint
+   for the trust jwt grant issuer operation.
+
+   Typically these are written to a http.Request.
 */
 type TrustJwtGrantIssuerParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.TrustJwtGrantIssuerBody
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the trust jwt grant issuer params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *TrustJwtGrantIssuerParams) WithDefaults() *TrustJwtGrantIssuerParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the trust jwt grant issuer params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *TrustJwtGrantIssuerParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the trust jwt grant issuer params
@@ -121,7 +135,6 @@ func (o *TrustJwtGrantIssuerParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/trust_jwt_grant_issuer_responses.go
+++ b/internal/httpclient/client/admin/trust_jwt_grant_issuer_responses.go
@@ -47,9 +47,8 @@ func (o *TrustJwtGrantIssuerReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewTrustJwtGrantIssuerCreated() *TrustJwtGrantIssuerCreated {
 	return &TrustJwtGrantIssuerCreated{}
 }
 
-/*TrustJwtGrantIssuerCreated handles this case with default header values.
+/* TrustJwtGrantIssuerCreated describes a response with status code 201, with default header values.
 
 trustedJwtGrantIssuer
 */
@@ -69,7 +68,6 @@ type TrustJwtGrantIssuerCreated struct {
 func (o *TrustJwtGrantIssuerCreated) Error() string {
 	return fmt.Sprintf("[POST /trust/grants/jwt-bearer/issuers][%d] trustJwtGrantIssuerCreated  %+v", 201, o.Payload)
 }
-
 func (o *TrustJwtGrantIssuerCreated) GetPayload() *models.TrustedJwtGrantIssuer {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewTrustJwtGrantIssuerBadRequest() *TrustJwtGrantIssuerBadRequest {
 	return &TrustJwtGrantIssuerBadRequest{}
 }
 
-/*TrustJwtGrantIssuerBadRequest handles this case with default header values.
+/* TrustJwtGrantIssuerBadRequest describes a response with status code 400, with default header values.
 
 genericError
 */
@@ -102,7 +100,6 @@ type TrustJwtGrantIssuerBadRequest struct {
 func (o *TrustJwtGrantIssuerBadRequest) Error() string {
 	return fmt.Sprintf("[POST /trust/grants/jwt-bearer/issuers][%d] trustJwtGrantIssuerBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *TrustJwtGrantIssuerBadRequest) GetPayload() *models.GenericError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewTrustJwtGrantIssuerConflict() *TrustJwtGrantIssuerConflict {
 	return &TrustJwtGrantIssuerConflict{}
 }
 
-/*TrustJwtGrantIssuerConflict handles this case with default header values.
+/* TrustJwtGrantIssuerConflict describes a response with status code 409, with default header values.
 
 genericError
 */
@@ -135,7 +132,6 @@ type TrustJwtGrantIssuerConflict struct {
 func (o *TrustJwtGrantIssuerConflict) Error() string {
 	return fmt.Sprintf("[POST /trust/grants/jwt-bearer/issuers][%d] trustJwtGrantIssuerConflict  %+v", 409, o.Payload)
 }
-
 func (o *TrustJwtGrantIssuerConflict) GetPayload() *models.GenericError {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewTrustJwtGrantIssuerInternalServerError() *TrustJwtGrantIssuerInternalSer
 	return &TrustJwtGrantIssuerInternalServerError{}
 }
 
-/*TrustJwtGrantIssuerInternalServerError handles this case with default header values.
+/* TrustJwtGrantIssuerInternalServerError describes a response with status code 500, with default header values.
 
 genericError
 */
@@ -168,7 +164,6 @@ type TrustJwtGrantIssuerInternalServerError struct {
 func (o *TrustJwtGrantIssuerInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /trust/grants/jwt-bearer/issuers][%d] trustJwtGrantIssuerInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *TrustJwtGrantIssuerInternalServerError) GetPayload() *models.GenericError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/update_json_web_key_parameters.go
+++ b/internal/httpclient/client/admin/update_json_web_key_parameters.go
@@ -18,66 +18,82 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewUpdateJSONWebKeyParams creates a new UpdateJSONWebKeyParams object
-// with the default values initialized.
+// NewUpdateJSONWebKeyParams creates a new UpdateJSONWebKeyParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewUpdateJSONWebKeyParams() *UpdateJSONWebKeyParams {
-	var ()
 	return &UpdateJSONWebKeyParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewUpdateJSONWebKeyParamsWithTimeout creates a new UpdateJSONWebKeyParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewUpdateJSONWebKeyParamsWithTimeout(timeout time.Duration) *UpdateJSONWebKeyParams {
-	var ()
 	return &UpdateJSONWebKeyParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewUpdateJSONWebKeyParamsWithContext creates a new UpdateJSONWebKeyParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewUpdateJSONWebKeyParamsWithContext(ctx context.Context) *UpdateJSONWebKeyParams {
-	var ()
 	return &UpdateJSONWebKeyParams{
-
 		Context: ctx,
 	}
 }
 
 // NewUpdateJSONWebKeyParamsWithHTTPClient creates a new UpdateJSONWebKeyParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewUpdateJSONWebKeyParamsWithHTTPClient(client *http.Client) *UpdateJSONWebKeyParams {
-	var ()
 	return &UpdateJSONWebKeyParams{
 		HTTPClient: client,
 	}
 }
 
-/*UpdateJSONWebKeyParams contains all the parameters to send to the API endpoint
-for the update Json web key operation typically these are written to a http.Request
+/* UpdateJSONWebKeyParams contains all the parameters to send to the API endpoint
+   for the update Json web key operation.
+
+   Typically these are written to a http.Request.
 */
 type UpdateJSONWebKeyParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.JSONWebKey
-	/*Kid
-	  The kid of the desired key
 
+	/* Kid.
+
+	   The kid of the desired key
 	*/
 	Kid string
-	/*Set
-	  The set
 
+	/* Set.
+
+	   The set
 	*/
 	Set string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the update Json web key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UpdateJSONWebKeyParams) WithDefaults() *UpdateJSONWebKeyParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the update Json web key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UpdateJSONWebKeyParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the update Json web key params
@@ -153,7 +169,6 @@ func (o *UpdateJSONWebKeyParams) WriteToRequest(r runtime.ClientRequest, reg str
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/update_json_web_key_responses.go
+++ b/internal/httpclient/client/admin/update_json_web_key_responses.go
@@ -47,9 +47,8 @@ func (o *UpdateJSONWebKeyReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewUpdateJSONWebKeyOK() *UpdateJSONWebKeyOK {
 	return &UpdateJSONWebKeyOK{}
 }
 
-/*UpdateJSONWebKeyOK handles this case with default header values.
+/* UpdateJSONWebKeyOK describes a response with status code 200, with default header values.
 
 JSONWebKey
 */
@@ -69,7 +68,6 @@ type UpdateJSONWebKeyOK struct {
 func (o *UpdateJSONWebKeyOK) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}/{kid}][%d] updateJsonWebKeyOK  %+v", 200, o.Payload)
 }
-
 func (o *UpdateJSONWebKeyOK) GetPayload() *models.JSONWebKey {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewUpdateJSONWebKeyUnauthorized() *UpdateJSONWebKeyUnauthorized {
 	return &UpdateJSONWebKeyUnauthorized{}
 }
 
-/*UpdateJSONWebKeyUnauthorized handles this case with default header values.
+/* UpdateJSONWebKeyUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -102,7 +100,6 @@ type UpdateJSONWebKeyUnauthorized struct {
 func (o *UpdateJSONWebKeyUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}/{kid}][%d] updateJsonWebKeyUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *UpdateJSONWebKeyUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewUpdateJSONWebKeyForbidden() *UpdateJSONWebKeyForbidden {
 	return &UpdateJSONWebKeyForbidden{}
 }
 
-/*UpdateJSONWebKeyForbidden handles this case with default header values.
+/* UpdateJSONWebKeyForbidden describes a response with status code 403, with default header values.
 
 jsonError
 */
@@ -135,7 +132,6 @@ type UpdateJSONWebKeyForbidden struct {
 func (o *UpdateJSONWebKeyForbidden) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}/{kid}][%d] updateJsonWebKeyForbidden  %+v", 403, o.Payload)
 }
-
 func (o *UpdateJSONWebKeyForbidden) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewUpdateJSONWebKeyInternalServerError() *UpdateJSONWebKeyInternalServerErr
 	return &UpdateJSONWebKeyInternalServerError{}
 }
 
-/*UpdateJSONWebKeyInternalServerError handles this case with default header values.
+/* UpdateJSONWebKeyInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -168,7 +164,6 @@ type UpdateJSONWebKeyInternalServerError struct {
 func (o *UpdateJSONWebKeyInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}/{kid}][%d] updateJsonWebKeyInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *UpdateJSONWebKeyInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/update_json_web_key_set_parameters.go
+++ b/internal/httpclient/client/admin/update_json_web_key_set_parameters.go
@@ -18,61 +18,76 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewUpdateJSONWebKeySetParams creates a new UpdateJSONWebKeySetParams object
-// with the default values initialized.
+// NewUpdateJSONWebKeySetParams creates a new UpdateJSONWebKeySetParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewUpdateJSONWebKeySetParams() *UpdateJSONWebKeySetParams {
-	var ()
 	return &UpdateJSONWebKeySetParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewUpdateJSONWebKeySetParamsWithTimeout creates a new UpdateJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewUpdateJSONWebKeySetParamsWithTimeout(timeout time.Duration) *UpdateJSONWebKeySetParams {
-	var ()
 	return &UpdateJSONWebKeySetParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewUpdateJSONWebKeySetParamsWithContext creates a new UpdateJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewUpdateJSONWebKeySetParamsWithContext(ctx context.Context) *UpdateJSONWebKeySetParams {
-	var ()
 	return &UpdateJSONWebKeySetParams{
-
 		Context: ctx,
 	}
 }
 
 // NewUpdateJSONWebKeySetParamsWithHTTPClient creates a new UpdateJSONWebKeySetParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewUpdateJSONWebKeySetParamsWithHTTPClient(client *http.Client) *UpdateJSONWebKeySetParams {
-	var ()
 	return &UpdateJSONWebKeySetParams{
 		HTTPClient: client,
 	}
 }
 
-/*UpdateJSONWebKeySetParams contains all the parameters to send to the API endpoint
-for the update Json web key set operation typically these are written to a http.Request
+/* UpdateJSONWebKeySetParams contains all the parameters to send to the API endpoint
+   for the update Json web key set operation.
+
+   Typically these are written to a http.Request.
 */
 type UpdateJSONWebKeySetParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.JSONWebKeySet
-	/*Set
-	  The set
 
+	/* Set.
+
+	   The set
 	*/
 	Set string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the update Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UpdateJSONWebKeySetParams) WithDefaults() *UpdateJSONWebKeySetParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the update Json web key set params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UpdateJSONWebKeySetParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the update Json web key set params
@@ -137,7 +152,6 @@ func (o *UpdateJSONWebKeySetParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/update_json_web_key_set_responses.go
+++ b/internal/httpclient/client/admin/update_json_web_key_set_responses.go
@@ -47,9 +47,8 @@ func (o *UpdateJSONWebKeySetReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewUpdateJSONWebKeySetOK() *UpdateJSONWebKeySetOK {
 	return &UpdateJSONWebKeySetOK{}
 }
 
-/*UpdateJSONWebKeySetOK handles this case with default header values.
+/* UpdateJSONWebKeySetOK describes a response with status code 200, with default header values.
 
 JSONWebKeySet
 */
@@ -69,7 +68,6 @@ type UpdateJSONWebKeySetOK struct {
 func (o *UpdateJSONWebKeySetOK) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}][%d] updateJsonWebKeySetOK  %+v", 200, o.Payload)
 }
-
 func (o *UpdateJSONWebKeySetOK) GetPayload() *models.JSONWebKeySet {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewUpdateJSONWebKeySetUnauthorized() *UpdateJSONWebKeySetUnauthorized {
 	return &UpdateJSONWebKeySetUnauthorized{}
 }
 
-/*UpdateJSONWebKeySetUnauthorized handles this case with default header values.
+/* UpdateJSONWebKeySetUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -102,7 +100,6 @@ type UpdateJSONWebKeySetUnauthorized struct {
 func (o *UpdateJSONWebKeySetUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}][%d] updateJsonWebKeySetUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *UpdateJSONWebKeySetUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewUpdateJSONWebKeySetForbidden() *UpdateJSONWebKeySetForbidden {
 	return &UpdateJSONWebKeySetForbidden{}
 }
 
-/*UpdateJSONWebKeySetForbidden handles this case with default header values.
+/* UpdateJSONWebKeySetForbidden describes a response with status code 403, with default header values.
 
 jsonError
 */
@@ -135,7 +132,6 @@ type UpdateJSONWebKeySetForbidden struct {
 func (o *UpdateJSONWebKeySetForbidden) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}][%d] updateJsonWebKeySetForbidden  %+v", 403, o.Payload)
 }
-
 func (o *UpdateJSONWebKeySetForbidden) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewUpdateJSONWebKeySetInternalServerError() *UpdateJSONWebKeySetInternalSer
 	return &UpdateJSONWebKeySetInternalServerError{}
 }
 
-/*UpdateJSONWebKeySetInternalServerError handles this case with default header values.
+/* UpdateJSONWebKeySetInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -168,7 +164,6 @@ type UpdateJSONWebKeySetInternalServerError struct {
 func (o *UpdateJSONWebKeySetInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /keys/{set}][%d] updateJsonWebKeySetInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *UpdateJSONWebKeySetInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/admin/update_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/admin/update_o_auth2_client_parameters.go
@@ -18,61 +18,76 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewUpdateOAuth2ClientParams creates a new UpdateOAuth2ClientParams object
-// with the default values initialized.
+// NewUpdateOAuth2ClientParams creates a new UpdateOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewUpdateOAuth2ClientParams() *UpdateOAuth2ClientParams {
-	var ()
 	return &UpdateOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewUpdateOAuth2ClientParamsWithTimeout creates a new UpdateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewUpdateOAuth2ClientParamsWithTimeout(timeout time.Duration) *UpdateOAuth2ClientParams {
-	var ()
 	return &UpdateOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewUpdateOAuth2ClientParamsWithContext creates a new UpdateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewUpdateOAuth2ClientParamsWithContext(ctx context.Context) *UpdateOAuth2ClientParams {
-	var ()
 	return &UpdateOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewUpdateOAuth2ClientParamsWithHTTPClient creates a new UpdateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewUpdateOAuth2ClientParamsWithHTTPClient(client *http.Client) *UpdateOAuth2ClientParams {
-	var ()
 	return &UpdateOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*UpdateOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the update o auth2 client operation typically these are written to a http.Request
+/* UpdateOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the update o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type UpdateOAuth2ClientParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.OAuth2Client
-	/*ID
-	  The id of the OAuth 2.0 Client.
 
+	/* ID.
+
+	   The id of the OAuth 2.0 Client.
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the update o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UpdateOAuth2ClientParams) WithDefaults() *UpdateOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the update o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UpdateOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the update o auth2 client params
@@ -137,7 +152,6 @@ func (o *UpdateOAuth2ClientParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/admin/update_o_auth2_client_responses.go
+++ b/internal/httpclient/client/admin/update_o_auth2_client_responses.go
@@ -46,7 +46,7 @@ func NewUpdateOAuth2ClientOK() *UpdateOAuth2ClientOK {
 	return &UpdateOAuth2ClientOK{}
 }
 
-/*UpdateOAuth2ClientOK handles this case with default header values.
+/* UpdateOAuth2ClientOK describes a response with status code 200, with default header values.
 
 oAuth2Client
 */
@@ -57,7 +57,6 @@ type UpdateOAuth2ClientOK struct {
 func (o *UpdateOAuth2ClientOK) Error() string {
 	return fmt.Sprintf("[PUT /clients/{id}][%d] updateOAuth2ClientOK  %+v", 200, o.Payload)
 }
-
 func (o *UpdateOAuth2ClientOK) GetPayload() *models.OAuth2Client {
 	return o.Payload
 }
@@ -81,7 +80,7 @@ func NewUpdateOAuth2ClientDefault(code int) *UpdateOAuth2ClientDefault {
 	}
 }
 
-/*UpdateOAuth2ClientDefault handles this case with default header values.
+/* UpdateOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -99,7 +98,6 @@ func (o *UpdateOAuth2ClientDefault) Code() int {
 func (o *UpdateOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[PUT /clients/{id}][%d] updateOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *UpdateOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/metadata/prometheus_parameters.go
+++ b/internal/httpclient/client/metadata/prometheus_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewPrometheusParams creates a new PrometheusParams object
-// with the default values initialized.
+// NewPrometheusParams creates a new PrometheusParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewPrometheusParams() *PrometheusParams {
-
 	return &PrometheusParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewPrometheusParamsWithTimeout creates a new PrometheusParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewPrometheusParamsWithTimeout(timeout time.Duration) *PrometheusParams {
-
 	return &PrometheusParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewPrometheusParamsWithContext creates a new PrometheusParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewPrometheusParamsWithContext(ctx context.Context) *PrometheusParams {
-
 	return &PrometheusParams{
-
 		Context: ctx,
 	}
 }
 
 // NewPrometheusParamsWithHTTPClient creates a new PrometheusParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewPrometheusParamsWithHTTPClient(client *http.Client) *PrometheusParams {
-
 	return &PrometheusParams{
 		HTTPClient: client,
 	}
 }
 
-/*PrometheusParams contains all the parameters to send to the API endpoint
-for the prometheus operation typically these are written to a http.Request
+/* PrometheusParams contains all the parameters to send to the API endpoint
+   for the prometheus operation.
+
+   Typically these are written to a http.Request.
 */
 type PrometheusParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the prometheus params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *PrometheusParams) WithDefaults() *PrometheusParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the prometheus params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *PrometheusParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the prometheus params

--- a/internal/httpclient/client/metadata/prometheus_responses.go
+++ b/internal/httpclient/client/metadata/prometheus_responses.go
@@ -26,9 +26,8 @@ func (o *PrometheusReader) ReadResponse(response runtime.ClientResponse, consume
 			return nil, err
 		}
 		return result, nil
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -37,9 +36,9 @@ func NewPrometheusOK() *PrometheusOK {
 	return &PrometheusOK{}
 }
 
-/*PrometheusOK handles this case with default header values.
+/* PrometheusOK describes a response with status code 200, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type PrometheusOK struct {

--- a/internal/httpclient/client/public/disconnect_user_parameters.go
+++ b/internal/httpclient/client/public/disconnect_user_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDisconnectUserParams creates a new DisconnectUserParams object
-// with the default values initialized.
+// NewDisconnectUserParams creates a new DisconnectUserParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDisconnectUserParams() *DisconnectUserParams {
-
 	return &DisconnectUserParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDisconnectUserParamsWithTimeout creates a new DisconnectUserParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDisconnectUserParamsWithTimeout(timeout time.Duration) *DisconnectUserParams {
-
 	return &DisconnectUserParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDisconnectUserParamsWithContext creates a new DisconnectUserParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDisconnectUserParamsWithContext(ctx context.Context) *DisconnectUserParams {
-
 	return &DisconnectUserParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDisconnectUserParamsWithHTTPClient creates a new DisconnectUserParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDisconnectUserParamsWithHTTPClient(client *http.Client) *DisconnectUserParams {
-
 	return &DisconnectUserParams{
 		HTTPClient: client,
 	}
 }
 
-/*DisconnectUserParams contains all the parameters to send to the API endpoint
-for the disconnect user operation typically these are written to a http.Request
+/* DisconnectUserParams contains all the parameters to send to the API endpoint
+   for the disconnect user operation.
+
+   Typically these are written to a http.Request.
 */
 type DisconnectUserParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the disconnect user params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DisconnectUserParams) WithDefaults() *DisconnectUserParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the disconnect user params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DisconnectUserParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the disconnect user params

--- a/internal/httpclient/client/public/disconnect_user_responses.go
+++ b/internal/httpclient/client/public/disconnect_user_responses.go
@@ -26,9 +26,8 @@ func (o *DisconnectUserReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -37,9 +36,9 @@ func NewDisconnectUserFound() *DisconnectUserFound {
 	return &DisconnectUserFound{}
 }
 
-/*DisconnectUserFound handles this case with default header values.
+/* DisconnectUserFound describes a response with status code 302, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type DisconnectUserFound struct {

--- a/internal/httpclient/client/public/discover_open_id_configuration_parameters.go
+++ b/internal/httpclient/client/public/discover_open_id_configuration_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDiscoverOpenIDConfigurationParams creates a new DiscoverOpenIDConfigurationParams object
-// with the default values initialized.
+// NewDiscoverOpenIDConfigurationParams creates a new DiscoverOpenIDConfigurationParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDiscoverOpenIDConfigurationParams() *DiscoverOpenIDConfigurationParams {
-
 	return &DiscoverOpenIDConfigurationParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDiscoverOpenIDConfigurationParamsWithTimeout creates a new DiscoverOpenIDConfigurationParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDiscoverOpenIDConfigurationParamsWithTimeout(timeout time.Duration) *DiscoverOpenIDConfigurationParams {
-
 	return &DiscoverOpenIDConfigurationParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDiscoverOpenIDConfigurationParamsWithContext creates a new DiscoverOpenIDConfigurationParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDiscoverOpenIDConfigurationParamsWithContext(ctx context.Context) *DiscoverOpenIDConfigurationParams {
-
 	return &DiscoverOpenIDConfigurationParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDiscoverOpenIDConfigurationParamsWithHTTPClient creates a new DiscoverOpenIDConfigurationParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDiscoverOpenIDConfigurationParamsWithHTTPClient(client *http.Client) *DiscoverOpenIDConfigurationParams {
-
 	return &DiscoverOpenIDConfigurationParams{
 		HTTPClient: client,
 	}
 }
 
-/*DiscoverOpenIDConfigurationParams contains all the parameters to send to the API endpoint
-for the discover open ID configuration operation typically these are written to a http.Request
+/* DiscoverOpenIDConfigurationParams contains all the parameters to send to the API endpoint
+   for the discover open ID configuration operation.
+
+   Typically these are written to a http.Request.
 */
 type DiscoverOpenIDConfigurationParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the discover open ID configuration params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DiscoverOpenIDConfigurationParams) WithDefaults() *DiscoverOpenIDConfigurationParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the discover open ID configuration params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DiscoverOpenIDConfigurationParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the discover open ID configuration params

--- a/internal/httpclient/client/public/discover_open_id_configuration_responses.go
+++ b/internal/httpclient/client/public/discover_open_id_configuration_responses.go
@@ -41,9 +41,8 @@ func (o *DiscoverOpenIDConfigurationReader) ReadResponse(response runtime.Client
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewDiscoverOpenIDConfigurationOK() *DiscoverOpenIDConfigurationOK {
 	return &DiscoverOpenIDConfigurationOK{}
 }
 
-/*DiscoverOpenIDConfigurationOK handles this case with default header values.
+/* DiscoverOpenIDConfigurationOK describes a response with status code 200, with default header values.
 
 wellKnown
 */
@@ -63,7 +62,6 @@ type DiscoverOpenIDConfigurationOK struct {
 func (o *DiscoverOpenIDConfigurationOK) Error() string {
 	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] discoverOpenIdConfigurationOK  %+v", 200, o.Payload)
 }
-
 func (o *DiscoverOpenIDConfigurationOK) GetPayload() *models.WellKnown {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewDiscoverOpenIDConfigurationUnauthorized() *DiscoverOpenIDConfigurationUn
 	return &DiscoverOpenIDConfigurationUnauthorized{}
 }
 
-/*DiscoverOpenIDConfigurationUnauthorized handles this case with default header values.
+/* DiscoverOpenIDConfigurationUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -96,7 +94,6 @@ type DiscoverOpenIDConfigurationUnauthorized struct {
 func (o *DiscoverOpenIDConfigurationUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] discoverOpenIdConfigurationUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *DiscoverOpenIDConfigurationUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewDiscoverOpenIDConfigurationInternalServerError() *DiscoverOpenIDConfigur
 	return &DiscoverOpenIDConfigurationInternalServerError{}
 }
 
-/*DiscoverOpenIDConfigurationInternalServerError handles this case with default header values.
+/* DiscoverOpenIDConfigurationInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -129,7 +126,6 @@ type DiscoverOpenIDConfigurationInternalServerError struct {
 func (o *DiscoverOpenIDConfigurationInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] discoverOpenIdConfigurationInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *DiscoverOpenIDConfigurationInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/dynamic_client_registration_create_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_create_o_auth2_client_parameters.go
@@ -18,56 +18,70 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewDynamicClientRegistrationCreateOAuth2ClientParams creates a new DynamicClientRegistrationCreateOAuth2ClientParams object
-// with the default values initialized.
+// NewDynamicClientRegistrationCreateOAuth2ClientParams creates a new DynamicClientRegistrationCreateOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDynamicClientRegistrationCreateOAuth2ClientParams() *DynamicClientRegistrationCreateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationCreateOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDynamicClientRegistrationCreateOAuth2ClientParamsWithTimeout creates a new DynamicClientRegistrationCreateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDynamicClientRegistrationCreateOAuth2ClientParamsWithTimeout(timeout time.Duration) *DynamicClientRegistrationCreateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationCreateOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDynamicClientRegistrationCreateOAuth2ClientParamsWithContext creates a new DynamicClientRegistrationCreateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDynamicClientRegistrationCreateOAuth2ClientParamsWithContext(ctx context.Context) *DynamicClientRegistrationCreateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationCreateOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDynamicClientRegistrationCreateOAuth2ClientParamsWithHTTPClient creates a new DynamicClientRegistrationCreateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDynamicClientRegistrationCreateOAuth2ClientParamsWithHTTPClient(client *http.Client) *DynamicClientRegistrationCreateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationCreateOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*DynamicClientRegistrationCreateOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the dynamic client registration create o auth2 client operation typically these are written to a http.Request
+/* DynamicClientRegistrationCreateOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the dynamic client registration create o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type DynamicClientRegistrationCreateOAuth2ClientParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.OAuth2Client
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the dynamic client registration create o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationCreateOAuth2ClientParams) WithDefaults() *DynamicClientRegistrationCreateOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the dynamic client registration create o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationCreateOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the dynamic client registration create o auth2 client params
@@ -121,7 +135,6 @@ func (o *DynamicClientRegistrationCreateOAuth2ClientParams) WriteToRequest(r run
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/public/dynamic_client_registration_create_o_auth2_client_responses.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_create_o_auth2_client_responses.go
@@ -46,7 +46,7 @@ func NewDynamicClientRegistrationCreateOAuth2ClientCreated() *DynamicClientRegis
 	return &DynamicClientRegistrationCreateOAuth2ClientCreated{}
 }
 
-/*DynamicClientRegistrationCreateOAuth2ClientCreated handles this case with default header values.
+/* DynamicClientRegistrationCreateOAuth2ClientCreated describes a response with status code 201, with default header values.
 
 oAuth2Client
 */
@@ -57,7 +57,6 @@ type DynamicClientRegistrationCreateOAuth2ClientCreated struct {
 func (o *DynamicClientRegistrationCreateOAuth2ClientCreated) Error() string {
 	return fmt.Sprintf("[POST /connect/register][%d] dynamicClientRegistrationCreateOAuth2ClientCreated  %+v", 201, o.Payload)
 }
-
 func (o *DynamicClientRegistrationCreateOAuth2ClientCreated) GetPayload() *models.OAuth2Client {
 	return o.Payload
 }
@@ -81,7 +80,7 @@ func NewDynamicClientRegistrationCreateOAuth2ClientDefault(code int) *DynamicCli
 	}
 }
 
-/*DynamicClientRegistrationCreateOAuth2ClientDefault handles this case with default header values.
+/* DynamicClientRegistrationCreateOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -99,7 +98,6 @@ func (o *DynamicClientRegistrationCreateOAuth2ClientDefault) Code() int {
 func (o *DynamicClientRegistrationCreateOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[POST /connect/register][%d] dynamicClientRegistrationCreateOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *DynamicClientRegistrationCreateOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/dynamic_client_registration_delete_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_delete_o_auth2_client_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDynamicClientRegistrationDeleteOAuth2ClientParams creates a new DynamicClientRegistrationDeleteOAuth2ClientParams object
-// with the default values initialized.
+// NewDynamicClientRegistrationDeleteOAuth2ClientParams creates a new DynamicClientRegistrationDeleteOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDynamicClientRegistrationDeleteOAuth2ClientParams() *DynamicClientRegistrationDeleteOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationDeleteOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDynamicClientRegistrationDeleteOAuth2ClientParamsWithTimeout creates a new DynamicClientRegistrationDeleteOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDynamicClientRegistrationDeleteOAuth2ClientParamsWithTimeout(timeout time.Duration) *DynamicClientRegistrationDeleteOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationDeleteOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDynamicClientRegistrationDeleteOAuth2ClientParamsWithContext creates a new DynamicClientRegistrationDeleteOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDynamicClientRegistrationDeleteOAuth2ClientParamsWithContext(ctx context.Context) *DynamicClientRegistrationDeleteOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationDeleteOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDynamicClientRegistrationDeleteOAuth2ClientParamsWithHTTPClient creates a new DynamicClientRegistrationDeleteOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDynamicClientRegistrationDeleteOAuth2ClientParamsWithHTTPClient(client *http.Client) *DynamicClientRegistrationDeleteOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationDeleteOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*DynamicClientRegistrationDeleteOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the dynamic client registration delete o auth2 client operation typically these are written to a http.Request
+/* DynamicClientRegistrationDeleteOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the dynamic client registration delete o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type DynamicClientRegistrationDeleteOAuth2ClientParams struct {
 
-	/*ID
-	  The id of the OAuth 2.0 Client.
+	/* ID.
 
+	   The id of the OAuth 2.0 Client.
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the dynamic client registration delete o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationDeleteOAuth2ClientParams) WithDefaults() *DynamicClientRegistrationDeleteOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the dynamic client registration delete o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationDeleteOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the dynamic client registration delete o auth2 client params

--- a/internal/httpclient/client/public/dynamic_client_registration_delete_o_auth2_client_responses.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_delete_o_auth2_client_responses.go
@@ -46,9 +46,9 @@ func NewDynamicClientRegistrationDeleteOAuth2ClientNoContent() *DynamicClientReg
 	return &DynamicClientRegistrationDeleteOAuth2ClientNoContent{}
 }
 
-/*DynamicClientRegistrationDeleteOAuth2ClientNoContent handles this case with default header values.
+/* DynamicClientRegistrationDeleteOAuth2ClientNoContent describes a response with status code 204, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type DynamicClientRegistrationDeleteOAuth2ClientNoContent struct {
@@ -70,7 +70,7 @@ func NewDynamicClientRegistrationDeleteOAuth2ClientDefault(code int) *DynamicCli
 	}
 }
 
-/*DynamicClientRegistrationDeleteOAuth2ClientDefault handles this case with default header values.
+/* DynamicClientRegistrationDeleteOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -88,7 +88,6 @@ func (o *DynamicClientRegistrationDeleteOAuth2ClientDefault) Code() int {
 func (o *DynamicClientRegistrationDeleteOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[DELETE /connect/register/{id}][%d] dynamicClientRegistrationDeleteOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *DynamicClientRegistrationDeleteOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/dynamic_client_registration_get_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_get_o_auth2_client_parameters.go
@@ -16,59 +16,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewDynamicClientRegistrationGetOAuth2ClientParams creates a new DynamicClientRegistrationGetOAuth2ClientParams object
-// with the default values initialized.
+// NewDynamicClientRegistrationGetOAuth2ClientParams creates a new DynamicClientRegistrationGetOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDynamicClientRegistrationGetOAuth2ClientParams() *DynamicClientRegistrationGetOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationGetOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDynamicClientRegistrationGetOAuth2ClientParamsWithTimeout creates a new DynamicClientRegistrationGetOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDynamicClientRegistrationGetOAuth2ClientParamsWithTimeout(timeout time.Duration) *DynamicClientRegistrationGetOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationGetOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDynamicClientRegistrationGetOAuth2ClientParamsWithContext creates a new DynamicClientRegistrationGetOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDynamicClientRegistrationGetOAuth2ClientParamsWithContext(ctx context.Context) *DynamicClientRegistrationGetOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationGetOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDynamicClientRegistrationGetOAuth2ClientParamsWithHTTPClient creates a new DynamicClientRegistrationGetOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDynamicClientRegistrationGetOAuth2ClientParamsWithHTTPClient(client *http.Client) *DynamicClientRegistrationGetOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationGetOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*DynamicClientRegistrationGetOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the dynamic client registration get o auth2 client operation typically these are written to a http.Request
+/* DynamicClientRegistrationGetOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the dynamic client registration get o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type DynamicClientRegistrationGetOAuth2ClientParams struct {
 
-	/*ID
-	  The id of the OAuth 2.0 Client.
+	/* ID.
 
+	   The id of the OAuth 2.0 Client.
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the dynamic client registration get o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationGetOAuth2ClientParams) WithDefaults() *DynamicClientRegistrationGetOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the dynamic client registration get o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationGetOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the dynamic client registration get o auth2 client params

--- a/internal/httpclient/client/public/dynamic_client_registration_get_o_auth2_client_responses.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_get_o_auth2_client_responses.go
@@ -46,7 +46,7 @@ func NewDynamicClientRegistrationGetOAuth2ClientOK() *DynamicClientRegistrationG
 	return &DynamicClientRegistrationGetOAuth2ClientOK{}
 }
 
-/*DynamicClientRegistrationGetOAuth2ClientOK handles this case with default header values.
+/* DynamicClientRegistrationGetOAuth2ClientOK describes a response with status code 200, with default header values.
 
 oAuth2Client
 */
@@ -57,7 +57,6 @@ type DynamicClientRegistrationGetOAuth2ClientOK struct {
 func (o *DynamicClientRegistrationGetOAuth2ClientOK) Error() string {
 	return fmt.Sprintf("[GET /connect/register/{id}][%d] dynamicClientRegistrationGetOAuth2ClientOK  %+v", 200, o.Payload)
 }
-
 func (o *DynamicClientRegistrationGetOAuth2ClientOK) GetPayload() *models.OAuth2Client {
 	return o.Payload
 }
@@ -81,7 +80,7 @@ func NewDynamicClientRegistrationGetOAuth2ClientDefault(code int) *DynamicClient
 	}
 }
 
-/*DynamicClientRegistrationGetOAuth2ClientDefault handles this case with default header values.
+/* DynamicClientRegistrationGetOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -99,7 +98,6 @@ func (o *DynamicClientRegistrationGetOAuth2ClientDefault) Code() int {
 func (o *DynamicClientRegistrationGetOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[GET /connect/register/{id}][%d] dynamicClientRegistrationGetOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *DynamicClientRegistrationGetOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/dynamic_client_registration_update_o_auth2_client_parameters.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_update_o_auth2_client_parameters.go
@@ -18,61 +18,76 @@ import (
 	"github.com/ory/hydra/internal/httpclient/models"
 )
 
-// NewDynamicClientRegistrationUpdateOAuth2ClientParams creates a new DynamicClientRegistrationUpdateOAuth2ClientParams object
-// with the default values initialized.
+// NewDynamicClientRegistrationUpdateOAuth2ClientParams creates a new DynamicClientRegistrationUpdateOAuth2ClientParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewDynamicClientRegistrationUpdateOAuth2ClientParams() *DynamicClientRegistrationUpdateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationUpdateOAuth2ClientParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewDynamicClientRegistrationUpdateOAuth2ClientParamsWithTimeout creates a new DynamicClientRegistrationUpdateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewDynamicClientRegistrationUpdateOAuth2ClientParamsWithTimeout(timeout time.Duration) *DynamicClientRegistrationUpdateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationUpdateOAuth2ClientParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewDynamicClientRegistrationUpdateOAuth2ClientParamsWithContext creates a new DynamicClientRegistrationUpdateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewDynamicClientRegistrationUpdateOAuth2ClientParamsWithContext(ctx context.Context) *DynamicClientRegistrationUpdateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationUpdateOAuth2ClientParams{
-
 		Context: ctx,
 	}
 }
 
 // NewDynamicClientRegistrationUpdateOAuth2ClientParamsWithHTTPClient creates a new DynamicClientRegistrationUpdateOAuth2ClientParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewDynamicClientRegistrationUpdateOAuth2ClientParamsWithHTTPClient(client *http.Client) *DynamicClientRegistrationUpdateOAuth2ClientParams {
-	var ()
 	return &DynamicClientRegistrationUpdateOAuth2ClientParams{
 		HTTPClient: client,
 	}
 }
 
-/*DynamicClientRegistrationUpdateOAuth2ClientParams contains all the parameters to send to the API endpoint
-for the dynamic client registration update o auth2 client operation typically these are written to a http.Request
+/* DynamicClientRegistrationUpdateOAuth2ClientParams contains all the parameters to send to the API endpoint
+   for the dynamic client registration update o auth2 client operation.
+
+   Typically these are written to a http.Request.
 */
 type DynamicClientRegistrationUpdateOAuth2ClientParams struct {
 
-	/*Body*/
+	// Body.
 	Body *models.OAuth2Client
-	/*ID
-	  The id of the OAuth 2.0 Client.
 
+	/* ID.
+
+	   The id of the OAuth 2.0 Client.
 	*/
 	ID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the dynamic client registration update o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationUpdateOAuth2ClientParams) WithDefaults() *DynamicClientRegistrationUpdateOAuth2ClientParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the dynamic client registration update o auth2 client params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *DynamicClientRegistrationUpdateOAuth2ClientParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the dynamic client registration update o auth2 client params
@@ -137,7 +152,6 @@ func (o *DynamicClientRegistrationUpdateOAuth2ClientParams) WriteToRequest(r run
 		return err
 	}
 	var res []error
-
 	if o.Body != nil {
 		if err := r.SetBodyParam(o.Body); err != nil {
 			return err

--- a/internal/httpclient/client/public/dynamic_client_registration_update_o_auth2_client_responses.go
+++ b/internal/httpclient/client/public/dynamic_client_registration_update_o_auth2_client_responses.go
@@ -46,7 +46,7 @@ func NewDynamicClientRegistrationUpdateOAuth2ClientOK() *DynamicClientRegistrati
 	return &DynamicClientRegistrationUpdateOAuth2ClientOK{}
 }
 
-/*DynamicClientRegistrationUpdateOAuth2ClientOK handles this case with default header values.
+/* DynamicClientRegistrationUpdateOAuth2ClientOK describes a response with status code 200, with default header values.
 
 oAuth2Client
 */
@@ -57,7 +57,6 @@ type DynamicClientRegistrationUpdateOAuth2ClientOK struct {
 func (o *DynamicClientRegistrationUpdateOAuth2ClientOK) Error() string {
 	return fmt.Sprintf("[PUT /connect/register/{id}][%d] dynamicClientRegistrationUpdateOAuth2ClientOK  %+v", 200, o.Payload)
 }
-
 func (o *DynamicClientRegistrationUpdateOAuth2ClientOK) GetPayload() *models.OAuth2Client {
 	return o.Payload
 }
@@ -81,7 +80,7 @@ func NewDynamicClientRegistrationUpdateOAuth2ClientDefault(code int) *DynamicCli
 	}
 }
 
-/*DynamicClientRegistrationUpdateOAuth2ClientDefault handles this case with default header values.
+/* DynamicClientRegistrationUpdateOAuth2ClientDefault describes a response with status code -1, with default header values.
 
 jsonError
 */
@@ -99,7 +98,6 @@ func (o *DynamicClientRegistrationUpdateOAuth2ClientDefault) Code() int {
 func (o *DynamicClientRegistrationUpdateOAuth2ClientDefault) Error() string {
 	return fmt.Sprintf("[PUT /connect/register/{id}][%d] dynamicClientRegistrationUpdateOAuth2Client default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *DynamicClientRegistrationUpdateOAuth2ClientDefault) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/is_instance_ready_parameters.go
+++ b/internal/httpclient/client/public/is_instance_ready_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewIsInstanceReadyParams creates a new IsInstanceReadyParams object
-// with the default values initialized.
+// NewIsInstanceReadyParams creates a new IsInstanceReadyParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewIsInstanceReadyParams() *IsInstanceReadyParams {
-
 	return &IsInstanceReadyParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewIsInstanceReadyParamsWithTimeout creates a new IsInstanceReadyParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewIsInstanceReadyParamsWithTimeout(timeout time.Duration) *IsInstanceReadyParams {
-
 	return &IsInstanceReadyParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewIsInstanceReadyParamsWithContext creates a new IsInstanceReadyParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewIsInstanceReadyParamsWithContext(ctx context.Context) *IsInstanceReadyParams {
-
 	return &IsInstanceReadyParams{
-
 		Context: ctx,
 	}
 }
 
 // NewIsInstanceReadyParamsWithHTTPClient creates a new IsInstanceReadyParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewIsInstanceReadyParamsWithHTTPClient(client *http.Client) *IsInstanceReadyParams {
-
 	return &IsInstanceReadyParams{
 		HTTPClient: client,
 	}
 }
 
-/*IsInstanceReadyParams contains all the parameters to send to the API endpoint
-for the is instance ready operation typically these are written to a http.Request
+/* IsInstanceReadyParams contains all the parameters to send to the API endpoint
+   for the is instance ready operation.
+
+   Typically these are written to a http.Request.
 */
 type IsInstanceReadyParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the is instance ready params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *IsInstanceReadyParams) WithDefaults() *IsInstanceReadyParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the is instance ready params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *IsInstanceReadyParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the is instance ready params

--- a/internal/httpclient/client/public/is_instance_ready_responses.go
+++ b/internal/httpclient/client/public/is_instance_ready_responses.go
@@ -35,9 +35,8 @@ func (o *IsInstanceReadyReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -46,7 +45,7 @@ func NewIsInstanceReadyOK() *IsInstanceReadyOK {
 	return &IsInstanceReadyOK{}
 }
 
-/*IsInstanceReadyOK handles this case with default header values.
+/* IsInstanceReadyOK describes a response with status code 200, with default header values.
 
 healthStatus
 */
@@ -57,7 +56,6 @@ type IsInstanceReadyOK struct {
 func (o *IsInstanceReadyOK) Error() string {
 	return fmt.Sprintf("[GET /health/ready][%d] isInstanceReadyOK  %+v", 200, o.Payload)
 }
-
 func (o *IsInstanceReadyOK) GetPayload() *models.HealthStatus {
 	return o.Payload
 }
@@ -79,7 +77,7 @@ func NewIsInstanceReadyServiceUnavailable() *IsInstanceReadyServiceUnavailable {
 	return &IsInstanceReadyServiceUnavailable{}
 }
 
-/*IsInstanceReadyServiceUnavailable handles this case with default header values.
+/* IsInstanceReadyServiceUnavailable describes a response with status code 503, with default header values.
 
 healthNotReadyStatus
 */
@@ -90,7 +88,6 @@ type IsInstanceReadyServiceUnavailable struct {
 func (o *IsInstanceReadyServiceUnavailable) Error() string {
 	return fmt.Sprintf("[GET /health/ready][%d] isInstanceReadyServiceUnavailable  %+v", 503, o.Payload)
 }
-
 func (o *IsInstanceReadyServiceUnavailable) GetPayload() *models.HealthNotReadyStatus {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/oauth2_token_parameters.go
+++ b/internal/httpclient/client/public/oauth2_token_parameters.go
@@ -16,64 +16,82 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewOauth2TokenParams creates a new Oauth2TokenParams object
-// with the default values initialized.
+// NewOauth2TokenParams creates a new Oauth2TokenParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewOauth2TokenParams() *Oauth2TokenParams {
-	var ()
 	return &Oauth2TokenParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewOauth2TokenParamsWithTimeout creates a new Oauth2TokenParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewOauth2TokenParamsWithTimeout(timeout time.Duration) *Oauth2TokenParams {
-	var ()
 	return &Oauth2TokenParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewOauth2TokenParamsWithContext creates a new Oauth2TokenParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewOauth2TokenParamsWithContext(ctx context.Context) *Oauth2TokenParams {
-	var ()
 	return &Oauth2TokenParams{
-
 		Context: ctx,
 	}
 }
 
 // NewOauth2TokenParamsWithHTTPClient creates a new Oauth2TokenParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewOauth2TokenParamsWithHTTPClient(client *http.Client) *Oauth2TokenParams {
-	var ()
 	return &Oauth2TokenParams{
 		HTTPClient: client,
 	}
 }
 
-/*Oauth2TokenParams contains all the parameters to send to the API endpoint
-for the oauth2 token operation typically these are written to a http.Request
+/* Oauth2TokenParams contains all the parameters to send to the API endpoint
+   for the oauth2 token operation.
+
+   Typically these are written to a http.Request.
 */
 type Oauth2TokenParams struct {
 
-	/*ClientID*/
+	// ClientID.
 	ClientID *string
-	/*Code*/
+
+	// Code.
 	Code *string
-	/*GrantType*/
+
+	// GrantType.
 	GrantType string
-	/*RedirectURI*/
+
+	// RedirectURI.
 	RedirectURI *string
-	/*RefreshToken*/
+
+	// RefreshToken.
 	RefreshToken *string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the oauth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *Oauth2TokenParams) WithDefaults() *Oauth2TokenParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the oauth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *Oauth2TokenParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the oauth2 token params
@@ -185,7 +203,6 @@ func (o *Oauth2TokenParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	if o.Code != nil {
@@ -201,7 +218,6 @@ func (o *Oauth2TokenParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	// form param grant_type
@@ -226,7 +242,6 @@ func (o *Oauth2TokenParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	if o.RefreshToken != nil {
@@ -242,7 +257,6 @@ func (o *Oauth2TokenParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/internal/httpclient/client/public/oauth2_token_responses.go
+++ b/internal/httpclient/client/public/oauth2_token_responses.go
@@ -47,9 +47,8 @@ func (o *Oauth2TokenReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -58,7 +57,7 @@ func NewOauth2TokenOK() *Oauth2TokenOK {
 	return &Oauth2TokenOK{}
 }
 
-/*Oauth2TokenOK handles this case with default header values.
+/* Oauth2TokenOK describes a response with status code 200, with default header values.
 
 oauth2TokenResponse
 */
@@ -69,7 +68,6 @@ type Oauth2TokenOK struct {
 func (o *Oauth2TokenOK) Error() string {
 	return fmt.Sprintf("[POST /oauth2/token][%d] oauth2TokenOK  %+v", 200, o.Payload)
 }
-
 func (o *Oauth2TokenOK) GetPayload() *models.Oauth2TokenResponse {
 	return o.Payload
 }
@@ -91,7 +89,7 @@ func NewOauth2TokenBadRequest() *Oauth2TokenBadRequest {
 	return &Oauth2TokenBadRequest{}
 }
 
-/*Oauth2TokenBadRequest handles this case with default header values.
+/* Oauth2TokenBadRequest describes a response with status code 400, with default header values.
 
 jsonError
 */
@@ -102,7 +100,6 @@ type Oauth2TokenBadRequest struct {
 func (o *Oauth2TokenBadRequest) Error() string {
 	return fmt.Sprintf("[POST /oauth2/token][%d] oauth2TokenBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *Oauth2TokenBadRequest) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -124,7 +121,7 @@ func NewOauth2TokenUnauthorized() *Oauth2TokenUnauthorized {
 	return &Oauth2TokenUnauthorized{}
 }
 
-/*Oauth2TokenUnauthorized handles this case with default header values.
+/* Oauth2TokenUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -135,7 +132,6 @@ type Oauth2TokenUnauthorized struct {
 func (o *Oauth2TokenUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /oauth2/token][%d] oauth2TokenUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *Oauth2TokenUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -157,7 +153,7 @@ func NewOauth2TokenInternalServerError() *Oauth2TokenInternalServerError {
 	return &Oauth2TokenInternalServerError{}
 }
 
-/*Oauth2TokenInternalServerError handles this case with default header values.
+/* Oauth2TokenInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -168,7 +164,6 @@ type Oauth2TokenInternalServerError struct {
 func (o *Oauth2TokenInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /oauth2/token][%d] oauth2TokenInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *Oauth2TokenInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/oauth_auth_parameters.go
+++ b/internal/httpclient/client/public/oauth_auth_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewOauthAuthParams creates a new OauthAuthParams object
-// with the default values initialized.
+// NewOauthAuthParams creates a new OauthAuthParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewOauthAuthParams() *OauthAuthParams {
-
 	return &OauthAuthParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewOauthAuthParamsWithTimeout creates a new OauthAuthParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewOauthAuthParamsWithTimeout(timeout time.Duration) *OauthAuthParams {
-
 	return &OauthAuthParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewOauthAuthParamsWithContext creates a new OauthAuthParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewOauthAuthParamsWithContext(ctx context.Context) *OauthAuthParams {
-
 	return &OauthAuthParams{
-
 		Context: ctx,
 	}
 }
 
 // NewOauthAuthParamsWithHTTPClient creates a new OauthAuthParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewOauthAuthParamsWithHTTPClient(client *http.Client) *OauthAuthParams {
-
 	return &OauthAuthParams{
 		HTTPClient: client,
 	}
 }
 
-/*OauthAuthParams contains all the parameters to send to the API endpoint
-for the oauth auth operation typically these are written to a http.Request
+/* OauthAuthParams contains all the parameters to send to the API endpoint
+   for the oauth auth operation.
+
+   Typically these are written to a http.Request.
 */
 type OauthAuthParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the oauth auth params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *OauthAuthParams) WithDefaults() *OauthAuthParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the oauth auth params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *OauthAuthParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the oauth auth params

--- a/internal/httpclient/client/public/oauth_auth_responses.go
+++ b/internal/httpclient/client/public/oauth_auth_responses.go
@@ -41,9 +41,8 @@ func (o *OauthAuthReader) ReadResponse(response runtime.ClientResponse, consumer
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewOauthAuthFound() *OauthAuthFound {
 	return &OauthAuthFound{}
 }
 
-/*OauthAuthFound handles this case with default header values.
+/* OauthAuthFound describes a response with status code 302, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type OauthAuthFound struct {
@@ -74,7 +73,7 @@ func NewOauthAuthUnauthorized() *OauthAuthUnauthorized {
 	return &OauthAuthUnauthorized{}
 }
 
-/*OauthAuthUnauthorized handles this case with default header values.
+/* OauthAuthUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -85,7 +84,6 @@ type OauthAuthUnauthorized struct {
 func (o *OauthAuthUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth][%d] oauthAuthUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *OauthAuthUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewOauthAuthInternalServerError() *OauthAuthInternalServerError {
 	return &OauthAuthInternalServerError{}
 }
 
-/*OauthAuthInternalServerError handles this case with default header values.
+/* OauthAuthInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -118,7 +116,6 @@ type OauthAuthInternalServerError struct {
 func (o *OauthAuthInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /oauth2/auth][%d] oauthAuthInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *OauthAuthInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/public_client.go
+++ b/internal/httpclient/client/public/public_client.go
@@ -25,31 +25,34 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	DisconnectUser(params *DisconnectUserParams) error
+	DisconnectUser(params *DisconnectUserParams, opts ...ClientOption) error
 
-	DiscoverOpenIDConfiguration(params *DiscoverOpenIDConfigurationParams) (*DiscoverOpenIDConfigurationOK, error)
+	DiscoverOpenIDConfiguration(params *DiscoverOpenIDConfigurationParams, opts ...ClientOption) (*DiscoverOpenIDConfigurationOK, error)
 
-	DynamicClientRegistrationCreateOAuth2Client(params *DynamicClientRegistrationCreateOAuth2ClientParams) (*DynamicClientRegistrationCreateOAuth2ClientCreated, error)
+	DynamicClientRegistrationCreateOAuth2Client(params *DynamicClientRegistrationCreateOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationCreateOAuth2ClientCreated, error)
 
-	DynamicClientRegistrationDeleteOAuth2Client(params *DynamicClientRegistrationDeleteOAuth2ClientParams) (*DynamicClientRegistrationDeleteOAuth2ClientNoContent, error)
+	DynamicClientRegistrationDeleteOAuth2Client(params *DynamicClientRegistrationDeleteOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationDeleteOAuth2ClientNoContent, error)
 
-	DynamicClientRegistrationGetOAuth2Client(params *DynamicClientRegistrationGetOAuth2ClientParams) (*DynamicClientRegistrationGetOAuth2ClientOK, error)
+	DynamicClientRegistrationGetOAuth2Client(params *DynamicClientRegistrationGetOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationGetOAuth2ClientOK, error)
 
-	DynamicClientRegistrationUpdateOAuth2Client(params *DynamicClientRegistrationUpdateOAuth2ClientParams) (*DynamicClientRegistrationUpdateOAuth2ClientOK, error)
+	DynamicClientRegistrationUpdateOAuth2Client(params *DynamicClientRegistrationUpdateOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationUpdateOAuth2ClientOK, error)
 
-	IsInstanceReady(params *IsInstanceReadyParams) (*IsInstanceReadyOK, error)
+	IsInstanceReady(params *IsInstanceReadyParams, opts ...ClientOption) (*IsInstanceReadyOK, error)
 
-	Oauth2Token(params *Oauth2TokenParams, authInfo runtime.ClientAuthInfoWriter) (*Oauth2TokenOK, error)
+	Oauth2Token(params *Oauth2TokenParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*Oauth2TokenOK, error)
 
-	OauthAuth(params *OauthAuthParams) error
+	OauthAuth(params *OauthAuthParams, opts ...ClientOption) error
 
-	RevokeOAuth2Token(params *RevokeOAuth2TokenParams, authInfo runtime.ClientAuthInfoWriter) (*RevokeOAuth2TokenOK, error)
+	RevokeOAuth2Token(params *RevokeOAuth2TokenParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RevokeOAuth2TokenOK, error)
 
-	Userinfo(params *UserinfoParams, authInfo runtime.ClientAuthInfoWriter) (*UserinfoOK, error)
+	Userinfo(params *UserinfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UserinfoOK, error)
 
-	WellKnown(params *WellKnownParams) (*WellKnownOK, error)
+	WellKnown(params *WellKnownParams, opts ...ClientOption) (*WellKnownOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -62,13 +65,12 @@ type ClientService interface {
 https://openid.net/specs/openid-connect-frontchannel-1_0.html
 https://openid.net/specs/openid-connect-backchannel-1_0.html
 */
-func (a *Client) DisconnectUser(params *DisconnectUserParams) error {
+func (a *Client) DisconnectUser(params *DisconnectUserParams, opts ...ClientOption) error {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDisconnectUserParams()
 	}
-
-	_, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "disconnectUser",
 		Method:             "GET",
 		PathPattern:        "/oauth2/sessions/logout",
@@ -79,7 +81,12 @@ func (a *Client) DisconnectUser(params *DisconnectUserParams) error {
 		Reader:             &DisconnectUserReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	_, err := a.transport.Submit(op)
 	if err != nil {
 		return err
 	}
@@ -96,13 +103,12 @@ flow at https://openid.net/specs/openid-connect-discovery-1_0.html .
 Popular libraries for OpenID Connect clients include oidc-client-js (JavaScript), go-oidc (Golang), and others.
 For a full list of clients go here: https://openid.net/developers/certified/
 */
-func (a *Client) DiscoverOpenIDConfiguration(params *DiscoverOpenIDConfigurationParams) (*DiscoverOpenIDConfigurationOK, error) {
+func (a *Client) DiscoverOpenIDConfiguration(params *DiscoverOpenIDConfigurationParams, opts ...ClientOption) (*DiscoverOpenIDConfigurationOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDiscoverOpenIDConfigurationParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "discoverOpenIDConfiguration",
 		Method:             "GET",
 		PathPattern:        "/.well-known/openid-configuration",
@@ -113,7 +119,12 @@ func (a *Client) DiscoverOpenIDConfiguration(params *DiscoverOpenIDConfiguration
 		Reader:             &DiscoverOpenIDConfigurationReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -142,13 +153,12 @@ values will be server generated when specifying `token_endpoint_auth_method` as 
 The `client_secret` will be returned in the response and you will not be able to retrieve it later on.
 Write the secret down and keep it somewhere safe.
 */
-func (a *Client) DynamicClientRegistrationCreateOAuth2Client(params *DynamicClientRegistrationCreateOAuth2ClientParams) (*DynamicClientRegistrationCreateOAuth2ClientCreated, error) {
+func (a *Client) DynamicClientRegistrationCreateOAuth2Client(params *DynamicClientRegistrationCreateOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationCreateOAuth2ClientCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDynamicClientRegistrationCreateOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "dynamicClientRegistrationCreateOAuth2Client",
 		Method:             "POST",
 		PathPattern:        "/connect/register",
@@ -159,7 +169,12 @@ func (a *Client) DynamicClientRegistrationCreateOAuth2Client(params *DynamicClie
 		Reader:             &DynamicClientRegistrationCreateOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -187,13 +202,12 @@ If it uses `client_secret_basic`, present the Client ID and the Client Secret in
 OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are
 generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 */
-func (a *Client) DynamicClientRegistrationDeleteOAuth2Client(params *DynamicClientRegistrationDeleteOAuth2ClientParams) (*DynamicClientRegistrationDeleteOAuth2ClientNoContent, error) {
+func (a *Client) DynamicClientRegistrationDeleteOAuth2Client(params *DynamicClientRegistrationDeleteOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationDeleteOAuth2ClientNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDynamicClientRegistrationDeleteOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "dynamicClientRegistrationDeleteOAuth2Client",
 		Method:             "DELETE",
 		PathPattern:        "/connect/register/{id}",
@@ -204,7 +218,12 @@ func (a *Client) DynamicClientRegistrationDeleteOAuth2Client(params *DynamicClie
 		Reader:             &DynamicClientRegistrationDeleteOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -232,13 +251,12 @@ If it uses `client_secret_basic`, present the Client ID and the Client Secret in
 OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are
 generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 */
-func (a *Client) DynamicClientRegistrationGetOAuth2Client(params *DynamicClientRegistrationGetOAuth2ClientParams) (*DynamicClientRegistrationGetOAuth2ClientOK, error) {
+func (a *Client) DynamicClientRegistrationGetOAuth2Client(params *DynamicClientRegistrationGetOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationGetOAuth2ClientOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDynamicClientRegistrationGetOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "dynamicClientRegistrationGetOAuth2Client",
 		Method:             "GET",
 		PathPattern:        "/connect/register/{id}",
@@ -249,7 +267,12 @@ func (a *Client) DynamicClientRegistrationGetOAuth2Client(params *DynamicClientR
 		Reader:             &DynamicClientRegistrationGetOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -280,13 +303,12 @@ If it uses `client_secret_basic`, present the Client ID and the Client Secret in
 OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are
 generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 */
-func (a *Client) DynamicClientRegistrationUpdateOAuth2Client(params *DynamicClientRegistrationUpdateOAuth2ClientParams) (*DynamicClientRegistrationUpdateOAuth2ClientOK, error) {
+func (a *Client) DynamicClientRegistrationUpdateOAuth2Client(params *DynamicClientRegistrationUpdateOAuth2ClientParams, opts ...ClientOption) (*DynamicClientRegistrationUpdateOAuth2ClientOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDynamicClientRegistrationUpdateOAuth2ClientParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "dynamicClientRegistrationUpdateOAuth2Client",
 		Method:             "PUT",
 		PathPattern:        "/connect/register/{id}",
@@ -297,7 +319,12 @@ func (a *Client) DynamicClientRegistrationUpdateOAuth2Client(params *DynamicClie
 		Reader:             &DynamicClientRegistrationUpdateOAuth2ClientReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -322,13 +349,12 @@ If the service supports TLS Edge Termination, this endpoint does not require the
 Be aware that if you are running multiple nodes of this service, the health status will never
 refer to the cluster state, only to a single instance.
 */
-func (a *Client) IsInstanceReady(params *IsInstanceReadyParams) (*IsInstanceReadyOK, error) {
+func (a *Client) IsInstanceReady(params *IsInstanceReadyParams, opts ...ClientOption) (*IsInstanceReadyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewIsInstanceReadyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "isInstanceReady",
 		Method:             "GET",
 		PathPattern:        "/health/ready",
@@ -339,7 +365,12 @@ func (a *Client) IsInstanceReady(params *IsInstanceReadyParams) (*IsInstanceRead
 		Reader:             &IsInstanceReadyReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -365,13 +396,12 @@ request entity-body.
 >
 > Do note that Hydra SDK does not implement this endpoint properly. Use one of the libraries listed above!
 */
-func (a *Client) Oauth2Token(params *Oauth2TokenParams, authInfo runtime.ClientAuthInfoWriter) (*Oauth2TokenOK, error) {
+func (a *Client) Oauth2Token(params *Oauth2TokenParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*Oauth2TokenOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewOauth2TokenParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "oauth2Token",
 		Method:             "POST",
 		PathPattern:        "/oauth2/token",
@@ -383,7 +413,12 @@ func (a *Client) Oauth2Token(params *Oauth2TokenParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -405,13 +440,12 @@ OAuth2 is a very popular protocol and a library for your programming language wi
 
 To learn more about this flow please refer to the specification: https://tools.ietf.org/html/rfc6749
 */
-func (a *Client) OauthAuth(params *OauthAuthParams) error {
+func (a *Client) OauthAuth(params *OauthAuthParams, opts ...ClientOption) error {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewOauthAuthParams()
 	}
-
-	_, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "oauthAuth",
 		Method:             "GET",
 		PathPattern:        "/oauth2/auth",
@@ -422,7 +456,12 @@ func (a *Client) OauthAuth(params *OauthAuthParams) error {
 		Reader:             &OauthAuthReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	_, err := a.transport.Submit(op)
 	if err != nil {
 		return err
 	}
@@ -437,13 +476,12 @@ longer be used to make access requests, and a revoked refresh token can no longe
 Revoking a refresh token also invalidates the access token that was created with it. A token may only be revoked by
 the client the token was generated for.
 */
-func (a *Client) RevokeOAuth2Token(params *RevokeOAuth2TokenParams, authInfo runtime.ClientAuthInfoWriter) (*RevokeOAuth2TokenOK, error) {
+func (a *Client) RevokeOAuth2Token(params *RevokeOAuth2TokenParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RevokeOAuth2TokenOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewRevokeOAuth2TokenParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "revokeOAuth2Token",
 		Method:             "POST",
 		PathPattern:        "/oauth2/revoke",
@@ -455,7 +493,12 @@ func (a *Client) RevokeOAuth2Token(params *RevokeOAuth2TokenParams, authInfo run
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -481,13 +524,12 @@ In the case of authentication error, a WWW-Authenticate header might be set in t
 with more information about the error. See [the spec](https://datatracker.ietf.org/doc/html/rfc6750#section-3)
 for more details about header format.
 */
-func (a *Client) Userinfo(params *UserinfoParams, authInfo runtime.ClientAuthInfoWriter) (*UserinfoOK, error) {
+func (a *Client) Userinfo(params *UserinfoParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UserinfoOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewUserinfoParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "userinfo",
 		Method:             "GET",
 		PathPattern:        "/userinfo",
@@ -499,7 +541,12 @@ func (a *Client) Userinfo(params *UserinfoParams, authInfo runtime.ClientAuthInf
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -520,13 +567,12 @@ func (a *Client) Userinfo(params *UserinfoParams, authInfo runtime.ClientAuthInf
 if enabled, OAuth 2.0 JWT Access Tokens. This endpoint can be used with client libraries like
 [node-jwks-rsa](https://github.com/auth0/node-jwks-rsa) among others.
 */
-func (a *Client) WellKnown(params *WellKnownParams) (*WellKnownOK, error) {
+func (a *Client) WellKnown(params *WellKnownParams, opts ...ClientOption) (*WellKnownOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewWellKnownParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "wellKnown",
 		Method:             "GET",
 		PathPattern:        "/.well-known/jwks.json",
@@ -537,7 +583,12 @@ func (a *Client) WellKnown(params *WellKnownParams) (*WellKnownOK, error) {
 		Reader:             &WellKnownReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpclient/client/public/revoke_o_auth2_token_parameters.go
+++ b/internal/httpclient/client/public/revoke_o_auth2_token_parameters.go
@@ -16,56 +16,70 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewRevokeOAuth2TokenParams creates a new RevokeOAuth2TokenParams object
-// with the default values initialized.
+// NewRevokeOAuth2TokenParams creates a new RevokeOAuth2TokenParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewRevokeOAuth2TokenParams() *RevokeOAuth2TokenParams {
-	var ()
 	return &RevokeOAuth2TokenParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewRevokeOAuth2TokenParamsWithTimeout creates a new RevokeOAuth2TokenParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewRevokeOAuth2TokenParamsWithTimeout(timeout time.Duration) *RevokeOAuth2TokenParams {
-	var ()
 	return &RevokeOAuth2TokenParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewRevokeOAuth2TokenParamsWithContext creates a new RevokeOAuth2TokenParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewRevokeOAuth2TokenParamsWithContext(ctx context.Context) *RevokeOAuth2TokenParams {
-	var ()
 	return &RevokeOAuth2TokenParams{
-
 		Context: ctx,
 	}
 }
 
 // NewRevokeOAuth2TokenParamsWithHTTPClient creates a new RevokeOAuth2TokenParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewRevokeOAuth2TokenParamsWithHTTPClient(client *http.Client) *RevokeOAuth2TokenParams {
-	var ()
 	return &RevokeOAuth2TokenParams{
 		HTTPClient: client,
 	}
 }
 
-/*RevokeOAuth2TokenParams contains all the parameters to send to the API endpoint
-for the revoke o auth2 token operation typically these are written to a http.Request
+/* RevokeOAuth2TokenParams contains all the parameters to send to the API endpoint
+   for the revoke o auth2 token operation.
+
+   Typically these are written to a http.Request.
 */
 type RevokeOAuth2TokenParams struct {
 
-	/*Token*/
+	// Token.
 	Token string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the revoke o auth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RevokeOAuth2TokenParams) WithDefaults() *RevokeOAuth2TokenParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the revoke o auth2 token params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *RevokeOAuth2TokenParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the revoke o auth2 token params

--- a/internal/httpclient/client/public/revoke_o_auth2_token_responses.go
+++ b/internal/httpclient/client/public/revoke_o_auth2_token_responses.go
@@ -41,9 +41,8 @@ func (o *RevokeOAuth2TokenReader) ReadResponse(response runtime.ClientResponse, 
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,9 +51,9 @@ func NewRevokeOAuth2TokenOK() *RevokeOAuth2TokenOK {
 	return &RevokeOAuth2TokenOK{}
 }
 
-/*RevokeOAuth2TokenOK handles this case with default header values.
+/* RevokeOAuth2TokenOK describes a response with status code 200, with default header values.
 
-Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+ Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
 typically 201.
 */
 type RevokeOAuth2TokenOK struct {
@@ -74,7 +73,7 @@ func NewRevokeOAuth2TokenUnauthorized() *RevokeOAuth2TokenUnauthorized {
 	return &RevokeOAuth2TokenUnauthorized{}
 }
 
-/*RevokeOAuth2TokenUnauthorized handles this case with default header values.
+/* RevokeOAuth2TokenUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -85,7 +84,6 @@ type RevokeOAuth2TokenUnauthorized struct {
 func (o *RevokeOAuth2TokenUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /oauth2/revoke][%d] revokeOAuth2TokenUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *RevokeOAuth2TokenUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -107,7 +105,7 @@ func NewRevokeOAuth2TokenInternalServerError() *RevokeOAuth2TokenInternalServerE
 	return &RevokeOAuth2TokenInternalServerError{}
 }
 
-/*RevokeOAuth2TokenInternalServerError handles this case with default header values.
+/* RevokeOAuth2TokenInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -118,7 +116,6 @@ type RevokeOAuth2TokenInternalServerError struct {
 func (o *RevokeOAuth2TokenInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /oauth2/revoke][%d] revokeOAuth2TokenInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *RevokeOAuth2TokenInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/userinfo_parameters.go
+++ b/internal/httpclient/client/public/userinfo_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewUserinfoParams creates a new UserinfoParams object
-// with the default values initialized.
+// NewUserinfoParams creates a new UserinfoParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewUserinfoParams() *UserinfoParams {
-
 	return &UserinfoParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewUserinfoParamsWithTimeout creates a new UserinfoParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewUserinfoParamsWithTimeout(timeout time.Duration) *UserinfoParams {
-
 	return &UserinfoParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewUserinfoParamsWithContext creates a new UserinfoParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewUserinfoParamsWithContext(ctx context.Context) *UserinfoParams {
-
 	return &UserinfoParams{
-
 		Context: ctx,
 	}
 }
 
 // NewUserinfoParamsWithHTTPClient creates a new UserinfoParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewUserinfoParamsWithHTTPClient(client *http.Client) *UserinfoParams {
-
 	return &UserinfoParams{
 		HTTPClient: client,
 	}
 }
 
-/*UserinfoParams contains all the parameters to send to the API endpoint
-for the userinfo operation typically these are written to a http.Request
+/* UserinfoParams contains all the parameters to send to the API endpoint
+   for the userinfo operation.
+
+   Typically these are written to a http.Request.
 */
 type UserinfoParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the userinfo params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UserinfoParams) WithDefaults() *UserinfoParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the userinfo params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UserinfoParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the userinfo params

--- a/internal/httpclient/client/public/userinfo_responses.go
+++ b/internal/httpclient/client/public/userinfo_responses.go
@@ -41,9 +41,8 @@ func (o *UserinfoReader) ReadResponse(response runtime.ClientResponse, consumer 
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -52,7 +51,7 @@ func NewUserinfoOK() *UserinfoOK {
 	return &UserinfoOK{}
 }
 
-/*UserinfoOK handles this case with default header values.
+/* UserinfoOK describes a response with status code 200, with default header values.
 
 userinfoResponse
 */
@@ -63,7 +62,6 @@ type UserinfoOK struct {
 func (o *UserinfoOK) Error() string {
 	return fmt.Sprintf("[GET /userinfo][%d] userinfoOK  %+v", 200, o.Payload)
 }
-
 func (o *UserinfoOK) GetPayload() *models.UserinfoResponse {
 	return o.Payload
 }
@@ -85,7 +83,7 @@ func NewUserinfoUnauthorized() *UserinfoUnauthorized {
 	return &UserinfoUnauthorized{}
 }
 
-/*UserinfoUnauthorized handles this case with default header values.
+/* UserinfoUnauthorized describes a response with status code 401, with default header values.
 
 jsonError
 */
@@ -96,7 +94,6 @@ type UserinfoUnauthorized struct {
 func (o *UserinfoUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /userinfo][%d] userinfoUnauthorized  %+v", 401, o.Payload)
 }
-
 func (o *UserinfoUnauthorized) GetPayload() *models.JSONError {
 	return o.Payload
 }
@@ -118,7 +115,7 @@ func NewUserinfoInternalServerError() *UserinfoInternalServerError {
 	return &UserinfoInternalServerError{}
 }
 
-/*UserinfoInternalServerError handles this case with default header values.
+/* UserinfoInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -129,7 +126,6 @@ type UserinfoInternalServerError struct {
 func (o *UserinfoInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /userinfo][%d] userinfoInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *UserinfoInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/client/public/well_known_parameters.go
+++ b/internal/httpclient/client/public/well_known_parameters.go
@@ -16,52 +16,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewWellKnownParams creates a new WellKnownParams object
-// with the default values initialized.
+// NewWellKnownParams creates a new WellKnownParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewWellKnownParams() *WellKnownParams {
-
 	return &WellKnownParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewWellKnownParamsWithTimeout creates a new WellKnownParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewWellKnownParamsWithTimeout(timeout time.Duration) *WellKnownParams {
-
 	return &WellKnownParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewWellKnownParamsWithContext creates a new WellKnownParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewWellKnownParamsWithContext(ctx context.Context) *WellKnownParams {
-
 	return &WellKnownParams{
-
 		Context: ctx,
 	}
 }
 
 // NewWellKnownParamsWithHTTPClient creates a new WellKnownParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewWellKnownParamsWithHTTPClient(client *http.Client) *WellKnownParams {
-
 	return &WellKnownParams{
 		HTTPClient: client,
 	}
 }
 
-/*WellKnownParams contains all the parameters to send to the API endpoint
-for the well known operation typically these are written to a http.Request
+/* WellKnownParams contains all the parameters to send to the API endpoint
+   for the well known operation.
+
+   Typically these are written to a http.Request.
 */
 type WellKnownParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the well known params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *WellKnownParams) WithDefaults() *WellKnownParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the well known params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *WellKnownParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the well known params

--- a/internal/httpclient/client/public/well_known_responses.go
+++ b/internal/httpclient/client/public/well_known_responses.go
@@ -35,9 +35,8 @@ func (o *WellKnownReader) ReadResponse(response runtime.ClientResponse, consumer
 			return nil, err
 		}
 		return nil, result
-
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 
@@ -46,7 +45,7 @@ func NewWellKnownOK() *WellKnownOK {
 	return &WellKnownOK{}
 }
 
-/*WellKnownOK handles this case with default header values.
+/* WellKnownOK describes a response with status code 200, with default header values.
 
 JSONWebKeySet
 */
@@ -57,7 +56,6 @@ type WellKnownOK struct {
 func (o *WellKnownOK) Error() string {
 	return fmt.Sprintf("[GET /.well-known/jwks.json][%d] wellKnownOK  %+v", 200, o.Payload)
 }
-
 func (o *WellKnownOK) GetPayload() *models.JSONWebKeySet {
 	return o.Payload
 }
@@ -79,7 +77,7 @@ func NewWellKnownInternalServerError() *WellKnownInternalServerError {
 	return &WellKnownInternalServerError{}
 }
 
-/*WellKnownInternalServerError handles this case with default header values.
+/* WellKnownInternalServerError describes a response with status code 500, with default header values.
 
 jsonError
 */
@@ -90,7 +88,6 @@ type WellKnownInternalServerError struct {
 func (o *WellKnownInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /.well-known/jwks.json][%d] wellKnownInternalServerError  %+v", 500, o.Payload)
 }
-
 func (o *WellKnownInternalServerError) GetPayload() *models.JSONError {
 	return o.Payload
 }

--- a/internal/httpclient/models/accept_consent_request.go
+++ b/internal/httpclient/models/accept_consent_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -65,7 +67,6 @@ func (m *AcceptConsentRequest) Validate(formats strfmt.Registry) error {
 }
 
 func (m *AcceptConsentRequest) validateGrantAccessTokenAudience(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.GrantAccessTokenAudience) { // not required
 		return nil
 	}
@@ -81,7 +82,6 @@ func (m *AcceptConsentRequest) validateGrantAccessTokenAudience(formats strfmt.R
 }
 
 func (m *AcceptConsentRequest) validateGrantScope(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.GrantScope) { // not required
 		return nil
 	}
@@ -97,7 +97,6 @@ func (m *AcceptConsentRequest) validateGrantScope(formats strfmt.Registry) error
 }
 
 func (m *AcceptConsentRequest) validateHandledAt(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.HandledAt) { // not required
 		return nil
 	}
@@ -113,13 +112,88 @@ func (m *AcceptConsentRequest) validateHandledAt(formats strfmt.Registry) error 
 }
 
 func (m *AcceptConsentRequest) validateSession(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Session) { // not required
 		return nil
 	}
 
 	if m.Session != nil {
 		if err := m.Session.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("session")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this accept consent request based on the context it is used
+func (m *AcceptConsentRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateGrantAccessTokenAudience(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGrantScope(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateHandledAt(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSession(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *AcceptConsentRequest) contextValidateGrantAccessTokenAudience(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.GrantAccessTokenAudience.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("grant_access_token_audience")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *AcceptConsentRequest) contextValidateGrantScope(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.GrantScope.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("grant_scope")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *AcceptConsentRequest) contextValidateHandledAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.HandledAt.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("handled_at")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *AcceptConsentRequest) contextValidateSession(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Session != nil {
+		if err := m.Session.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("session")
 			}

--- a/internal/httpclient/models/accept_login_request.go
+++ b/internal/httpclient/models/accept_login_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -79,7 +81,6 @@ func (m *AcceptLoginRequest) Validate(formats strfmt.Registry) error {
 }
 
 func (m *AcceptLoginRequest) validateAmr(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Amr) { // not required
 		return nil
 	}
@@ -97,6 +98,32 @@ func (m *AcceptLoginRequest) validateAmr(formats strfmt.Registry) error {
 func (m *AcceptLoginRequest) validateSubject(formats strfmt.Registry) error {
 
 	if err := validate.Required("subject", "body", m.Subject); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this accept login request based on the context it is used
+func (m *AcceptLoginRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAmr(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *AcceptLoginRequest) contextValidateAmr(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.Amr.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("amr")
+		}
 		return err
 	}
 

--- a/internal/httpclient/models/completed_request.go
+++ b/internal/httpclient/models/completed_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -42,6 +44,11 @@ func (m *CompletedRequest) validateRedirectTo(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this completed request based on context it is used
+func (m *CompletedRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/consent_request.go
+++ b/internal/httpclient/models/consent_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -104,7 +106,6 @@ func (m *ConsentRequest) Validate(formats strfmt.Registry) error {
 }
 
 func (m *ConsentRequest) validateAmr(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Amr) { // not required
 		return nil
 	}
@@ -129,7 +130,6 @@ func (m *ConsentRequest) validateChallenge(formats strfmt.Registry) error {
 }
 
 func (m *ConsentRequest) validateClient(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Client) { // not required
 		return nil
 	}
@@ -147,7 +147,6 @@ func (m *ConsentRequest) validateClient(formats strfmt.Registry) error {
 }
 
 func (m *ConsentRequest) validateOidcContext(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.OidcContext) { // not required
 		return nil
 	}
@@ -165,7 +164,6 @@ func (m *ConsentRequest) validateOidcContext(formats strfmt.Registry) error {
 }
 
 func (m *ConsentRequest) validateRequestedAccessTokenAudience(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.RequestedAccessTokenAudience) { // not required
 		return nil
 	}
@@ -181,12 +179,105 @@ func (m *ConsentRequest) validateRequestedAccessTokenAudience(formats strfmt.Reg
 }
 
 func (m *ConsentRequest) validateRequestedScope(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.RequestedScope) { // not required
 		return nil
 	}
 
 	if err := m.RequestedScope.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("requested_scope")
+		}
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this consent request based on the context it is used
+func (m *ConsentRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAmr(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateClient(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateOidcContext(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRequestedAccessTokenAudience(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRequestedScope(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ConsentRequest) contextValidateAmr(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.Amr.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("amr")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *ConsentRequest) contextValidateClient(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Client != nil {
+		if err := m.Client.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("client")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ConsentRequest) contextValidateOidcContext(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.OidcContext != nil {
+		if err := m.OidcContext.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("oidc_context")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ConsentRequest) contextValidateRequestedAccessTokenAudience(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.RequestedAccessTokenAudience.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("requested_access_token_audience")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *ConsentRequest) contextValidateRequestedScope(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.RequestedScope.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("requested_scope")
 		}

--- a/internal/httpclient/models/consent_request_session.go
+++ b/internal/httpclient/models/consent_request_session.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -28,6 +30,11 @@ type ConsentRequestSession struct {
 
 // Validate validates this consent request session
 func (m *ConsentRequestSession) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this consent request session based on context it is used
+func (m *ConsentRequestSession) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/container_wait_o_k_body_error.go
+++ b/internal/httpclient/models/container_wait_o_k_body_error.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -21,6 +23,11 @@ type ContainerWaitOKBodyError struct {
 
 // Validate validates this container wait o k body error
 func (m *ContainerWaitOKBodyError) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this container wait o k body error based on context it is used
+func (m *ContainerWaitOKBodyError) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/flush_inactive_o_auth2_tokens_request.go
+++ b/internal/httpclient/models/flush_inactive_o_auth2_tokens_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -38,7 +40,6 @@ func (m *FlushInactiveOAuth2TokensRequest) Validate(formats strfmt.Registry) err
 }
 
 func (m *FlushInactiveOAuth2TokensRequest) validateNotAfter(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.NotAfter) { // not required
 		return nil
 	}
@@ -47,6 +48,11 @@ func (m *FlushInactiveOAuth2TokensRequest) validateNotAfter(formats strfmt.Regis
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this flush inactive o auth2 tokens request based on context it is used
+func (m *FlushInactiveOAuth2TokensRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/generic_error.go
+++ b/internal/httpclient/models/generic_error.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -18,12 +20,14 @@ import (
 type GenericError struct {
 
 	// The status code
+	// Example: 404
 	Code int64 `json:"code,omitempty"`
 
 	// Debug information
 	//
 	// This field is often not exposed to protect against leaking
 	// sensitive information.
+	// Example: SQL field \"foo\" is not a bool.
 	Debug string `json:"debug,omitempty"`
 
 	// Further error details
@@ -37,19 +41,23 @@ type GenericError struct {
 	// Error message
 	//
 	// The error's message.
+	// Example: The resource could not be found
 	// Required: true
 	Message *string `json:"message"`
 
 	// A human-readable reason for the error
+	// Example: User with ID 1234 does not exist.
 	Reason string `json:"reason,omitempty"`
 
 	// The request ID
 	//
 	// The request ID is often exposed internally in order to trace
 	// errors across service architectures. This is often a UUID.
+	// Example: d7ef54b1-ec15-46e6-bccb-524b82c035e6
 	Request string `json:"request,omitempty"`
 
 	// The status description
+	// Example: Not Found
 	Status string `json:"status,omitempty"`
 }
 
@@ -73,6 +81,11 @@ func (m *GenericError) validateMessage(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this generic error based on context it is used
+func (m *GenericError) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/health_not_ready_status.go
+++ b/internal/httpclient/models/health_not_ready_status.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -21,6 +23,11 @@ type HealthNotReadyStatus struct {
 
 // Validate validates this health not ready status
 func (m *HealthNotReadyStatus) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this health not ready status based on context it is used
+func (m *HealthNotReadyStatus) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/health_status.go
+++ b/internal/httpclient/models/health_status.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -21,6 +23,11 @@ type HealthStatus struct {
 
 // Validate validates this health status
 func (m *HealthStatus) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this health status based on context it is used
+func (m *HealthStatus) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/json_error.go
+++ b/internal/httpclient/models/json_error.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -18,20 +20,29 @@ import (
 type JSONError struct {
 
 	// Name is the error name.
+	// Example: The requested resource could not be found
 	Error string `json:"error,omitempty"`
 
 	// Debug contains debug information. This is usually not available and has to be enabled.
+	// Example: The database adapter was unable to find the element
 	ErrorDebug string `json:"error_debug,omitempty"`
 
 	// Description contains further information on the nature of the error.
+	// Example: Object with ID 12345 does not exist
 	ErrorDescription string `json:"error_description,omitempty"`
 
 	// Code represents the error status code (404, 403, 401, ...).
+	// Example: 404
 	StatusCode int64 `json:"status_code,omitempty"`
 }
 
 // Validate validates this json error
 func (m *JSONError) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this json error based on context it is used
+func (m *JSONError) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/json_web_key.go
+++ b/internal/httpclient/models/json_web_key.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -24,25 +26,32 @@ type JSONWebKey struct {
 	// IANA "JSON Web Signature and Encryption Algorithms" registry
 	// established by [JWA] or be a value that contains a Collision-
 	// Resistant Name.
+	// Example: RS256
 	// Required: true
 	Alg *string `json:"alg"`
 
 	// crv
+	// Example: P-256
 	Crv string `json:"crv,omitempty"`
 
 	// d
+	// Example: T_N8I-6He3M8a7X1vWt6TGIx4xB_GP3Mb4SsZSA4v-orvJzzRiQhLlRR81naWYxfQAYt5isDI6_C2L9bdWo4FFPjGQFvNoRX-_sBJyBI_rl-TBgsZYoUlAj3J92WmY2inbA-PwyJfsaIIDceYBC-eX-xiCu6qMqkZi3MwQAFL6bMdPEM0z4JBcwFT3VdiWAIRUuACWQwrXMq672x7fMuaIaHi7XDGgt1ith23CLfaREmJku9PQcchbt_uEY-hqrFY6ntTtS4paWWQj86xLL94S-Tf6v6xkL918PfLSOTq6XCzxvlFwzBJqApnAhbwqLjpPhgUG04EDRrqrSBc5Y1BLevn6Ip5h1AhessBp3wLkQgz_roeckt-ybvzKTjESMuagnpqLvOT7Y9veIug2MwPJZI2VjczRc1vzMs25XrFQ8DpUy-bNdp89TmvAXwctUMiJdgHloJw23Cv03gIUAkDnsTqZmkpbIf-crpgNKFmQP_EDKoe8p_PXZZgfbRri3NoEVGP7Mk6yEu8LjJhClhZaBNjuWw2-KlBfOA3g79mhfBnkInee5KO9mGR50qPk1V-MorUYNTFMZIm0kFE6eYVWFBwJHLKYhHU34DoiK1VP-svZpC2uAMFNA_UJEwM9CQ2b8qe4-5e9aywMvwcuArRkAB5mBIfOaOJao3mfukKAE
 	D string `json:"d,omitempty"`
 
 	// dp
+	// Example: G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0
 	Dp string `json:"dp,omitempty"`
 
 	// dq
+	// Example: s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk
 	Dq string `json:"dq,omitempty"`
 
 	// e
+	// Example: AQAB
 	E string `json:"e,omitempty"`
 
 	// k
+	// Example: GawgguFyGrWKav7AX4VKUg
 	K string `json:"k,omitempty"`
 
 	// The "kid" (key ID) parameter is used to match a specific key.  This
@@ -54,6 +63,7 @@ type JSONWebKey struct {
 	// they have different "kty" (key type) values but are considered to be
 	// equivalent alternatives by the application using them.)  The "kid"
 	// value is a case-sensitive string.
+	// Example: 1603dfe0af8f4596
 	// Required: true
 	Kid *string `json:"kid"`
 
@@ -62,29 +72,36 @@ type JSONWebKey struct {
 	// either be registered in the IANA "JSON Web Key Types" registry
 	// established by [JWA] or be a value that contains a Collision-
 	// Resistant Name.  The "kty" value is a case-sensitive string.
+	// Example: RSA
 	// Required: true
 	Kty *string `json:"kty"`
 
 	// n
+	// Example: vTqrxUyQPl_20aqf5kXHwDZrel-KovIp8s7ewJod2EXHl8tWlRB3_Rem34KwBfqlKQGp1nqah-51H4Jzruqe0cFP58hPEIt6WqrvnmJCXxnNuIB53iX_uUUXXHDHBeaPCSRoNJzNysjoJ30TIUsKBiirhBa7f235PXbKiHducLevV6PcKxJ5cY8zO286qJLBWSPm-OIevwqsIsSIH44Qtm9sioFikhkbLwoqwWORGAY0nl6XvVOlhADdLjBSqSAeT1FPuCDCnXwzCDR8N9IFB_IjdStFkC-rVt2K5BYfPd0c3yFp_vHR15eRd0zJ8XQ7woBC8Vnsac6Et1pKS59pX6256DPWu8UDdEOolKAPgcd_g2NpA76cAaF_jcT80j9KrEzw8Tv0nJBGesuCjPNjGs_KzdkWTUXt23Hn9QJsdc1MZuaW0iqXBepHYfYoqNelzVte117t4BwVp0kUM6we0IqyXClaZgOI8S-WDBw2_Ovdm8e5NmhYAblEVoygcX8Y46oH6bKiaCQfKCFDMcRgChme7AoE1yZZYsPbaG_3IjPrC4LBMHQw8rM9dWjJ8ImjicvZ1pAm0dx-KHCP3y5PVKrxBDf1zSOsBRkOSjB8TPODnJMz6-jd5hTtZxpZPwPoIdCanTZ3ZD6uRBpTmDwtpRGm63UQs1m5FWPwb0T2IF0
 	N string `json:"n,omitempty"`
 
 	// p
+	// Example: 6NbkXwDWUhi-eR55Cgbf27FkQDDWIamOaDr0rj1q0f1fFEz1W5A_09YvG09Fiv1AO2-D8Rl8gS1Vkz2i0zCSqnyy8A025XOcRviOMK7nIxE4OH_PEsko8dtIrb3TmE2hUXvCkmzw9EsTF1LQBOGC6iusLTXepIC1x9ukCKFZQvdgtEObQ5kzd9Nhq-cdqmSeMVLoxPLd1blviVT9Vm8-y12CtYpeJHOaIDtVPLlBhJiBoPKWg3vxSm4XxIliNOefqegIlsmTIa3MpS6WWlCK3yHhat0Q-rRxDxdyiVdG_wzJvp0Iw_2wms7pe-PgNPYvUWH9JphWP5K38YqEBiJFXQ
 	P string `json:"p,omitempty"`
 
 	// q
+	// Example: 0A1FmpOWR91_RAWpqreWSavNaZb9nXeKiBo0DQGBz32DbqKqQ8S4aBJmbRhJcctjCLjain-ivut477tAUMmzJwVJDDq2MZFwC9Q-4VYZmFU4HJityQuSzHYe64RjN-E_NQ02TWhG3QGW6roq6c57c99rrUsETwJJiwS8M5p15Miuz53DaOjv-uqqFAFfywN5WkxHbraBcjHtMiQuyQbQqkCFh-oanHkwYNeytsNhTu2mQmwR5DR2roZ2nPiFjC6nsdk-A7E3S3wMzYYFw7jvbWWoYWo9vB40_MY2Y0FYQSqcDzcBIcq_0tnnasf3VW4Fdx6m80RzOb2Fsnln7vKXAQ
 	Q string `json:"q,omitempty"`
 
 	// qi
+	// Example: GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU
 	Qi string `json:"qi,omitempty"`
 
 	// Use ("public key use") identifies the intended use of
 	// the public key. The "use" parameter is employed to indicate whether
 	// a public key is used for encrypting data or verifying the signature
 	// on data. Values are commonly "sig" (signature) or "enc" (encryption).
+	// Example: sig
 	// Required: true
 	Use *string `json:"use"`
 
 	// x
+	// Example: f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU
 	X string `json:"x,omitempty"`
 
 	// The "x5c" (X.509 certificate chain) parameter contains a chain of one
@@ -97,6 +114,7 @@ type JSONWebKey struct {
 	X5c []string `json:"x5c"`
 
 	// y
+	// Example: x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0
 	Y string `json:"y,omitempty"`
 }
 
@@ -159,6 +177,11 @@ func (m *JSONWebKey) validateUse(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this JSON web key based on context it is used
+func (m *JSONWebKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/json_web_key_set.go
+++ b/internal/httpclient/models/json_web_key_set.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -45,7 +46,6 @@ func (m *JSONWebKeySet) Validate(formats strfmt.Registry) error {
 }
 
 func (m *JSONWebKeySet) validateKeys(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Keys) { // not required
 		return nil
 	}
@@ -57,6 +57,38 @@ func (m *JSONWebKeySet) validateKeys(formats strfmt.Registry) error {
 
 		if m.Keys[i] != nil {
 			if err := m.Keys[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("keys" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this JSON web key set based on the context it is used
+func (m *JSONWebKeySet) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateKeys(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *JSONWebKeySet) contextValidateKeys(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Keys); i++ {
+
+		if m.Keys[i] != nil {
+			if err := m.Keys[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("keys" + "." + strconv.Itoa(i))
 				}

--- a/internal/httpclient/models/json_web_key_set_generator_request.go
+++ b/internal/httpclient/models/json_web_key_set_generator_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -79,6 +81,11 @@ func (m *JSONWebKeySetGeneratorRequest) validateUse(formats strfmt.Registry) err
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this json web key set generator request based on context it is used
+func (m *JSONWebKeySetGeneratorRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/login_request.go
+++ b/internal/httpclient/models/login_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -133,7 +135,6 @@ func (m *LoginRequest) validateClient(formats strfmt.Registry) error {
 }
 
 func (m *LoginRequest) validateOidcContext(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.OidcContext) { // not required
 		return nil
 	}
@@ -203,6 +204,84 @@ func (m *LoginRequest) validateSkip(formats strfmt.Registry) error {
 func (m *LoginRequest) validateSubject(formats strfmt.Registry) error {
 
 	if err := validate.Required("subject", "body", m.Subject); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this login request based on the context it is used
+func (m *LoginRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateClient(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateOidcContext(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRequestedAccessTokenAudience(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRequestedScope(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *LoginRequest) contextValidateClient(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Client != nil {
+		if err := m.Client.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("client")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *LoginRequest) contextValidateOidcContext(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.OidcContext != nil {
+		if err := m.OidcContext.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("oidc_context")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *LoginRequest) contextValidateRequestedAccessTokenAudience(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.RequestedAccessTokenAudience.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("requested_access_token_audience")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *LoginRequest) contextValidateRequestedScope(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.RequestedScope.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("requested_scope")
+		}
 		return err
 	}
 

--- a/internal/httpclient/models/logout_request.go
+++ b/internal/httpclient/models/logout_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -51,13 +53,40 @@ func (m *LogoutRequest) Validate(formats strfmt.Registry) error {
 }
 
 func (m *LogoutRequest) validateClient(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Client) { // not required
 		return nil
 	}
 
 	if m.Client != nil {
 		if err := m.Client.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("client")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this logout request based on the context it is used
+func (m *LogoutRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateClient(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *LogoutRequest) contextValidateClient(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Client != nil {
+		if err := m.Client.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("client")
 			}

--- a/internal/httpclient/models/null_time.go
+++ b/internal/httpclient/models/null_time.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -38,6 +40,11 @@ func (m NullTime) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// ContextValidate validates this null time based on context it is used
+func (m NullTime) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/o_auth2_client.go
+++ b/internal/httpclient/models/o_auth2_client.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -219,7 +221,6 @@ func (m *OAuth2Client) Validate(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateAllowedCorsOrigins(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.AllowedCorsOrigins) { // not required
 		return nil
 	}
@@ -235,7 +236,6 @@ func (m *OAuth2Client) validateAllowedCorsOrigins(formats strfmt.Registry) error
 }
 
 func (m *OAuth2Client) validateAudience(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Audience) { // not required
 		return nil
 	}
@@ -251,7 +251,6 @@ func (m *OAuth2Client) validateAudience(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateContacts(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Contacts) { // not required
 		return nil
 	}
@@ -267,7 +266,6 @@ func (m *OAuth2Client) validateContacts(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateCreatedAt(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.CreatedAt) { // not required
 		return nil
 	}
@@ -280,7 +278,6 @@ func (m *OAuth2Client) validateCreatedAt(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateGrantTypes(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.GrantTypes) { // not required
 		return nil
 	}
@@ -296,7 +293,6 @@ func (m *OAuth2Client) validateGrantTypes(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validatePostLogoutRedirectUris(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.PostLogoutRedirectUris) { // not required
 		return nil
 	}
@@ -312,7 +308,6 @@ func (m *OAuth2Client) validatePostLogoutRedirectUris(formats strfmt.Registry) e
 }
 
 func (m *OAuth2Client) validateRedirectUris(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.RedirectUris) { // not required
 		return nil
 	}
@@ -328,7 +323,6 @@ func (m *OAuth2Client) validateRedirectUris(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateRequestUris(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.RequestUris) { // not required
 		return nil
 	}
@@ -344,7 +338,6 @@ func (m *OAuth2Client) validateRequestUris(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateResponseTypes(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.ResponseTypes) { // not required
 		return nil
 	}
@@ -360,12 +353,11 @@ func (m *OAuth2Client) validateResponseTypes(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateScope(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Scope) { // not required
 		return nil
 	}
 
-	if err := validate.Pattern("scope", "body", string(m.Scope), `([a-zA-Z0-9\.\*]+\s?)+`); err != nil {
+	if err := validate.Pattern("scope", "body", m.Scope, `([a-zA-Z0-9\.\*]+\s?)+`); err != nil {
 		return err
 	}
 
@@ -373,12 +365,149 @@ func (m *OAuth2Client) validateScope(formats strfmt.Registry) error {
 }
 
 func (m *OAuth2Client) validateUpdatedAt(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.UpdatedAt) { // not required
 		return nil
 	}
 
 	if err := validate.FormatOf("updated_at", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this o auth2 client based on the context it is used
+func (m *OAuth2Client) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateAllowedCorsOrigins(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateAudience(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateContacts(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGrantTypes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePostLogoutRedirectUris(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRedirectUris(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRequestUris(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateResponseTypes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *OAuth2Client) contextValidateAllowedCorsOrigins(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.AllowedCorsOrigins.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("allowed_cors_origins")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OAuth2Client) contextValidateAudience(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.Audience.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("audience")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OAuth2Client) contextValidateContacts(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.Contacts.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("contacts")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OAuth2Client) contextValidateGrantTypes(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.GrantTypes.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("grant_types")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OAuth2Client) contextValidatePostLogoutRedirectUris(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.PostLogoutRedirectUris.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("post_logout_redirect_uris")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OAuth2Client) contextValidateRedirectUris(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.RedirectUris.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("redirect_uris")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OAuth2Client) contextValidateRequestUris(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.RequestUris.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("request_uris")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *OAuth2Client) contextValidateResponseTypes(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.ResponseTypes.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("response_types")
+		}
 		return err
 	}
 

--- a/internal/httpclient/models/o_auth2_token_introspection.go
+++ b/internal/httpclient/models/o_auth2_token_introspection.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -102,6 +104,11 @@ func (m *OAuth2TokenIntrospection) validateActive(formats strfmt.Registry) error
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this o auth2 token introspection based on context it is used
+func (m *OAuth2TokenIntrospection) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/oauth2_token_response.go
+++ b/internal/httpclient/models/oauth2_token_response.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -36,6 +38,11 @@ type Oauth2TokenResponse struct {
 
 // Validate validates this oauth2 token response
 func (m *Oauth2TokenResponse) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this oauth2 token response based on context it is used
+func (m *Oauth2TokenResponse) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/open_id_connect_context.go
+++ b/internal/httpclient/models/open_id_connect_context.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -56,6 +58,11 @@ type OpenIDConnectContext struct {
 
 // Validate validates this open ID connect context
 func (m *OpenIDConnectContext) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this open ID connect context based on context it is used
+func (m *OpenIDConnectContext) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/patch_document.go
+++ b/internal/httpclient/models/patch_document.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -21,10 +23,12 @@ type PatchDocument struct {
 	From string `json:"from,omitempty"`
 
 	// The operation to be performed
+	// Example: \"replace\
 	// Required: true
 	Op *string `json:"op"`
 
 	// A JSON-pointer
+	// Example: \"/name\
 	// Required: true
 	Path *string `json:"path"`
 
@@ -65,6 +69,11 @@ func (m *PatchDocument) validatePath(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this patch document based on context it is used
+func (m *PatchDocument) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/patch_request.go
+++ b/internal/httpclient/models/patch_request.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -29,6 +30,29 @@ func (m PatchRequest) Validate(formats strfmt.Registry) error {
 
 		if m[i] != nil {
 			if err := m[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName(strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+// ContextValidate validate this patch request based on the context it is used
+func (m PatchRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	for i := 0; i < len(m); i++ {
+
+		if m[i] != nil {
+			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
 				}

--- a/internal/httpclient/models/plugin_config.go
+++ b/internal/httpclient/models/plugin_config.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -328,7 +329,6 @@ func (m *PluginConfig) validatePropagatedMount(formats strfmt.Registry) error {
 }
 
 func (m *PluginConfig) validateUser(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.User) { // not required
 		return nil
 	}
@@ -355,13 +355,174 @@ func (m *PluginConfig) validateWorkDir(formats strfmt.Registry) error {
 }
 
 func (m *PluginConfig) validateRootfs(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Rootfs) { // not required
 		return nil
 	}
 
 	if m.Rootfs != nil {
 		if err := m.Rootfs.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("rootfs")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this plugin config based on the context it is used
+func (m *PluginConfig) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateArgs(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateEnv(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateInterface(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateLinux(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateMounts(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateNetwork(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateUser(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRootfs(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *PluginConfig) contextValidateArgs(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Args != nil {
+		if err := m.Args.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("Args")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PluginConfig) contextValidateEnv(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Env); i++ {
+
+		if m.Env[i] != nil {
+			if err := m.Env[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("Env" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *PluginConfig) contextValidateInterface(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Interface != nil {
+		if err := m.Interface.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("Interface")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PluginConfig) contextValidateLinux(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Linux != nil {
+		if err := m.Linux.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("Linux")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PluginConfig) contextValidateMounts(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Mounts); i++ {
+
+		if m.Mounts[i] != nil {
+			if err := m.Mounts[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("Mounts" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *PluginConfig) contextValidateNetwork(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Network != nil {
+		if err := m.Network.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("Network")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PluginConfig) contextValidateUser(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.User != nil {
+		if err := m.User.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("User")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PluginConfig) contextValidateRootfs(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Rootfs != nil {
+		if err := m.Rootfs.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("rootfs")
 			}

--- a/internal/httpclient/models/plugin_config_args.go
+++ b/internal/httpclient/models/plugin_config_args.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -93,6 +95,11 @@ func (m *PluginConfigArgs) validateValue(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this plugin config args based on context it is used
+func (m *PluginConfigArgs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_config_interface.go
+++ b/internal/httpclient/models/plugin_config_interface.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -71,6 +72,38 @@ func (m *PluginConfigInterface) validateTypes(formats strfmt.Registry) error {
 
 		if m.Types[i] != nil {
 			if err := m.Types[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("Types" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this plugin config interface based on the context it is used
+func (m *PluginConfigInterface) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateTypes(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *PluginConfigInterface) contextValidateTypes(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Types); i++ {
+
+		if m.Types[i] != nil {
+			if err := m.Types[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("Types" + "." + strconv.Itoa(i))
 				}

--- a/internal/httpclient/models/plugin_config_linux_swagger.go
+++ b/internal/httpclient/models/plugin_config_linux_swagger.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -85,6 +86,38 @@ func (m *PluginConfigLinux) validateDevices(formats strfmt.Registry) error {
 
 		if m.Devices[i] != nil {
 			if err := m.Devices[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("Devices" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this plugin config linux based on the context it is used
+func (m *PluginConfigLinux) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateDevices(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *PluginConfigLinux) contextValidateDevices(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Devices); i++ {
+
+		if m.Devices[i] != nil {
+			if err := m.Devices[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("Devices" + "." + strconv.Itoa(i))
 				}

--- a/internal/httpclient/models/plugin_config_network.go
+++ b/internal/httpclient/models/plugin_config_network.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -42,6 +44,11 @@ func (m *PluginConfigNetwork) validateType(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this plugin config network based on context it is used
+func (m *PluginConfigNetwork) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_config_rootfs.go
+++ b/internal/httpclient/models/plugin_config_rootfs.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -24,6 +26,11 @@ type PluginConfigRootfs struct {
 
 // Validate validates this plugin config rootfs
 func (m *PluginConfigRootfs) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this plugin config rootfs based on context it is used
+func (m *PluginConfigRootfs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_config_user.go
+++ b/internal/httpclient/models/plugin_config_user.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -24,6 +26,11 @@ type PluginConfigUser struct {
 
 // Validate validates this plugin config user
 func (m *PluginConfigUser) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this plugin config user based on context it is used
+func (m *PluginConfigUser) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_device.go
+++ b/internal/httpclient/models/plugin_device.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -93,6 +95,11 @@ func (m *PluginDevice) validateSettable(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this plugin device based on context it is used
+func (m *PluginDevice) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_env.go
+++ b/internal/httpclient/models/plugin_env.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -93,6 +95,11 @@ func (m *PluginEnv) validateValue(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this plugin env based on context it is used
+func (m *PluginEnv) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_interface_type.go
+++ b/internal/httpclient/models/plugin_interface_type.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -76,6 +78,11 @@ func (m *PluginInterfaceType) validateVersion(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this plugin interface type based on context it is used
+func (m *PluginInterfaceType) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_mount.go
+++ b/internal/httpclient/models/plugin_mount.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -144,6 +146,11 @@ func (m *PluginMount) validateType(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this plugin mount based on context it is used
+func (m *PluginMount) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/plugin_settings.go
+++ b/internal/httpclient/models/plugin_settings.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -118,6 +119,60 @@ func (m *PluginSettings) validateMounts(formats strfmt.Registry) error {
 
 		if m.Mounts[i] != nil {
 			if err := m.Mounts[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("Mounts" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this plugin settings based on the context it is used
+func (m *PluginSettings) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateDevices(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateMounts(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *PluginSettings) contextValidateDevices(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Devices); i++ {
+
+		if m.Devices[i] != nil {
+			if err := m.Devices[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("Devices" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *PluginSettings) contextValidateMounts(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Mounts); i++ {
+
+		if m.Mounts[i] != nil {
+			if err := m.Mounts[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("Mounts" + "." + strconv.Itoa(i))
 				}

--- a/internal/httpclient/models/previous_consent_session.go
+++ b/internal/httpclient/models/previous_consent_session.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -73,7 +75,6 @@ func (m *PreviousConsentSession) Validate(formats strfmt.Registry) error {
 }
 
 func (m *PreviousConsentSession) validateConsentRequest(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.ConsentRequest) { // not required
 		return nil
 	}
@@ -91,7 +92,6 @@ func (m *PreviousConsentSession) validateConsentRequest(formats strfmt.Registry)
 }
 
 func (m *PreviousConsentSession) validateGrantAccessTokenAudience(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.GrantAccessTokenAudience) { // not required
 		return nil
 	}
@@ -107,7 +107,6 @@ func (m *PreviousConsentSession) validateGrantAccessTokenAudience(formats strfmt
 }
 
 func (m *PreviousConsentSession) validateGrantScope(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.GrantScope) { // not required
 		return nil
 	}
@@ -123,7 +122,6 @@ func (m *PreviousConsentSession) validateGrantScope(formats strfmt.Registry) err
 }
 
 func (m *PreviousConsentSession) validateHandledAt(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.HandledAt) { // not required
 		return nil
 	}
@@ -139,13 +137,106 @@ func (m *PreviousConsentSession) validateHandledAt(formats strfmt.Registry) erro
 }
 
 func (m *PreviousConsentSession) validateSession(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Session) { // not required
 		return nil
 	}
 
 	if m.Session != nil {
 		if err := m.Session.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("session")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this previous consent session based on the context it is used
+func (m *PreviousConsentSession) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateConsentRequest(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGrantAccessTokenAudience(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGrantScope(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateHandledAt(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSession(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *PreviousConsentSession) contextValidateConsentRequest(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ConsentRequest != nil {
+		if err := m.ConsentRequest.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("consent_request")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PreviousConsentSession) contextValidateGrantAccessTokenAudience(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.GrantAccessTokenAudience.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("grant_access_token_audience")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PreviousConsentSession) contextValidateGrantScope(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.GrantScope.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("grant_scope")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PreviousConsentSession) contextValidateHandledAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.HandledAt.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("handled_at")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *PreviousConsentSession) contextValidateSession(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Session != nil {
+		if err := m.Session.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("session")
 			}

--- a/internal/httpclient/models/reject_request.go
+++ b/internal/httpclient/models/reject_request.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -38,6 +40,11 @@ type RejectRequest struct {
 
 // Validate validates this reject request
 func (m *RejectRequest) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this reject request based on context it is used
+func (m *RejectRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/request_was_handled_response.go
+++ b/internal/httpclient/models/request_was_handled_response.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -42,6 +44,11 @@ func (m *RequestWasHandledResponse) validateRedirectTo(formats strfmt.Registry) 
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this request was handled response based on context it is used
+func (m *RequestWasHandledResponse) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/string_slice_pipe_delimiter.go
+++ b/internal/httpclient/models/string_slice_pipe_delimiter.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 )
 
@@ -16,5 +18,10 @@ type StringSlicePipeDelimiter []string
 
 // Validate validates this string slice pipe delimiter
 func (m StringSlicePipeDelimiter) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this string slice pipe delimiter based on context it is used
+func (m StringSlicePipeDelimiter) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }

--- a/internal/httpclient/models/trust_jwt_grant_issuer_body.go
+++ b/internal/httpclient/models/trust_jwt_grant_issuer_body.go
@@ -19,9 +19,9 @@ import (
 // swagger:model trustJwtGrantIssuerBody
 type TrustJwtGrantIssuerBody struct {
 
-	// The "domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
+	// The "allowed_domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
 	// Example: example.com
-	Domain string `json:"domain,omitempty"`
+	AllowedDomain string `json:"allowed_domain,omitempty"`
 
 	// The "expires_at" indicates, when grant will expire, so we will reject assertion from "issuer" targeting "subject".
 	// Required: true
@@ -42,7 +42,7 @@ type TrustJwtGrantIssuerBody struct {
 	// Required: true
 	Scope []string `json:"scope"`
 
-	// The "subject" identifies the principal that is the subject of the JWT. Either this or "domain" must be present.
+	// The "subject" identifies the principal that is the subject of the JWT. Either this or "allowed_domain" must be present.
 	// Example: mike@example.com
 	Subject string `json:"subject,omitempty"`
 }

--- a/internal/httpclient/models/trusted_json_web_key.go
+++ b/internal/httpclient/models/trusted_json_web_key.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -16,14 +18,21 @@ import (
 type TrustedJSONWebKey struct {
 
 	// The "key_id" is key unique identifier (same as kid header in jws/jwt).
+	// Example: 123e4567-e89b-12d3-a456-426655440000
 	Kid string `json:"kid,omitempty"`
 
 	// The "set" is basically a name for a group(set) of keys. Will be the same as "issuer" in grant.
+	// Example: https://jwt-idp.example.com
 	Set string `json:"set,omitempty"`
 }
 
 // Validate validates this trusted Json web key
 func (m *TrustedJSONWebKey) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this trusted Json web key based on context it is used
+func (m *TrustedJSONWebKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/trusted_jwt_grant_issuer.go
+++ b/internal/httpclient/models/trusted_jwt_grant_issuer.go
@@ -19,13 +19,13 @@ import (
 // swagger:model trustedJwtGrantIssuer
 type TrustedJwtGrantIssuer struct {
 
+	// The "allowed_domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
+	// Example: example.com
+	AllowedDomain string `json:"allowed_domain,omitempty"`
+
 	// The "created_at" indicates, when grant was created.
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
-
-	// The "domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
-	// Example: example.com
-	Domain string `json:"domain,omitempty"`
 
 	// The "expires_at" indicates, when grant will expire, so we will reject assertion from "issuer" targeting "subject".
 	// Format: date-time
@@ -46,7 +46,7 @@ type TrustedJwtGrantIssuer struct {
 	// Example: ["openid","offline"]
 	Scope []string `json:"scope"`
 
-	// The "subject" identifies the principal that is the subject of the JWT. Either this or "domain" must be present.
+	// The "subject" identifies the principal that is the subject of the JWT. Either this or "allowed_domain" must be present.
 	// Example: mike@example.com
 	Subject string `json:"subject,omitempty"`
 }

--- a/internal/httpclient/models/trusted_jwt_grant_issuers.go
+++ b/internal/httpclient/models/trusted_jwt_grant_issuers.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -29,6 +30,29 @@ func (m TrustedJwtGrantIssuers) Validate(formats strfmt.Registry) error {
 
 		if m[i] != nil {
 			if err := m[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName(strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+// ContextValidate validate this trusted jwt grant issuers based on the context it is used
+func (m TrustedJwtGrantIssuers) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	for i := 0; i < len(m); i++ {
+
+		if m[i] != nil {
+			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
 				}

--- a/internal/httpclient/models/userinfo_response.go
+++ b/internal/httpclient/models/userinfo_response.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -75,6 +77,11 @@ type UserinfoResponse struct {
 
 // Validate validates this userinfo response
 func (m *UserinfoResponse) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this userinfo response based on context it is used
+func (m *UserinfoResponse) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/version.go
+++ b/internal/httpclient/models/version.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -21,6 +23,11 @@ type Version struct {
 
 // Validate validates this version
 func (m *Version) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this version based on context it is used
+func (m *Version) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/volume.go
+++ b/internal/httpclient/models/volume.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -106,6 +108,10 @@ func (m *Volume) validateDriver(formats strfmt.Registry) error {
 
 func (m *Volume) validateLabels(formats strfmt.Registry) error {
 
+	if err := validate.Required("Labels", "body", m.Labels); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -129,6 +135,10 @@ func (m *Volume) validateName(formats strfmt.Registry) error {
 
 func (m *Volume) validateOptions(formats strfmt.Registry) error {
 
+	if err := validate.Required("Options", "body", m.Options); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -142,13 +152,40 @@ func (m *Volume) validateScope(formats strfmt.Registry) error {
 }
 
 func (m *Volume) validateUsageData(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.UsageData) { // not required
 		return nil
 	}
 
 	if m.UsageData != nil {
 		if err := m.UsageData.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("UsageData")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this volume based on the context it is used
+func (m *Volume) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateUsageData(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Volume) contextValidateUsageData(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.UsageData != nil {
+		if err := m.UsageData.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("UsageData")
 			}

--- a/internal/httpclient/models/volume_usage_data.go
+++ b/internal/httpclient/models/volume_usage_data.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -64,6 +66,11 @@ func (m *VolumeUsageData) validateSize(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this volume usage data based on context it is used
+func (m *VolumeUsageData) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/internal/httpclient/models/well_known.go
+++ b/internal/httpclient/models/well_known.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -21,6 +23,7 @@ import (
 type WellKnown struct {
 
 	// URL of the OP's OAuth 2.0 Authorization Endpoint.
+	// Example: https://playground.ory.sh/ory-hydra/public/oauth2/auth
 	// Required: true
 	AuthorizationEndpoint *string `json:"authorization_endpoint"`
 
@@ -64,6 +67,7 @@ type WellKnown struct {
 	// URL using the https scheme with no query or fragment component that the OP asserts as its IssuerURL Identifier.
 	// If IssuerURL discovery is supported , this value MUST be identical to the issuer value returned
 	// by WebFinger. This also MUST be identical to the iss Claim value in ID Tokens issued from this IssuerURL.
+	// Example: https://playground.ory.sh/ory-hydra/public/
 	// Required: true
 	Issuer *string `json:"issuer"`
 
@@ -74,10 +78,12 @@ type WellKnown struct {
 	// Although some algorithms allow the same key to be used for both signatures and encryption, doing so is
 	// NOT RECOMMENDED, as it is less secure. The JWK x5c parameter MAY be used to provide X.509 representations of
 	// keys provided. When used, the bare key values MUST still be present and MUST match those in the certificate.
+	// Example: https://playground.ory.sh/ory-hydra/public/.well-known/jwks.json
 	// Required: true
 	JwksURI *string `json:"jwks_uri"`
 
 	// URL of the OP's Dynamic Client Registration Endpoint.
+	// Example: https://playground.ory.sh/ory-hydra/admin/client
 	RegistrationEndpoint string `json:"registration_endpoint,omitempty"`
 
 	// JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for Request Objects,
@@ -117,6 +123,7 @@ type WellKnown struct {
 	SubjectTypesSupported []string `json:"subject_types_supported"`
 
 	// URL of the OP's OAuth 2.0 Token Endpoint
+	// Example: https://playground.ory.sh/ory-hydra/public/oauth2/token
 	// Required: true
 	TokenEndpoint *string `json:"token_endpoint"`
 
@@ -229,6 +236,11 @@ func (m *WellKnown) validateTokenEndpoint(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this well known based on context it is used
+func (m *WellKnown) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/oauth2/trust/doc.go
+++ b/oauth2/trust/doc.go
@@ -38,15 +38,15 @@ type trustJwtGrantIssuerBody struct {
 	// example: https://jwt-idp.example.com
 	Issuer string `json:"issuer"`
 
-	// The "subject" identifies the principal that is the subject of the JWT. Either this or "domain" must be present.
+	// The "subject" identifies the principal that is the subject of the JWT. Either this or "allowed_domain" must be present.
 	//
 	// example: mike@example.com
 	Subject string `json:"subject"`
 
-	// The "domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
+	// The "allowed_domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
 	//
 	// example: example.com
-	Domain string `json:"domain"`
+	AllowedDomain string `json:"allowed_domain"`
 
 	// The "scope" contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	//
@@ -108,13 +108,13 @@ type trustedJwtGrantIssuer struct {
 	// example: https://jwt-idp.example.com
 	Issuer string `json:"issuer"`
 
-	// The "subject" identifies the principal that is the subject of the JWT. Either this or "domain" must be present.
+	// The "subject" identifies the principal that is the subject of the JWT. Either this or "allowed_domain" must be present.
 	// example: mike@example.com
 	Subject string `json:"subject"`
 
-	// The "domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
+	// The "allowed_domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
 	// example: example.com
-	Domain string `json:"domain"`
+	AllowedDomain string `json:"allowed_domain"`
 
 	// The "scope" contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	// example: ["openid", "offline"]

--- a/oauth2/trust/doc.go
+++ b/oauth2/trust/doc.go
@@ -38,11 +38,15 @@ type trustJwtGrantIssuerBody struct {
 	// example: https://jwt-idp.example.com
 	Issuer string `json:"issuer"`
 
-	// The "subject" identifies the principal that is the subject of the JWT.
+	// The "subject" identifies the principal that is the subject of the JWT. Either this or "domain" must be present.
 	//
-	// required:true
 	// example: mike@example.com
 	Subject string `json:"subject"`
+
+	// The "domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
+	//
+	// example: example.com
+	Domain string `json:"domain"`
 
 	// The "scope" contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	//
@@ -104,9 +108,13 @@ type trustedJwtGrantIssuer struct {
 	// example: https://jwt-idp.example.com
 	Issuer string `json:"issuer"`
 
-	// The "subject" identifies the principal that is the subject of the JWT.
+	// The "subject" identifies the principal that is the subject of the JWT. Either this or "domain" must be present.
 	// example: mike@example.com
 	Subject string `json:"subject"`
+
+	// The "domain" is used to allow any user under that domain as the subject of the JWT. Either this or "subject" must be present.
+	// example: example.com
+	Domain string `json:"domain"`
 
 	// The "scope" contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	// example: ["openid", "offline"]

--- a/oauth2/trust/grant.go
+++ b/oauth2/trust/grant.go
@@ -11,7 +11,10 @@ type Grant struct {
 	Issuer string `json:"issuer"`
 
 	// Subject identifies the principal that is the subject of the JWT.
-	Subject string `json:"subject"`
+	Subject string `json:"subject,omitempty"`
+
+	// Domain contains the domain the issuer can authorise.
+	Domain string `json:"domain,omitempty"`
 
 	// Scope contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	Scope []string `json:"scope"`

--- a/oauth2/trust/grant.go
+++ b/oauth2/trust/grant.go
@@ -13,8 +13,8 @@ type Grant struct {
 	// Subject identifies the principal that is the subject of the JWT.
 	Subject string `json:"subject,omitempty"`
 
-	// Domain contains the domain the issuer can authorise.
-	Domain string `json:"domain,omitempty"`
+	// AllowedDomain contains the domain the issuer can authorise.
+	AllowedDomain string `json:"allowed_domain,omitempty"`
 
 	// Scope contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	Scope []string `json:"scope"`

--- a/oauth2/trust/handler.go
+++ b/oauth2/trust/handler.go
@@ -72,6 +72,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 		ID:      uuid.New().String(),
 		Issuer:  grantRequest.Issuer,
 		Subject: grantRequest.Subject,
+		Domain:  grantRequest.Domain,
 		Scope:   grantRequest.Scope,
 		PublicKey: PublicKey{
 			Set:   grantRequest.Issuer, // group all keys by issuer, so set=issuer

--- a/oauth2/trust/handler.go
+++ b/oauth2/trust/handler.go
@@ -69,11 +69,11 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	}
 
 	grant := Grant{
-		ID:      uuid.New().String(),
-		Issuer:  grantRequest.Issuer,
-		Subject: grantRequest.Subject,
-		Domain:  grantRequest.Domain,
-		Scope:   grantRequest.Scope,
+		ID:            uuid.New().String(),
+		Issuer:        grantRequest.Issuer,
+		Subject:       grantRequest.Subject,
+		AllowedDomain: grantRequest.AllowedDomain,
+		Scope:         grantRequest.Scope,
 		PublicKey: PublicKey{
 			Set:   grantRequest.Issuer, // group all keys by issuer, so set=issuer
 			KeyID: grantRequest.PublicKeyJWK.KeyID,

--- a/oauth2/trust/handler_test.go
+++ b/oauth2/trust/handler_test.go
@@ -92,7 +92,7 @@ func (s *HandlerTestSuite) TestGrantCanBeCreatedAndFetched() {
 	s.Require().NoError(err, "no errors expected on grant creation")
 	s.NotEmpty(createResult.Payload.ID, " grant id expected to be non-empty")
 	s.Equal(*model.Issuer, createResult.Payload.Issuer, "issuer must match")
-	s.Equal(*model.Subject, createResult.Payload.Subject, "subject must match")
+	s.Equal(model.Subject, createResult.Payload.Subject, "subject must match")
 	s.Equal(model.Scope, createResult.Payload.Scope, "scopes must match")
 	s.Equal(*model.Issuer, createResult.Payload.PublicKey.Set, "public key set must match grant issuer")
 	s.Equal(*model.Jwk.Kid, createResult.Payload.PublicKey.Kid, "public key id must match")
@@ -105,7 +105,7 @@ func (s *HandlerTestSuite) TestGrantCanBeCreatedAndFetched() {
 	s.Require().NoError(err, "no errors expected on grant fetching")
 	s.Equal(getRequestParams.ID, getResult.Payload.ID, " grant id must match")
 	s.Equal(*model.Issuer, getResult.Payload.Issuer, "issuer must match")
-	s.Equal(*model.Subject, getResult.Payload.Subject, "subject must match")
+	s.Equal(model.Subject, getResult.Payload.Subject, "subject must match")
 	s.Equal(model.Scope, getResult.Payload.Scope, "scopes must match")
 	s.Equal(*model.Issuer, getResult.Payload.PublicKey.Set, "public key set must match grant issuer")
 	s.Equal(*model.Jwk.Kid, getResult.Payload.PublicKey.Kid, "public key id must match")
@@ -198,7 +198,7 @@ func (s *HandlerTestSuite) TestGrantPublicCanBeFetched() {
 	createRequestParams := s.newCreateJwtBearerGrantParams(
 		"ory",
 		"hackerman@example.com",
-		"example.com",
+		"",
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -302,8 +302,8 @@ func (s *HandlerTestSuite) newCreateJwtBearerGrantParams(
 		Issuer:    &issuer,
 		Jwk:       s.generateJWK(s.publicKey),
 		Scope:     scope,
-		Subject:   &subject,
-		//Domain: &domain,
+		Subject:   subject,
+		Domain:    domain,
 	}
 	createRequestParams.SetBody(model)
 

--- a/oauth2/trust/handler_test.go
+++ b/oauth2/trust/handler_test.go
@@ -293,17 +293,17 @@ func (s *HandlerTestSuite) generateJWK(publicKey *rsa.PublicKey) *models.JSONWeb
 }
 
 func (s *HandlerTestSuite) newCreateJwtBearerGrantParams(
-	issuer, subject string, domain string, scope []string, expiresAt time.Time,
+	issuer, subject string, allowedDomain string, scope []string, expiresAt time.Time,
 ) *admin.TrustJwtGrantIssuerParams {
 	createRequestParams := admin.NewTrustJwtGrantIssuerParams()
 	exp := strfmt.DateTime(expiresAt.UTC().Round(time.Second))
 	model := &models.TrustJwtGrantIssuerBody{
-		ExpiresAt: &exp,
-		Issuer:    &issuer,
-		Jwk:       s.generateJWK(s.publicKey),
-		Scope:     scope,
-		Subject:   subject,
-		Domain:    domain,
+		ExpiresAt:     &exp,
+		Issuer:        &issuer,
+		Jwk:           s.generateJWK(s.publicKey),
+		Scope:         scope,
+		Subject:       subject,
+		AllowedDomain: allowedDomain,
 	}
 	createRequestParams.SetBody(model)
 

--- a/oauth2/trust/manager.go
+++ b/oauth2/trust/manager.go
@@ -17,15 +17,15 @@ type GrantManager interface {
 }
 
 type SQLData struct {
-	ID        string    `db:"id"`
-	Issuer    string    `db:"issuer"`
-	Subject   string    `db:"subject"`
-	Domain    string    `db:"domain"`
-	Scope     string    `db:"scope"`
-	KeySet    string    `db:"key_set"`
-	KeyID     string    `db:"key_id"`
-	CreatedAt time.Time `db:"created_at"`
-	ExpiresAt time.Time `db:"expires_at"`
+	ID            string    `db:"id"`
+	Issuer        string    `db:"issuer"`
+	Subject       string    `db:"subject"`
+	AllowedDomain string    `db:"allowed_domain"`
+	Scope         string    `db:"scope"`
+	KeySet        string    `db:"key_set"`
+	KeyID         string    `db:"key_id"`
+	CreatedAt     time.Time `db:"created_at"`
+	ExpiresAt     time.Time `db:"expires_at"`
 }
 
 func (SQLData) TableName() string {

--- a/oauth2/trust/manager.go
+++ b/oauth2/trust/manager.go
@@ -20,6 +20,7 @@ type SQLData struct {
 	ID        string    `db:"id"`
 	Issuer    string    `db:"issuer"`
 	Subject   string    `db:"subject"`
+	Domain    string    `db:"domain"`
 	Scope     string    `db:"scope"`
 	KeySet    string    `db:"key_set"`
 	KeyID     string    `db:"key_id"`

--- a/oauth2/trust/request.go
+++ b/oauth2/trust/request.go
@@ -14,7 +14,7 @@ type createGrantRequest struct {
 	Subject string `json:"subject"`
 
 	// Domain contains the domain the issuer can authorise.
-	Domain string `json:"domain"`
+	AllowedDomain string `json:"allowed_domain"`
 
 	// Scope contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	Scope []string `json:"scope"`

--- a/oauth2/trust/request.go
+++ b/oauth2/trust/request.go
@@ -13,6 +13,9 @@ type createGrantRequest struct {
 	// Subject identifies the principal that is the subject of the JWT.
 	Subject string `json:"subject"`
 
+	// Domain contains the domain the issuer can authorise.
+	Domain string `json:"domain"`
+
 	// Scope contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	Scope []string `json:"scope"`
 

--- a/oauth2/trust/validator.go
+++ b/oauth2/trust/validator.go
@@ -16,8 +16,12 @@ func (v *GrantValidator) Validate(request createGrantRequest) error {
 		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Field 'issuer' is required."))
 	}
 
-	if request.Subject == "" {
-		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Field 'subject' is required."))
+	if request.Domain != "" && request.Subject != "" {
+		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Fields 'subject' and 'domain' are mutually exclusive, both cannot be set at the same time."))
+	}
+
+	if request.Subject == "" && request.Domain == "" {
+		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Both 'subject' and 'domain' fields are empty, one of them is required."))
 	}
 
 	if request.ExpiresAt.IsZero() {

--- a/oauth2/trust/validator.go
+++ b/oauth2/trust/validator.go
@@ -16,12 +16,12 @@ func (v *GrantValidator) Validate(request createGrantRequest) error {
 		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Field 'issuer' is required."))
 	}
 
-	if request.Domain != "" && request.Subject != "" {
-		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Fields 'subject' and 'domain' are mutually exclusive, both cannot be set at the same time."))
+	if request.AllowedDomain != "" && request.Subject != "" {
+		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Fields 'subject' and 'allowed_domain' are mutually exclusive, both cannot be set at the same time."))
 	}
 
-	if request.Subject == "" && request.Domain == "" {
-		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Both 'subject' and 'domain' fields are empty, one of them is required."))
+	if request.Subject == "" && request.AllowedDomain == "" {
+		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Both 'subject' and 'allowed_domain' fields are empty, one of them is required."))
 	}
 
 	if request.ExpiresAt.IsZero() {

--- a/oauth2/trust/validator_test.go
+++ b/oauth2/trust/validator_test.go
@@ -11,10 +11,10 @@ func TestEmptyIssuerIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "",
-		Subject:   "valid-subject",
-		Domain:    "",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:        "",
+		Subject:       "valid-subject",
+		AllowedDomain: "",
+		ExpiresAt:     time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -29,10 +29,10 @@ func TestEmptySubjectIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "",
-		Domain:    "",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:        "valid-issuer",
+		Subject:       "",
+		AllowedDomain: "",
+		ExpiresAt:     time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -47,10 +47,10 @@ func TestEmptyExpiresAtIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "valid-subject",
-		Domain:    "",
-		ExpiresAt: time.Time{},
+		Issuer:        "valid-issuer",
+		Subject:       "valid-subject",
+		AllowedDomain: "",
+		ExpiresAt:     time.Time{},
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -65,10 +65,10 @@ func TestEmptyPublicKeyIdIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "valid-subject",
-		Domain:    "",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:        "valid-issuer",
+		Subject:       "valid-subject",
+		AllowedDomain: "",
+		ExpiresAt:     time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "",
 		},
@@ -83,10 +83,10 @@ func TestIsValid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "valid-subject",
-		Domain:    "",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:        "valid-issuer",
+		Subject:       "valid-subject",
+		AllowedDomain: "",
+		ExpiresAt:     time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -101,10 +101,10 @@ func TestDomainIsValid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "",
-		Domain:    "ory.sh",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:        "valid-issuer",
+		Subject:       "",
+		AllowedDomain: "ory.sh",
+		ExpiresAt:     time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -119,10 +119,10 @@ func TestAnySubjectWithSubjectIsNotValid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "valid-subject",
-		Domain:    "ory.sh",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:        "valid-issuer",
+		Subject:       "valid-subject",
+		AllowedDomain: "ory.sh",
+		ExpiresAt:     time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},

--- a/oauth2/trust/validator_test.go
+++ b/oauth2/trust/validator_test.go
@@ -13,6 +13,7 @@ func TestEmptyIssuerIsInvalid(t *testing.T) {
 	r := createGrantRequest{
 		Issuer:    "",
 		Subject:   "valid-subject",
+		Domain:    "",
 		ExpiresAt: time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
@@ -30,6 +31,7 @@ func TestEmptySubjectIsInvalid(t *testing.T) {
 	r := createGrantRequest{
 		Issuer:    "valid-issuer",
 		Subject:   "",
+		Domain:    "",
 		ExpiresAt: time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
@@ -47,6 +49,7 @@ func TestEmptyExpiresAtIsInvalid(t *testing.T) {
 	r := createGrantRequest{
 		Issuer:    "valid-issuer",
 		Subject:   "valid-subject",
+		Domain:    "",
 		ExpiresAt: time.Time{},
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
@@ -64,6 +67,7 @@ func TestEmptyPublicKeyIdIsInvalid(t *testing.T) {
 	r := createGrantRequest{
 		Issuer:    "valid-issuer",
 		Subject:   "valid-subject",
+		Domain:    "",
 		ExpiresAt: time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "",
@@ -81,6 +85,7 @@ func TestIsValid(t *testing.T) {
 	r := createGrantRequest{
 		Issuer:    "valid-issuer",
 		Subject:   "valid-subject",
+		Domain:    "",
 		ExpiresAt: time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
@@ -89,5 +94,41 @@ func TestIsValid(t *testing.T) {
 
 	if err := v.Validate(r); err != nil {
 		t.Error("A request with an issuer, a subject, an expiration and a public key should be valid")
+	}
+}
+
+func TestDomainIsValid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:    "valid-issuer",
+		Subject:   "",
+		Domain:    "ory.sh",
+		ExpiresAt: time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err != nil {
+		t.Error("A request with a domain restriction and an empty subject should be valid")
+	}
+}
+
+func TestAnySubjectWithSubjectIsNotValid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:    "valid-issuer",
+		Subject:   "valid-subject",
+		Domain:    "ory.sh",
+		ExpiresAt: time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err == nil {
+		t.Error("A request with a domain restriction and a non-empty subject should not be valid")
 	}
 }

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.down.sql
@@ -1,6 +1,6 @@
-DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_domain_key_id_key CASCADE;
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_allowed_domain_key_id_key CASCADE;
 
-ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    DROP COLUMN domain;
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer DROP COLUMN allowed_domain;
 
-CREATE UNIQUE INDEX ON hydra_oauth2_trusted_jwt_bearer_issuer(issuer, subject, key_id);
+CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key
+    ON hydra_oauth2_trusted_jwt_bearer_issuer(issuer, subject, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_domain_key_id_key CASCADE;
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    DROP COLUMN domain;
+
+CREATE UNIQUE INDEX ON hydra_oauth2_trusted_jwt_bearer_issuer(issuer, subject, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.up.sql
@@ -1,0 +1,6 @@
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key CASCADE;
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    ADD COLUMN domain VARCHAR(255) NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX ON hydra_oauth2_trusted_jwt_bearer_issuer(issuer, subject, domain, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.cockroach.up.sql
@@ -1,6 +1,7 @@
 DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key CASCADE;
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    ADD COLUMN domain VARCHAR(255) NOT NULL DEFAULT '';
+    ADD COLUMN allowed_domain VARCHAR(255) NOT NULL DEFAULT '';
 
-CREATE UNIQUE INDEX ON hydra_oauth2_trusted_jwt_bearer_issuer(issuer, subject, domain, key_id);
+CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_allowed_domain_key_id_key
+    ON hydra_oauth2_trusted_jwt_bearer_issuer(issuer, subject, allowed_domain, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.down.sql
@@ -4,4 +4,4 @@ ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
     ADD CONSTRAINT issuer UNIQUE (issuer, subject, key_id);
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    DROP COLUMN domain;
+    DROP COLUMN allowed_domain;

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.down.sql
@@ -1,0 +1,7 @@
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx,
+    ADD CONSTRAINT issuer UNIQUE (issuer, subject, key_id);
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    DROP COLUMN domain;

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.up.sql
@@ -1,7 +1,7 @@
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    ADD COLUMN domain VARCHAR(255) NOT NULL DEFAULT '',
+    ADD COLUMN allowed_domain VARCHAR(255) NOT NULL DEFAULT '',
     DROP INDEX issuer;
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer, subject, domain, key_id);
+    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer, subject, allowed_domain, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.up.sql
@@ -1,0 +1,7 @@
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    ADD COLUMN domain VARCHAR(255) NOT NULL DEFAULT '',
+    DROP INDEX issuer;
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer, subject, domain, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.mysql.up.sql
@@ -4,4 +4,4 @@ ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
     DROP INDEX issuer;
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer, subject, allowed_domain, key_id);
+    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer(128), subject(128), allowed_domain(128), key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.down.sql
@@ -1,0 +1,7 @@
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    DROP CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx,
+    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issue_issuer_subject_key_id_key UNIQUE (issuer, subject, key_id);
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    DROP COLUMN domain;

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.down.sql
@@ -4,4 +4,4 @@ ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
     ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issue_issuer_subject_key_id_key UNIQUE (issuer, subject, key_id);
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    DROP COLUMN domain;
+    DROP COLUMN allowed_domain;

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.up.sql
@@ -1,0 +1,7 @@
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    ADD COLUMN domain VARCHAR(255) NOT NULL DEFAULT '',
+    DROP CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issue_issuer_subject_key_id_key;
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer, subject, domain, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.postgres.up.sql
@@ -1,7 +1,7 @@
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    ADD COLUMN domain VARCHAR(255) NOT NULL DEFAULT '',
+    ADD COLUMN allowed_domain VARCHAR(255) NOT NULL DEFAULT '',
     DROP CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issue_issuer_subject_key_id_key;
 
 ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
-    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer, subject, domain, key_id);
+    ADD CONSTRAINT hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_idx UNIQUE (issuer, subject, allowed_domain, key_id);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.down.sql
@@ -1,0 +1,23 @@
+
+CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer_tmp
+(
+    id         VARCHAR(36) PRIMARY KEY,
+    issuer     VARCHAR(255) NOT NULL,
+    subject    VARCHAR(255) NOT NULL,
+    scope      TEXT         NOT NULL,
+    key_set    varchar(255) NOT NULL,
+    key_id     varchar(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE (issuer, subject, key_id),
+    FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
+);
+
+INSERT INTO hydra_oauth2_trusted_jwt_bearer_issuer_tmp
+SELECT id, issuer, subject, scope, key_set, key_id, created_at, expires_at FROM hydra_oauth2_trusted_jwt_bearer_issuer;
+
+DROP TABLE hydra_oauth2_trusted_jwt_bearer_issuer;
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer_tmp RENAME TO hydra_oauth2_trusted_jwt_bearer_issuer;
+
+CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.down.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.down.sql
@@ -1,5 +1,5 @@
 
-CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer_tmp
+CREATE TABLE "_hydra_oauth2_trusted_jwt_bearer_issuer_tmp"
 (
     id         VARCHAR(36) PRIMARY KEY,
     issuer     VARCHAR(255) NOT NULL,
@@ -13,11 +13,11 @@ CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer_tmp
     FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
 );
 
-INSERT INTO hydra_oauth2_trusted_jwt_bearer_issuer_tmp
-SELECT id, issuer, subject, scope, key_set, key_id, created_at, expires_at FROM hydra_oauth2_trusted_jwt_bearer_issuer;
+INSERT INTO "_hydra_oauth2_trusted_jwt_bearer_issuer_tmp"
+SELECT id, issuer, subject, scope, key_set, key_id, created_at, expires_at FROM "hydra_oauth2_trusted_jwt_bearer_issuer";
 
-DROP TABLE hydra_oauth2_trusted_jwt_bearer_issuer;
+DROP TABLE "hydra_oauth2_trusted_jwt_bearer_issuer";
 
-ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer_tmp RENAME TO hydra_oauth2_trusted_jwt_bearer_issuer;
+ALTER TABLE "_hydra_oauth2_trusted_jwt_bearer_issuer_tmp" RENAME TO "hydra_oauth2_trusted_jwt_bearer_issuer";
 
 CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.up.sql
@@ -1,0 +1,24 @@
+
+CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer_tmp
+(
+    id         VARCHAR(36) PRIMARY KEY,
+    issuer     VARCHAR(255) NOT NULL,
+    subject    VARCHAR(255) NOT NULL,
+    domain     VARCHAR(255) NOT NULL,
+    scope      TEXT         NOT NULL,
+    key_set    varchar(255) NOT NULL,
+    key_id     varchar(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE (issuer, subject, domain, key_id),
+    FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
+);
+
+INSERT INTO hydra_oauth2_trusted_jwt_bearer_issuer_tmp
+SELECT id, issuer, subject, '', scope, key_set, key_id, created_at, expires_at FROM hydra_oauth2_trusted_jwt_bearer_issuer;
+
+DROP TABLE hydra_oauth2_trusted_jwt_bearer_issuer;
+
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer_tmp RENAME TO hydra_oauth2_trusted_jwt_bearer_issuer;
+
+CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.up.sql
+++ b/persistence/sql/migrations/20220127125900000000_domain_jwk_bearer.sqlite.up.sql
@@ -1,24 +1,24 @@
 
-CREATE TABLE IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer_tmp
+CREATE TABLE "_hydra_oauth2_trusted_jwt_bearer_issuer_tmp"
 (
-    id         VARCHAR(36) PRIMARY KEY,
-    issuer     VARCHAR(255) NOT NULL,
-    subject    VARCHAR(255) NOT NULL,
-    domain     VARCHAR(255) NOT NULL,
-    scope      TEXT         NOT NULL,
-    key_set    varchar(255) NOT NULL,
-    key_id     varchar(255) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    expires_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    UNIQUE (issuer, subject, domain, key_id),
+    id             VARCHAR(36) PRIMARY KEY,
+    issuer         VARCHAR(255) NOT NULL,
+    subject        VARCHAR(255) NOT NULL,
+    allowed_domain VARCHAR(255) NOT NULL,
+    scope          TEXT         NOT NULL,
+    key_set        varchar(255) NOT NULL,
+    key_id         varchar(255) NOT NULL,
+    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE (issuer, subject, allowed_domain, key_id),
     FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
 );
 
-INSERT INTO hydra_oauth2_trusted_jwt_bearer_issuer_tmp
-SELECT id, issuer, subject, '', scope, key_set, key_id, created_at, expires_at FROM hydra_oauth2_trusted_jwt_bearer_issuer;
+INSERT INTO "_hydra_oauth2_trusted_jwt_bearer_issuer_tmp"
+SELECT id, issuer, subject, '', scope, key_set, key_id, created_at, expires_at FROM "hydra_oauth2_trusted_jwt_bearer_issuer";
 
-DROP TABLE hydra_oauth2_trusted_jwt_bearer_issuer;
+DROP TABLE "hydra_oauth2_trusted_jwt_bearer_issuer";
 
-ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer_tmp RENAME TO hydra_oauth2_trusted_jwt_bearer_issuer;
+ALTER TABLE "_hydra_oauth2_trusted_jwt_bearer_issuer_tmp" RENAME TO "hydra_oauth2_trusted_jwt_bearer_issuer";
 
 CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/persister_grant_jwk.go
+++ b/persistence/sql/persister_grant_jwk.go
@@ -93,7 +93,7 @@ func (p *Persister) GetPublicKey(ctx context.Context, issuer string, subject str
 		Where("key_id = ?", keyId)
 
 	if domain := getDomainFromSubject(subject); domain != "" {
-		query = query.Where("subject = ? or domain = ?", subject, domain)
+		query = query.Where("subject = ? or allowed_domain = ?", subject, domain)
 	} else {
 		query = query.Where("subject = ?", subject)
 	}
@@ -115,7 +115,7 @@ func (p *Persister) GetPublicKeys(ctx context.Context, issuer string, subject st
 	query := p.Connection(ctx).Where("issuer = ?", issuer)
 
 	if domain := getDomainFromSubject(subject); domain != "" {
-		query = query.Where("subject = ? or domain = ?", subject, domain)
+		query = query.Where("subject = ? or allowed_domain = ?", subject, domain)
 	} else {
 		query = query.Where("subject = ?", subject)
 	}
@@ -152,7 +152,7 @@ func (p *Persister) GetPublicKeyScopes(ctx context.Context, issuer string, subje
 		Where("key_id = ?", keyId)
 
 	if domain := getDomainFromSubject(subject); domain != "" {
-		query = query.Where("subject = ? or domain = ?", subject, domain)
+		query = query.Where("subject = ? or allowed_domain = ?", subject, domain)
 	} else {
 		query = query.Where("subject = ?", subject)
 	}
@@ -179,25 +179,25 @@ func (p *Persister) MarkJWTUsedForTime(ctx context.Context, jti string, exp time
 
 func (p *Persister) sqlDataFromJWTGrant(g trust.Grant) trust.SQLData {
 	return trust.SQLData{
-		ID:        g.ID,
-		Issuer:    g.Issuer,
-		Subject:   g.Subject,
-		Domain:    g.Domain,
-		Scope:     strings.Join(g.Scope, "|"),
-		KeySet:    g.PublicKey.Set,
-		KeyID:     g.PublicKey.KeyID,
-		CreatedAt: g.CreatedAt,
-		ExpiresAt: g.ExpiresAt,
+		ID:            g.ID,
+		Issuer:        g.Issuer,
+		Subject:       g.Subject,
+		AllowedDomain: g.AllowedDomain,
+		Scope:         strings.Join(g.Scope, "|"),
+		KeySet:        g.PublicKey.Set,
+		KeyID:         g.PublicKey.KeyID,
+		CreatedAt:     g.CreatedAt,
+		ExpiresAt:     g.ExpiresAt,
 	}
 }
 
 func (p *Persister) jwtGrantFromSQlData(data trust.SQLData) trust.Grant {
 	return trust.Grant{
-		ID:      data.ID,
-		Issuer:  data.Issuer,
-		Subject: data.Subject,
-		Domain:  data.Domain,
-		Scope:   stringsx.Splitx(data.Scope, "|"),
+		ID:            data.ID,
+		Issuer:        data.Issuer,
+		Subject:       data.Subject,
+		AllowedDomain: data.AllowedDomain,
+		Scope:         stringsx.Splitx(data.Scope, "|"),
 		PublicKey: trust.PublicKey{
 			Set:   data.KeySet,
 			KeyID: data.KeyID,

--- a/spec/api.json
+++ b/spec/api.json
@@ -3608,8 +3608,8 @@
         "expires_at"
       ],
       "properties": {
-        "domain": {
-          "description": "The \"domain\" is used to allow any user under that domain as the subject of the JWT. Either this or \"subject\" must be present.",
+        "allowed_domain": {
+          "description": "The \"allowed_domain\" is used to allow any user under that domain as the subject of the JWT. Either this or \"subject\" must be present.",
           "type": "string",
           "example": "example.com"
         },
@@ -3638,7 +3638,7 @@
           ]
         },
         "subject": {
-          "description": "The \"subject\" identifies the principal that is the subject of the JWT. Either this or \"domain\" must be present.",
+          "description": "The \"subject\" identifies the principal that is the subject of the JWT. Either this or \"allowed_domain\" must be present.",
           "type": "string",
           "example": "mike@example.com"
         }
@@ -3662,15 +3662,15 @@
     "trustedJwtGrantIssuer": {
       "type": "object",
       "properties": {
+        "allowed_domain": {
+          "description": "The \"allowed_domain\" is used to allow any user under that domain as the subject of the JWT. Either this or \"subject\" must be present.",
+          "type": "string",
+          "example": "example.com"
+        },
         "created_at": {
           "description": "The \"created_at\" indicates, when grant was created.",
           "type": "string",
           "format": "date-time"
-        },
-        "domain": {
-          "description": "The \"domain\" is used to allow any user under that domain as the subject of the JWT. Either this or \"subject\" must be present.",
-          "type": "string",
-          "example": "example.com"
         },
         "expires_at": {
           "description": "The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".",
@@ -3701,7 +3701,7 @@
           ]
         },
         "subject": {
-          "description": "The \"subject\" identifies the principal that is the subject of the JWT. Either this or \"domain\" must be present.",
+          "description": "The \"subject\" identifies the principal that is the subject of the JWT. Either this or \"allowed_domain\" must be present.",
           "type": "string",
           "example": "mike@example.com"
         }

--- a/spec/api.json
+++ b/spec/api.json
@@ -3603,12 +3603,16 @@
       "type": "object",
       "required": [
         "issuer",
-        "subject",
         "scope",
         "jwk",
         "expires_at"
       ],
       "properties": {
+        "domain": {
+          "description": "The \"domain\" is used to allow any user under that domain as the subject of the JWT. Either this or \"subject\" must be present.",
+          "type": "string",
+          "example": "example.com"
+        },
         "expires_at": {
           "description": "The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".",
           "type": "string",
@@ -3634,7 +3638,7 @@
           ]
         },
         "subject": {
-          "description": "The \"subject\" identifies the principal that is the subject of the JWT.",
+          "description": "The \"subject\" identifies the principal that is the subject of the JWT. Either this or \"domain\" must be present.",
           "type": "string",
           "example": "mike@example.com"
         }
@@ -3662,6 +3666,11 @@
           "description": "The \"created_at\" indicates, when grant was created.",
           "type": "string",
           "format": "date-time"
+        },
+        "domain": {
+          "description": "The \"domain\" is used to allow any user under that domain as the subject of the JWT. Either this or \"subject\" must be present.",
+          "type": "string",
+          "example": "example.com"
         },
         "expires_at": {
           "description": "The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".",
@@ -3692,7 +3701,7 @@
           ]
         },
         "subject": {
-          "description": "The \"subject\" identifies the principal that is the subject of the JWT.",
+          "description": "The \"subject\" identifies the principal that is the subject of the JWT. Either this or \"domain\" must be present.",
           "type": "string",
           "example": "mike@example.com"
         }


### PR DESCRIPTION
This PR adds support for domain wide trust relationships. This will allow setting issuers that can sign tokens for every user under the configured domain, instead registering all subjects individually.

The following changes have been made:

#### REST service
Added a new `domain` field in the REST service used to setup the trust grants. Also the `subject` field is no longer required, either one of `domain` or `subject` has to be present, never both. Validation has been updated to this.
```
POST https://<admin.ory-hydra>/trust/grants/jwt-bearer/issuers
Content-Type: application/json

{
  "issuer": "https://my-issuer.com",
  "domain": "example.com",
  "scope": ["read"],
  "jwk": { ... },
  "expires_at": "2021-04-23T18:25:43.511Z",
}
```

Single subject trust relationships can still be setup by defining setting the `subject` field in the request:
```
POST https://<admin.ory-hydra>/trust/grants/jwt-bearer/issuers
Content-Type: application/json

{
  "issuer": "https://my-issuer.com",
  "subject": "alice@example.com",
  "scope": ["read"],
  "jwk": { ... },
  "expires_at": "2021-04-23T18:25:43.511Z",
}
```

#### Database
Added a new `domain` column to the `hydra_oauth2_trusted_jwt_bearer_issuer` table, and updated the unique index to contain this new column.

#### JWT Token validation
When a token is received, if the subject looks like an email, hydra will look for public keys that exactly match the subject or the domain (`subject = ? or domain = ?`). If the subject is not an email then only the subject is checked (keeps previous behaviour).

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)
#2930
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

