### PR TITLE
fix(janitor): flaky test for `flush-consent-request-limit` case

### DIFF
--- a/internal/testhelpers/janitor_test_helper.go
+++ b/internal/testhelpers/janitor_test_helper.go
@@ -230,9 +230,14 @@ func (j *JanitorConsentTestHelper) LimitSetup(ctx context.Context, cm consent.Ma
 			require.NoError(t, cm.CreateLoginRequest(ctx, r))
 		}
 
+		// Create consent requests
+		for _, r := range j.flushConsentRequests {
+			require.NoError(t, cm.CreateConsentRequest(ctx, r))
+		}
+
 		// Reject each request
-		for _, r := range j.flushLoginRequests {
-			_, err = cm.HandleLoginRequest(ctx, r.ID, consent.NewHandledLoginRequest(
+		for _, r := range j.flushConsentRequests {
+			_, err = cm.HandleConsentRequest(ctx, r.ID, consent.NewHandledConsentRequest(
 				r.ID, true, r.RequestedAt, r.AuthenticatedAt))
 			require.NoError(t, err)
 		}
@@ -242,10 +247,21 @@ func (j *JanitorConsentTestHelper) LimitSetup(ctx context.Context, cm consent.Ma
 func (j *JanitorConsentTestHelper) LimitValidate(ctx context.Context, cm consent.Manager) func(t *testing.T) {
 	return func(t *testing.T) {
 		// flush-login-2 and 3 should be cleared now
+
 		for _, r := range j.flushLoginRequests {
 			t.Logf("check login: %s", r.ID)
 			_, err := cm.GetLoginRequest(ctx, r.ID)
 			if r.ID == j.flushLoginRequests[0].ID {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		}
+
+		for _, r := range j.flushConsentRequests {
+			t.Logf("check consent: %s", r.ID)
+			_, err := cm.GetConsentRequest(ctx, r.ID)
+			if r.ID == j.flushConsentRequests[0].ID {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)


### PR DESCRIPTION
## Related issue(s)

No related issues, this fixes a flaky test introduced in PR #2540

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
