### PR TITLE
fix: update mailchimp list ids

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,8 +285,8 @@ jobs:
     steps:
       - uses: ory/ci/newsletter@master
         with:
-          mailchimp_list_id: 058a056618
-          mailchmip_segment_id: 11398953
+          mailchimp_list_id: f605a41b53
+          mailchmip_segment_id: 6479481
           mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
           draft: 'true'
           ssh_key: ${{ secrets.ORY_BOT_SSH_KEY }}
@@ -312,8 +312,8 @@ jobs:
     steps:
       - uses: ory/ci/newsletter@master
         with:
-          mailchimp_list_id: 058a056618
-          mailchmip_segment_id: 11398953
+          mailchimp_list_id: f605a41b53
+          mailchmip_segment_id: 6479481
           mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
           draft: 'false'
           ssh_key: ${{ secrets.ORY_BOT_SSH_KEY }}


### PR DESCRIPTION
Updates the newsletter list IDs to the actual production one (from the
CIrcleCI config).