### PR TITLE
feat: disable follow redirect when performing backchannel logout request

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -697,7 +697,14 @@ func (s *DefaultStrategy) executeBackChannelLogout(ctx context.Context, r *http.
 	}
 
 	var wg sync.WaitGroup
-	hc := httpx.NewResilientClient()
+	hc := httpx.NewResilientClient(
+		httpx.ResilientClientWithClient(
+			&http.Client{
+				Timeout: time.Minute,
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse // This results in no retry. If retry is favorable, then custom error should be thrown. If redirects should be allowed, then CheckRedirect should be made configurable (other configuration related PRs #2875, #2849).
+				},
+			}))
 	wg.Add(len(tasks))
 
 	var execute = func(t task) {


### PR DESCRIPTION
This pull request changes backchannel logout request client behaviour, when server responds with http redirect. This might happen when backchannel logout url requires authentication due to wrong configuration. This implementation will not retry on such response, but it could be made configurable. Also if redirect is actual use case, this feature should be configurable with default being original behaviour. 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
