### PR TITLE
feat: add support for trust grants that can issue tokens for any subject

### DIFF
--- a/cypress/integration/admin/grant_jwtbearer.js
+++ b/cypress/integration/admin/grant_jwtbearer.js
@@ -6,9 +6,9 @@ dayjs.extend(isBetween)
 
 describe('The JWT-Bearer Grants Admin Interface', () => {
   let d = dayjs().utc().add(1, 'year').set('millisecond', 0)
-  const newGrant = (issuer = 'token-service', subject = 'bob@example.com') => ({
-    issuer,
-    subject,
+  const newGrant = () => ({
+    issuer: 'token-service',
+    subject: 'bob@example.com',
     expires_at: d.toISOString(),
     scope: ['openid', 'offline'],
     jwk: {
@@ -117,6 +117,58 @@ describe('The JWT-Bearer Grants Admin Interface', () => {
       body: JSON.stringify(grant)
     }).then((response) => {
       expect(response.status).to.equal(400)
+    })
+  })
+
+  it('should fail, because trying to create grant with no subject and no allow_any_subject flag', () => {
+    const grant = newGrant()
+    delete grant.subject
+    delete grant.allow_any_subject
+    cy.request({
+      method: 'POST',
+      url: Cypress.env('admin_url') + '/trust/grants/jwt-bearer/issuers',
+      failOnStatusCode: false,
+      body: JSON.stringify(grant)
+    }).then((response) => {
+      expect(response.status).to.equal(400)
+    })
+  })
+
+  it('should return newly created jwt-bearer grant when issuer is allowed to authorize any subject', () => {
+    const grant = newGrant()
+    delete grant.subject
+    grant.allow_any_subject = true
+    const start = dayjs().subtract(1, 'minutes')
+    const end = dayjs().add(1, 'minutes')
+    cy.request(
+      'POST',
+      Cypress.env('admin_url') + '/trust/grants/jwt-bearer/issuers',
+      JSON.stringify(grant)
+    ).then((response) => {
+      const createdAt = dayjs(response.body.created_at)
+      const expiresAt = dayjs(response.body.expires_at)
+      const grantID = response.body.id
+
+      expect(response.body.allow_any_subject).to.equal(grant.allow_any_subject)
+      expect(response.body.issuer).to.equal(grant.issuer)
+      expect(createdAt.isBetween(start, end)).to.true
+      expect(expiresAt.isSame(grant.expires_at)).to.true
+      expect(response.body.scope).to.deep.equal(grant.scope)
+      expect(response.body.public_key.set).to.equal(grant.issuer)
+      expect(response.body.public_key.kid).to.equal(grant.jwk.kid)
+
+      cy.request(
+        'GET',
+        Cypress.env('admin_url') + '/trust/grants/jwt-bearer/issuers/' + grantID
+      ).then((response) => {
+        expect(response.body.allow_any_subject).to.equal(
+          grant.allow_any_subject
+        )
+        expect(response.body.issuer).to.equal(grant.issuer)
+        expect(response.body.scope).to.deep.equal(grant.scope)
+        expect(response.body.public_key.set).to.equal(grant.issuer)
+        expect(response.body.public_key.kid).to.equal(grant.jwk.kid)
+      })
     })
   })
 })

--- a/internal/httpclient-next/api/openapi.yaml
+++ b/internal/httpclient-next/api/openapi.yaml
@@ -3520,6 +3520,10 @@ components:
       type: object
     trustJwtGrantIssuerBody:
       properties:
+        allow_any_subject:
+          description: The "allow_any_subject" indicates that the issuer is allowed
+            to have any principal as the subject of the JWT.
+          type: boolean
         expires_at:
           description: The "expires_at" indicates, when grant will expire, so we will
             reject assertion from "issuer" targeting "subject".
@@ -3551,7 +3555,6 @@ components:
       - issuer
       - jwk
       - scope
-      - subject
       type: object
     trustedJsonWebKey:
       example:
@@ -3581,8 +3584,13 @@ components:
         - offline
         created_at: 2000-01-23T04:56:07.000+00:00
         id: 9edc811f-4e28-453c-9b46-4de65f00217f
+        allow_any_subject: true
         issuer: https://jwt-idp.example.com
       properties:
+        allow_any_subject:
+          description: The "allow_any_subject" indicates that the issuer is allowed
+            to have any principal as the subject of the JWT.
+          type: boolean
         created_at:
           description: The "created_at" indicates, when grant was created.
           format: date-time

--- a/internal/httpclient-next/docs/AdminApi.md
+++ b/internal/httpclient-next/docs/AdminApi.md
@@ -1967,7 +1967,7 @@ import (
 )
 
 func main() {
-    trustJwtGrantIssuerBody := *openapiclient.NewTrustJwtGrantIssuerBody(time.Now(), "https://jwt-idp.example.com", *openapiclient.NewJSONWebKey("RS256", "1603dfe0af8f4596", "RSA", "sig"), []string{"Scope_example"}, "mike@example.com") // TrustJwtGrantIssuerBody |  (optional)
+    trustJwtGrantIssuerBody := *openapiclient.NewTrustJwtGrantIssuerBody(time.Now(), "https://jwt-idp.example.com", *openapiclient.NewJSONWebKey("RS256", "1603dfe0af8f4596", "RSA", "sig"), []string{"Scope_example"}) // TrustJwtGrantIssuerBody |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)

--- a/internal/httpclient-next/docs/TrustJwtGrantIssuerBody.md
+++ b/internal/httpclient-next/docs/TrustJwtGrantIssuerBody.md
@@ -4,17 +4,18 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**AllowAnySubject** | Pointer to **bool** | The \&quot;allow_any_subject\&quot; indicates that the issuer is allowed to have any principal as the subject of the JWT. | [optional] 
 **ExpiresAt** | **time.Time** | The \&quot;expires_at\&quot; indicates, when grant will expire, so we will reject assertion from \&quot;issuer\&quot; targeting \&quot;subject\&quot;. | 
 **Issuer** | **string** | The \&quot;issuer\&quot; identifies the principal that issued the JWT assertion (same as \&quot;iss\&quot; claim in JWT). | 
 **Jwk** | [**JSONWebKey**](JSONWebKey.md) |  | 
 **Scope** | **[]string** | The \&quot;scope\&quot; contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749]) | 
-**Subject** | **string** | The \&quot;subject\&quot; identifies the principal that is the subject of the JWT. | 
+**Subject** | Pointer to **string** | The \&quot;subject\&quot; identifies the principal that is the subject of the JWT. | [optional] 
 
 ## Methods
 
 ### NewTrustJwtGrantIssuerBody
 
-`func NewTrustJwtGrantIssuerBody(expiresAt time.Time, issuer string, jwk JSONWebKey, scope []string, subject string, ) *TrustJwtGrantIssuerBody`
+`func NewTrustJwtGrantIssuerBody(expiresAt time.Time, issuer string, jwk JSONWebKey, scope []string, ) *TrustJwtGrantIssuerBody`
 
 NewTrustJwtGrantIssuerBody instantiates a new TrustJwtGrantIssuerBody object
 This constructor will assign default values to properties that have it defined,
@@ -28,6 +29,31 @@ will change when the set of required properties is changed
 NewTrustJwtGrantIssuerBodyWithDefaults instantiates a new TrustJwtGrantIssuerBody object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAllowAnySubject
+
+`func (o *TrustJwtGrantIssuerBody) GetAllowAnySubject() bool`
+
+GetAllowAnySubject returns the AllowAnySubject field if non-nil, zero value otherwise.
+
+### GetAllowAnySubjectOk
+
+`func (o *TrustJwtGrantIssuerBody) GetAllowAnySubjectOk() (*bool, bool)`
+
+GetAllowAnySubjectOk returns a tuple with the AllowAnySubject field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAllowAnySubject
+
+`func (o *TrustJwtGrantIssuerBody) SetAllowAnySubject(v bool)`
+
+SetAllowAnySubject sets AllowAnySubject field to given value.
+
+### HasAllowAnySubject
+
+`func (o *TrustJwtGrantIssuerBody) HasAllowAnySubject() bool`
+
+HasAllowAnySubject returns a boolean if a field has been set.
 
 ### GetExpiresAt
 
@@ -128,6 +154,11 @@ and a boolean to check if the value has been set.
 
 SetSubject sets Subject field to given value.
 
+### HasSubject
+
+`func (o *TrustJwtGrantIssuerBody) HasSubject() bool`
+
+HasSubject returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/internal/httpclient-next/docs/TrustedJwtGrantIssuer.md
+++ b/internal/httpclient-next/docs/TrustedJwtGrantIssuer.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**AllowAnySubject** | Pointer to **bool** | The \&quot;allow_any_subject\&quot; indicates that the issuer is allowed to have any principal as the subject of the JWT. | [optional] 
 **CreatedAt** | Pointer to **time.Time** | The \&quot;created_at\&quot; indicates, when grant was created. | [optional] 
 **ExpiresAt** | Pointer to **time.Time** | The \&quot;expires_at\&quot; indicates, when grant will expire, so we will reject assertion from \&quot;issuer\&quot; targeting \&quot;subject\&quot;. | [optional] 
 **Id** | Pointer to **string** |  | [optional] 
@@ -30,6 +31,31 @@ will change when the set of required properties is changed
 NewTrustedJwtGrantIssuerWithDefaults instantiates a new TrustedJwtGrantIssuer object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAllowAnySubject
+
+`func (o *TrustedJwtGrantIssuer) GetAllowAnySubject() bool`
+
+GetAllowAnySubject returns the AllowAnySubject field if non-nil, zero value otherwise.
+
+### GetAllowAnySubjectOk
+
+`func (o *TrustedJwtGrantIssuer) GetAllowAnySubjectOk() (*bool, bool)`
+
+GetAllowAnySubjectOk returns a tuple with the AllowAnySubject field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAllowAnySubject
+
+`func (o *TrustedJwtGrantIssuer) SetAllowAnySubject(v bool)`
+
+SetAllowAnySubject sets AllowAnySubject field to given value.
+
+### HasAllowAnySubject
+
+`func (o *TrustedJwtGrantIssuer) HasAllowAnySubject() bool`
+
+HasAllowAnySubject returns a boolean if a field has been set.
 
 ### GetCreatedAt
 

--- a/internal/httpclient-next/model_trust_jwt_grant_issuer_body.go
+++ b/internal/httpclient-next/model_trust_jwt_grant_issuer_body.go
@@ -18,6 +18,8 @@ import (
 
 // TrustJwtGrantIssuerBody struct for TrustJwtGrantIssuerBody
 type TrustJwtGrantIssuerBody struct {
+	// The \"allow_any_subject\" indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject *bool `json:"allow_any_subject,omitempty"`
 	// The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".
 	ExpiresAt time.Time `json:"expires_at"`
 	// The \"issuer\" identifies the principal that issued the JWT assertion (same as \"iss\" claim in JWT).
@@ -26,20 +28,19 @@ type TrustJwtGrantIssuerBody struct {
 	// The \"scope\" contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	Scope []string `json:"scope"`
 	// The \"subject\" identifies the principal that is the subject of the JWT.
-	Subject string `json:"subject"`
+	Subject *string `json:"subject,omitempty"`
 }
 
 // NewTrustJwtGrantIssuerBody instantiates a new TrustJwtGrantIssuerBody object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTrustJwtGrantIssuerBody(expiresAt time.Time, issuer string, jwk JSONWebKey, scope []string, subject string) *TrustJwtGrantIssuerBody {
+func NewTrustJwtGrantIssuerBody(expiresAt time.Time, issuer string, jwk JSONWebKey, scope []string) *TrustJwtGrantIssuerBody {
 	this := TrustJwtGrantIssuerBody{}
 	this.ExpiresAt = expiresAt
 	this.Issuer = issuer
 	this.Jwk = jwk
 	this.Scope = scope
-	this.Subject = subject
 	return &this
 }
 
@@ -49,6 +50,38 @@ func NewTrustJwtGrantIssuerBody(expiresAt time.Time, issuer string, jwk JSONWebK
 func NewTrustJwtGrantIssuerBodyWithDefaults() *TrustJwtGrantIssuerBody {
 	this := TrustJwtGrantIssuerBody{}
 	return &this
+}
+
+// GetAllowAnySubject returns the AllowAnySubject field value if set, zero value otherwise.
+func (o *TrustJwtGrantIssuerBody) GetAllowAnySubject() bool {
+	if o == nil || o.AllowAnySubject == nil {
+		var ret bool
+		return ret
+	}
+	return *o.AllowAnySubject
+}
+
+// GetAllowAnySubjectOk returns a tuple with the AllowAnySubject field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TrustJwtGrantIssuerBody) GetAllowAnySubjectOk() (*bool, bool) {
+	if o == nil || o.AllowAnySubject == nil {
+		return nil, false
+	}
+	return o.AllowAnySubject, true
+}
+
+// HasAllowAnySubject returns a boolean if a field has been set.
+func (o *TrustJwtGrantIssuerBody) HasAllowAnySubject() bool {
+	if o != nil && o.AllowAnySubject != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAllowAnySubject gets a reference to the given bool and assigns it to the AllowAnySubject field.
+func (o *TrustJwtGrantIssuerBody) SetAllowAnySubject(v bool) {
+	o.AllowAnySubject = &v
 }
 
 // GetExpiresAt returns the ExpiresAt field value
@@ -147,32 +180,43 @@ func (o *TrustJwtGrantIssuerBody) SetScope(v []string) {
 	o.Scope = v
 }
 
-// GetSubject returns the Subject field value
+// GetSubject returns the Subject field value if set, zero value otherwise.
 func (o *TrustJwtGrantIssuerBody) GetSubject() string {
-	if o == nil {
+	if o == nil || o.Subject == nil {
 		var ret string
 		return ret
 	}
-
-	return o.Subject
+	return *o.Subject
 }
 
-// GetSubjectOk returns a tuple with the Subject field value
+// GetSubjectOk returns a tuple with the Subject field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *TrustJwtGrantIssuerBody) GetSubjectOk() (*string, bool) {
-	if o == nil {
+	if o == nil || o.Subject == nil {
 		return nil, false
 	}
-	return &o.Subject, true
+	return o.Subject, true
 }
 
-// SetSubject sets field value
+// HasSubject returns a boolean if a field has been set.
+func (o *TrustJwtGrantIssuerBody) HasSubject() bool {
+	if o != nil && o.Subject != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSubject gets a reference to the given string and assigns it to the Subject field.
 func (o *TrustJwtGrantIssuerBody) SetSubject(v string) {
-	o.Subject = v
+	o.Subject = &v
 }
 
 func (o TrustJwtGrantIssuerBody) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.AllowAnySubject != nil {
+		toSerialize["allow_any_subject"] = o.AllowAnySubject
+	}
 	if true {
 		toSerialize["expires_at"] = o.ExpiresAt
 	}
@@ -185,7 +229,7 @@ func (o TrustJwtGrantIssuerBody) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["scope"] = o.Scope
 	}
-	if true {
+	if o.Subject != nil {
 		toSerialize["subject"] = o.Subject
 	}
 	return json.Marshal(toSerialize)

--- a/internal/httpclient-next/model_trusted_jwt_grant_issuer.go
+++ b/internal/httpclient-next/model_trusted_jwt_grant_issuer.go
@@ -18,6 +18,8 @@ import (
 
 // TrustedJwtGrantIssuer struct for TrustedJwtGrantIssuer
 type TrustedJwtGrantIssuer struct {
+	// The \"allow_any_subject\" indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject *bool `json:"allow_any_subject,omitempty"`
 	// The \"created_at\" indicates, when grant was created.
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	// The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".
@@ -47,6 +49,38 @@ func NewTrustedJwtGrantIssuer() *TrustedJwtGrantIssuer {
 func NewTrustedJwtGrantIssuerWithDefaults() *TrustedJwtGrantIssuer {
 	this := TrustedJwtGrantIssuer{}
 	return &this
+}
+
+// GetAllowAnySubject returns the AllowAnySubject field value if set, zero value otherwise.
+func (o *TrustedJwtGrantIssuer) GetAllowAnySubject() bool {
+	if o == nil || o.AllowAnySubject == nil {
+		var ret bool
+		return ret
+	}
+	return *o.AllowAnySubject
+}
+
+// GetAllowAnySubjectOk returns a tuple with the AllowAnySubject field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TrustedJwtGrantIssuer) GetAllowAnySubjectOk() (*bool, bool) {
+	if o == nil || o.AllowAnySubject == nil {
+		return nil, false
+	}
+	return o.AllowAnySubject, true
+}
+
+// HasAllowAnySubject returns a boolean if a field has been set.
+func (o *TrustedJwtGrantIssuer) HasAllowAnySubject() bool {
+	if o != nil && o.AllowAnySubject != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAllowAnySubject gets a reference to the given bool and assigns it to the AllowAnySubject field.
+func (o *TrustedJwtGrantIssuer) SetAllowAnySubject(v bool) {
+	o.AllowAnySubject = &v
 }
 
 // GetCreatedAt returns the CreatedAt field value if set, zero value otherwise.
@@ -275,6 +309,9 @@ func (o *TrustedJwtGrantIssuer) SetSubject(v string) {
 
 func (o TrustedJwtGrantIssuer) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.AllowAnySubject != nil {
+		toSerialize["allow_any_subject"] = o.AllowAnySubject
+	}
 	if o.CreatedAt != nil {
 		toSerialize["created_at"] = o.CreatedAt
 	}

--- a/internal/httpclient/models/trust_jwt_grant_issuer_body.go
+++ b/internal/httpclient/models/trust_jwt_grant_issuer_body.go
@@ -19,6 +19,9 @@ import (
 // swagger:model trustJwtGrantIssuerBody
 type TrustJwtGrantIssuerBody struct {
 
+	// The "allow_any_subject" indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject bool `json:"allow_any_subject,omitempty"`
+
 	// The "expires_at" indicates, when grant will expire, so we will reject assertion from "issuer" targeting "subject".
 	// Required: true
 	// Format: date-time
@@ -40,8 +43,7 @@ type TrustJwtGrantIssuerBody struct {
 
 	// The "subject" identifies the principal that is the subject of the JWT.
 	// Example: mike@example.com
-	// Required: true
-	Subject *string `json:"subject"`
+	Subject string `json:"subject,omitempty"`
 }
 
 // Validate validates this trust jwt grant issuer body
@@ -61,10 +63,6 @@ func (m *TrustJwtGrantIssuerBody) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateScope(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSubject(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -117,15 +115,6 @@ func (m *TrustJwtGrantIssuerBody) validateJwk(formats strfmt.Registry) error {
 func (m *TrustJwtGrantIssuerBody) validateScope(formats strfmt.Registry) error {
 
 	if err := validate.Required("scope", "body", m.Scope); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *TrustJwtGrantIssuerBody) validateSubject(formats strfmt.Registry) error {
-
-	if err := validate.Required("subject", "body", m.Subject); err != nil {
 		return err
 	}
 

--- a/internal/httpclient/models/trusted_jwt_grant_issuer.go
+++ b/internal/httpclient/models/trusted_jwt_grant_issuer.go
@@ -19,6 +19,9 @@ import (
 // swagger:model trustedJwtGrantIssuer
 type TrustedJwtGrantIssuer struct {
 
+	// The "allow_any_subject" indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject bool `json:"allow_any_subject,omitempty"`
+
 	// The "created_at" indicates, when grant was created.
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`

--- a/oauth2/trust/doc.go
+++ b/oauth2/trust/doc.go
@@ -40,9 +40,11 @@ type trustJwtGrantIssuerBody struct {
 
 	// The "subject" identifies the principal that is the subject of the JWT.
 	//
-	// required:true
 	// example: mike@example.com
 	Subject string `json:"subject"`
+
+	// The "allow_any_subject" indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject bool `json:"allow_any_subject"`
 
 	// The "scope" contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	//
@@ -107,6 +109,9 @@ type trustedJwtGrantIssuer struct {
 	// The "subject" identifies the principal that is the subject of the JWT.
 	// example: mike@example.com
 	Subject string `json:"subject"`
+
+	// The "allow_any_subject" indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject bool `json:"allow_any_subject"`
 
 	// The "scope" contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	// example: ["openid", "offline"]

--- a/oauth2/trust/grant.go
+++ b/oauth2/trust/grant.go
@@ -13,6 +13,9 @@ type Grant struct {
 	// Subject identifies the principal that is the subject of the JWT.
 	Subject string `json:"subject"`
 
+	// AllowAnySubject indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject bool `json:"allow_any_subject"`
+
 	// Scope contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	Scope []string `json:"scope"`
 

--- a/oauth2/trust/handler.go
+++ b/oauth2/trust/handler.go
@@ -69,10 +69,11 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	}
 
 	grant := Grant{
-		ID:      uuid.New().String(),
-		Issuer:  grantRequest.Issuer,
-		Subject: grantRequest.Subject,
-		Scope:   grantRequest.Scope,
+		ID:              uuid.New().String(),
+		Issuer:          grantRequest.Issuer,
+		Subject:         grantRequest.Subject,
+		AllowAnySubject: grantRequest.AllowAnySubject,
+		Scope:           grantRequest.Scope,
 		PublicKey: PublicKey{
 			Set:   grantRequest.Issuer, // group all keys by issuer, so set=issuer
 			KeyID: grantRequest.PublicKeyJWK.KeyID,

--- a/oauth2/trust/handler_test.go
+++ b/oauth2/trust/handler_test.go
@@ -3,6 +3,7 @@ package trust_test
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -202,6 +203,22 @@ func (s *HandlerTestSuite) TestGrantPublicCanBeFetched() {
 
 	s.Require().NoError(err, "no error expected on fetching public key")
 	s.Equal(*model.Jwk.Kid, *getResult.Payload.Keys[0].Kid)
+}
+
+func (s *HandlerTestSuite) TestGrantWithAnySubjectCanBeCreated() {
+	createRequestParams := s.newCreateJwtBearerGrantParams(
+		"ory",
+		"",
+		true,
+		[]string{"openid", "offline", "profile"},
+		time.Now().Add(time.Hour),
+	)
+
+	grant, err := s.hydraClient.Admin.TrustJwtGrantIssuer(createRequestParams)
+	s.Require().NoError(err, "no error expected on grant creation")
+
+	assert.Empty(s.T(), grant.Payload.Subject)
+	assert.Truef(s.T(), grant.Payload.AllowAnySubject, "grant with any subject must be true")
 }
 
 func (s *HandlerTestSuite) TestGrantListCanBeFetched() {

--- a/oauth2/trust/handler_test.go
+++ b/oauth2/trust/handler_test.go
@@ -81,6 +81,7 @@ func (s *HandlerTestSuite) TestGrantCanBeCreatedAndFetched() {
 	createRequestParams := s.newCreateJwtBearerGrantParams(
 		"ory",
 		"hackerman@example.com",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -91,7 +92,7 @@ func (s *HandlerTestSuite) TestGrantCanBeCreatedAndFetched() {
 	s.Require().NoError(err, "no errors expected on grant creation")
 	s.NotEmpty(createResult.Payload.ID, " grant id expected to be non-empty")
 	s.Equal(*model.Issuer, createResult.Payload.Issuer, "issuer must match")
-	s.Equal(*model.Subject, createResult.Payload.Subject, "subject must match")
+	s.Equal(model.Subject, createResult.Payload.Subject, "subject must match")
 	s.Equal(model.Scope, createResult.Payload.Scope, "scopes must match")
 	s.Equal(*model.Issuer, createResult.Payload.PublicKey.Set, "public key set must match grant issuer")
 	s.Equal(*model.Jwk.Kid, createResult.Payload.PublicKey.Kid, "public key id must match")
@@ -104,7 +105,7 @@ func (s *HandlerTestSuite) TestGrantCanBeCreatedAndFetched() {
 	s.Require().NoError(err, "no errors expected on grant fetching")
 	s.Equal(getRequestParams.ID, getResult.Payload.ID, " grant id must match")
 	s.Equal(*model.Issuer, getResult.Payload.Issuer, "issuer must match")
-	s.Equal(*model.Subject, getResult.Payload.Subject, "subject must match")
+	s.Equal(model.Subject, getResult.Payload.Subject, "subject must match")
 	s.Equal(model.Scope, getResult.Payload.Scope, "scopes must match")
 	s.Equal(*model.Issuer, getResult.Payload.PublicKey.Set, "public key set must match grant issuer")
 	s.Equal(*model.Jwk.Kid, getResult.Payload.PublicKey.Kid, "public key id must match")
@@ -115,6 +116,7 @@ func (s *HandlerTestSuite) TestGrantCanNotBeCreatedWithSameIssuerSubjectKey() {
 	createRequestParams := s.newCreateJwtBearerGrantParams(
 		"ory",
 		"hackerman@example.com",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -131,10 +133,24 @@ func (s *HandlerTestSuite) TestGrantCanNotBeCreatedWithSameIssuerSubjectKey() {
 	s.NoError(err, "no errors expected on grant creation, because kid is now different")
 }
 
+func (s *HandlerTestSuite) TestGrantCanNotBeCreatedWithSubjectAndAnySubject() {
+	createRequestParams := s.newCreateJwtBearerGrantParams(
+		"ory",
+		"hackerman@example.com",
+		true,
+		[]string{"openid", "offline", "profile"},
+		time.Now().Add(time.Hour),
+	)
+
+	_, err := s.hydraClient.Admin.TrustJwtGrantIssuer(createRequestParams)
+	s.Require().Error(err, "expected error, because a grant with a subject and allow_any_subject cannot be created")
+}
+
 func (s *HandlerTestSuite) TestGrantCanNotBeCreatedWithMissingFields() {
 	createRequestParams := s.newCreateJwtBearerGrantParams(
 		"",
 		"hackerman@example.com",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -145,6 +161,7 @@ func (s *HandlerTestSuite) TestGrantCanNotBeCreatedWithMissingFields() {
 	createRequestParams = s.newCreateJwtBearerGrantParams(
 		"ory",
 		"",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -155,6 +172,7 @@ func (s *HandlerTestSuite) TestGrantCanNotBeCreatedWithMissingFields() {
 	createRequestParams = s.newCreateJwtBearerGrantParams(
 		"ory",
 		"hackerman@example.com",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Time{},
 	)
@@ -167,6 +185,7 @@ func (s *HandlerTestSuite) TestGrantPublicCanBeFetched() {
 	createRequestParams := s.newCreateJwtBearerGrantParams(
 		"ory",
 		"hackerman@example.com",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -189,12 +208,14 @@ func (s *HandlerTestSuite) TestGrantListCanBeFetched() {
 	createRequestParams := s.newCreateJwtBearerGrantParams(
 		"ory",
 		"hackerman@example.com",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
 	createRequestParams2 := s.newCreateJwtBearerGrantParams(
 		"ory2",
 		"safetyman@example.com",
+		false,
 		[]string{"profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -223,6 +244,7 @@ func (s *HandlerTestSuite) TestGrantCanBeDeleted() {
 	createRequestParams := s.newCreateJwtBearerGrantParams(
 		"ory",
 		"hackerman@example.com",
+		false,
 		[]string{"openid", "offline", "profile"},
 		time.Now().Add(time.Hour),
 	)
@@ -258,16 +280,17 @@ func (s *HandlerTestSuite) generateJWK(publicKey *rsa.PublicKey) *models.JSONWeb
 }
 
 func (s *HandlerTestSuite) newCreateJwtBearerGrantParams(
-	issuer, subject string, scope []string, expiresAt time.Time,
+	issuer, subject string, allowAnySubject bool, scope []string, expiresAt time.Time,
 ) *admin.TrustJwtGrantIssuerParams {
 	createRequestParams := admin.NewTrustJwtGrantIssuerParams()
 	exp := strfmt.DateTime(expiresAt.UTC().Round(time.Second))
 	model := &models.TrustJwtGrantIssuerBody{
-		ExpiresAt: &exp,
-		Issuer:    &issuer,
-		Jwk:       s.generateJWK(s.publicKey),
-		Scope:     scope,
-		Subject:   &subject,
+		ExpiresAt:       &exp,
+		Issuer:          &issuer,
+		Jwk:             s.generateJWK(s.publicKey),
+		Scope:           scope,
+		Subject:         subject,
+		AllowAnySubject: allowAnySubject,
 	}
 	createRequestParams.SetBody(model)
 

--- a/oauth2/trust/manager.go
+++ b/oauth2/trust/manager.go
@@ -17,14 +17,15 @@ type GrantManager interface {
 }
 
 type SQLData struct {
-	ID        string    `db:"id"`
-	Issuer    string    `db:"issuer"`
-	Subject   string    `db:"subject"`
-	Scope     string    `db:"scope"`
-	KeySet    string    `db:"key_set"`
-	KeyID     string    `db:"key_id"`
-	CreatedAt time.Time `db:"created_at"`
-	ExpiresAt time.Time `db:"expires_at"`
+	ID              string    `db:"id"`
+	Issuer          string    `db:"issuer"`
+	Subject         string    `db:"subject"`
+	AllowAnySubject bool      `db:"allow_any_subject"`
+	Scope           string    `db:"scope"`
+	KeySet          string    `db:"key_set"`
+	KeyID           string    `db:"key_id"`
+	CreatedAt       time.Time `db:"created_at"`
+	ExpiresAt       time.Time `db:"expires_at"`
 }
 
 func (SQLData) TableName() string {

--- a/oauth2/trust/request.go
+++ b/oauth2/trust/request.go
@@ -13,6 +13,9 @@ type createGrantRequest struct {
 	// Subject identifies the principal that is the subject of the JWT.
 	Subject string `json:"subject"`
 
+	// AllowAnySubject indicates that the issuer is allowed to have any principal as the subject of the JWT.
+	AllowAnySubject bool `json:"allow_any_subject"`
+
 	// Scope contains list of scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
 	Scope []string `json:"scope"`
 

--- a/oauth2/trust/validator.go
+++ b/oauth2/trust/validator.go
@@ -16,8 +16,12 @@ func (v *GrantValidator) Validate(request createGrantRequest) error {
 		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Field 'issuer' is required."))
 	}
 
-	if request.Subject == "" {
-		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Field 'subject' is required."))
+	if request.Subject == "" && !request.AllowAnySubject {
+		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("One of 'subject' or 'allow_any_subject' field must be set."))
+	}
+
+	if request.Subject != "" && request.AllowAnySubject {
+		return errorsx.WithStack(ErrMissingRequiredParameter.WithHint("Both 'subject' and 'allow_any_subject' fields cannot be set at the same time."))
 	}
 
 	if request.ExpiresAt.IsZero() {

--- a/oauth2/trust/validator_test.go
+++ b/oauth2/trust/validator_test.go
@@ -11,9 +11,10 @@ func TestEmptyIssuerIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "",
-		Subject:   "valid-subject",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:          "",
+		Subject:         "valid-subject",
+		AllowAnySubject: false,
+		ExpiresAt:       time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -24,13 +25,14 @@ func TestEmptyIssuerIsInvalid(t *testing.T) {
 	}
 }
 
-func TestEmptySubjectIsInvalid(t *testing.T) {
+func TestEmptySubjectAndNoAnySubjectFlagIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:          "valid-issuer",
+		Subject:         "",
+		AllowAnySubject: false,
+		ExpiresAt:       time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -41,13 +43,50 @@ func TestEmptySubjectIsInvalid(t *testing.T) {
 	}
 }
 
+func TestEmptySubjectWithAnySubjectFlagIsValid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:          "valid-issuer",
+		Subject:         "",
+		AllowAnySubject: true,
+		ExpiresAt:       time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err != nil {
+		t.Error("an empty subject with the allow_any_subject flag should be valid")
+	}
+}
+
+func TestNonEmptySubjectWithAnySubjectFlagIsInvalid(t *testing.T) {
+	v := GrantValidator{}
+
+	r := createGrantRequest{
+		Issuer:          "valid-issuer",
+		Subject:         "some-issuer",
+		AllowAnySubject: true,
+		ExpiresAt:       time.Now().Add(time.Hour * 10),
+		PublicKeyJWK: jose.JSONWebKey{
+			KeyID: "valid-key-id",
+		},
+	}
+
+	if err := v.Validate(r); err == nil {
+		t.Error("a non empty subject with the allow_any_subject flag should not be valid")
+	}
+}
+
 func TestEmptyExpiresAtIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "valid-subject",
-		ExpiresAt: time.Time{},
+		Issuer:          "valid-issuer",
+		Subject:         "valid-subject",
+		AllowAnySubject: false,
+		ExpiresAt:       time.Time{},
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},
@@ -62,9 +101,10 @@ func TestEmptyPublicKeyIdIsInvalid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "valid-subject",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:          "valid-issuer",
+		Subject:         "valid-subject",
+		AllowAnySubject: false,
+		ExpiresAt:       time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "",
 		},
@@ -79,9 +119,10 @@ func TestIsValid(t *testing.T) {
 	v := GrantValidator{}
 
 	r := createGrantRequest{
-		Issuer:    "valid-issuer",
-		Subject:   "valid-subject",
-		ExpiresAt: time.Now().Add(time.Hour * 10),
+		Issuer:          "valid-issuer",
+		Subject:         "valid-subject",
+		AllowAnySubject: false,
+		ExpiresAt:       time.Now().Add(time.Hour * 10),
 		PublicKeyJWK: jose.JSONWebKey{
 			KeyID: "valid-key-id",
 		},

--- a/persistence/sql/migratest/testdata/20220328111500_testdata.sql
+++ b/persistence/sql/migratest/testdata/20220328111500_testdata.sql
@@ -1,0 +1,7 @@
+INSERT INTO hydra_jwk (pk, sid, kid, version, keydata, created_at) VALUES (9, 'sid-0009', 'kid-0009', 2, 'key-0002', now());
+
+INSERT INTO hydra_oauth2_trusted_jwt_bearer_issuer (id, issuer, subject, allow_any_subject, scope, key_set, key_id)
+VALUES ('30e51720-4a88-48ca-8243-de7d8f461675', 'some-issuer', 'some-subject', false, 'some-scope', 'sid-0009', 'kid-0009');
+
+INSERT INTO hydra_oauth2_trusted_jwt_bearer_issuer (id, issuer, subject, allow_any_subject, scope, key_set, key_id)
+VALUES ('30e51720-4a88-48ca-8243-de7d8f461676', 'some-issuer', '', true, 'some-scope', 'sid-0009', 'kid-0009');

--- a/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.down.sql
+++ b/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    DROP COLUMN allow_any_subject;

--- a/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.sqlite.down.sql
+++ b/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.sqlite.down.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "_hydra_oauth2_trusted_jwt_bearer_issuer"
+(
+    id         VARCHAR(36) PRIMARY KEY,
+    issuer     VARCHAR(255) NOT NULL,
+    subject    VARCHAR(255) NOT NULL,
+    scope      TEXT         NOT NULL,
+    key_set    varchar(255) NOT NULL,
+    key_id     varchar(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE (issuer, subject, key_id),
+    FOREIGN KEY (key_set, key_id) REFERENCES hydra_jwk (sid, kid) ON DELETE CASCADE
+);
+
+INSERT INTO "_hydra_oauth2_trusted_jwt_bearer_issuer" (
+    id, issuer, subject, scope, key_set, key_id, created_at, expires_at
+) SELECT id, issuer, subject, scope, key_set, key_id, created_at, expires_at FROM "hydra_oauth2_trusted_jwt_bearer_issuer";
+
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx;
+DROP TABLE "hydra_oauth2_trusted_jwt_bearer_issuer";
+
+ALTER TABLE "_hydra_oauth2_trusted_jwt_bearer_issuer" RENAME TO "hydra_oauth2_trusted_jwt_bearer_issuer";
+CREATE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_expires_at_idx ON hydra_oauth2_trusted_jwt_bearer_issuer (expires_at);

--- a/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.sqlite.up.sql
+++ b/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.sqlite.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    ADD allow_any_subject INTEGER NOT NULL DEFAULT FALSE;

--- a/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.up.sql
+++ b/persistence/sql/migrations/20220328111500000000_support_any_subject_trusts.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hydra_oauth2_trusted_jwt_bearer_issuer
+    ADD COLUMN allow_any_subject BOOL NOT NULL DEFAULT FALSE;

--- a/spec/api.json
+++ b/spec/api.json
@@ -965,6 +965,10 @@
       },
       "trustJwtGrantIssuerBody": {
         "properties": {
+          "allow_any_subject": {
+            "description": "The \"allow_any_subject\" indicates that the issuer is allowed to have any principal as the subject of the JWT.",
+            "type": "boolean"
+          },
           "expires_at": {
             "description": "The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".",
             "format": "date-time",
@@ -997,7 +1001,6 @@
         },
         "required": [
           "issuer",
-          "subject",
           "scope",
           "jwk",
           "expires_at"
@@ -1021,6 +1024,10 @@
       },
       "trustedJwtGrantIssuer": {
         "properties": {
+          "allow_any_subject": {
+            "description": "The \"allow_any_subject\" indicates that the issuer is allowed to have any principal as the subject of the JWT.",
+            "type": "boolean"
+          },
           "created_at": {
             "description": "The \"created_at\" indicates, when grant was created.",
             "format": "date-time",

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -3171,12 +3171,15 @@
       "type": "object",
       "required": [
         "issuer",
-        "subject",
         "scope",
         "jwk",
         "expires_at"
       ],
       "properties": {
+        "allow_any_subject": {
+          "description": "The \"allow_any_subject\" indicates that the issuer is allowed to have any principal as the subject of the JWT.",
+          "type": "boolean"
+        },
         "expires_at": {
           "description": "The \"expires_at\" indicates, when grant will expire, so we will reject assertion from \"issuer\" targeting \"subject\".",
           "type": "string",
@@ -3226,6 +3229,10 @@
     "trustedJwtGrantIssuer": {
       "type": "object",
       "properties": {
+        "allow_any_subject": {
+          "description": "The \"allow_any_subject\" indicates that the issuer is allowed to have any principal as the subject of the JWT.",
+          "type": "boolean"
+        },
         "created_at": {
           "description": "The \"created_at\" indicates, when grant was created.",
           "type": "string",


### PR DESCRIPTION
Previously, a trust relationship had to be setup for every subject
before the issuer could sign a JWT token for it. This change will allow
setting up token services that can issue tokens with any value in the
subject field.

## Related issue(s)
#2930

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Implementation details

### REST api
This PR adds a new field to the trust creation request called `allow_any_subject`, and as long as this flag is set to false (or unset), the trust relationship creation service will behave just like it did before this change: the `subject` field will be required.

```json
{
  "issuer": "https://jwt-idp.example.com",
  "subject": "mike@example.com",
  "...": "..."
}
```

When `allow_any_subject` is set to true, then the issuer will be allowed to sign tokens for any subject. Also, as a safety measure, the `subject` field MUST be empty (or unset), otherwise the validation will fail. This is done to avoid creating an issuer that can sign tokens for any subject by mistake.

```json
{
  "issuer": "https://jwt-idp.example.com",
  "allow_any_subject": true,
  "...": "..."
}
```

### Database

When `allow_any_subject` is set to true, then the subject field is stored with an empty string value in the database. This allows us to keep (and benefit from) the `UNIQUE` constraint that the `hydra_oauth2_trusted_jwt_bearer_issuer` table has, requires no changes to the database schema and makes the database query used to find an issuer's public key really simple: `subject = ? or subject = ''`.

