### PR TITLE
fix: pass swag-spec-location to sdk-release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,6 +243,7 @@ jobs:
     steps:
       - uses: ory/ci/sdk/release@master
         with:
+          swag-spec-location: spec/api.json
           token: ${{ secrets.ORY_BOT_PAT }}
 
   release:


### PR DESCRIPTION
Pass `swag-spec-location` to the `sdk-release` job.