### PR TITLE
fix: revert back to PATs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: ory/ci/sdk/generate@master
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.ORY_BOT_PAT }}
           app-name: Ory_Hydra
           swag-spec-ignore: internal/httpclient gopkg.in/square/go-jose.v2
           swag-spec-location: spec/api.json
@@ -234,7 +234,7 @@ jobs:
     steps:
       - uses: ory/ci/docs/cli@master
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.ORY_BOT_PAT }}
 
   changelog:
     name: Generate changelog
@@ -251,7 +251,7 @@ jobs:
           fetch-depth: 0
       - uses: ory/ci/changelog@master
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.ORY_BOT_PAT }}
 
   sdk-release:
     name: Release SDKs
@@ -285,7 +285,7 @@ jobs:
     steps:
       - uses: ory/ci/releaser@master
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.ORY_BOT_PAT }}
           goreleaser_key: ${{ secrets.GORELEASER_KEY }}
           cosign_pwd: ${{ secrets.COSIGN_PWD }}
           docker_username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Due to how branch protection works, we can't push without a token that
has permissions to bypass branch protection. Hence, we revert back to
PATs here.

However, we also want to prevent triggering recursive workflow runs
which can potentially occur in commits originating from a non-GitHub
Actions actor. One possible workaround would be to add a `[skip ci]` to
the body in autogen commits. This prevents any workflow from triggering
on the commit. See: https://github.com/ory/ci/commit/849d2713e4b24ee3540b1f752ad1a4094d634e2f

Let me know what you think.