### PR TITLE
fix: jwk generator checks were never executed. fixed that and some checks.

### DIFF
--- a/jwk/generator_test.go
+++ b/jwk/generator_test.go
@@ -43,7 +43,7 @@ func TestGenerator(t *testing.T) {
 			g:   &RS256Generator{},
 			use: "sig",
 			check: func(ks *jose.JSONWebKeySet) {
-				assert.Len(t, ks, 2)
+				assert.Len(t, ks.Keys, 2)
 				assert.NotEmpty(t, ks.Keys[0].Key)
 				assert.NotEmpty(t, ks.Keys[1].Key)
 				assert.Equal(t, "sig", ks.Keys[0].Use)
@@ -54,7 +54,7 @@ func TestGenerator(t *testing.T) {
 			g:   &ECDSA512Generator{},
 			use: "enc",
 			check: func(ks *jose.JSONWebKeySet) {
-				assert.Len(t, ks, 2)
+				assert.Len(t, ks.Keys, 2)
 				assert.NotEmpty(t, ks.Keys[0].Key)
 				assert.NotEmpty(t, ks.Keys[1].Key)
 				assert.Equal(t, "enc", ks.Keys[0].Use)
@@ -65,7 +65,7 @@ func TestGenerator(t *testing.T) {
 			g:   &ECDSA256Generator{},
 			use: "sig",
 			check: func(ks *jose.JSONWebKeySet) {
-				assert.Len(t, ks, 2)
+				assert.Len(t, ks.Keys, 2)
 				assert.NotEmpty(t, ks.Keys[0].Key)
 				assert.NotEmpty(t, ks.Keys[1].Key)
 				assert.Equal(t, "sig", ks.Keys[0].Use)
@@ -76,27 +76,25 @@ func TestGenerator(t *testing.T) {
 			g:   &HS256Generator{},
 			use: "sig",
 			check: func(ks *jose.JSONWebKeySet) {
-				assert.Len(t, ks, 1)
+				assert.Len(t, ks.Keys, 1)
 				assert.NotEmpty(t, ks.Keys[0].Key)
 				assert.Equal(t, "sig", ks.Keys[0].Use)
-				assert.Equal(t, "sig", ks.Keys[1].Use)
 			},
 		},
 		{
 			g:   &HS512Generator{},
 			use: "enc",
 			check: func(ks *jose.JSONWebKeySet) {
-				assert.Len(t, ks, 1)
+				assert.Len(t, ks.Keys, 1)
 				assert.NotEmpty(t, ks.Keys[0].Key)
 				assert.Equal(t, "enc", ks.Keys[0].Use)
-				assert.Equal(t, "enc", ks.Keys[1].Use)
 			},
 		},
 		{
 			g:   &EdDSAGenerator{},
 			use: "sig",
 			check: func(ks *jose.JSONWebKeySet) {
-				assert.Len(t, ks, 2)
+				assert.Len(t, ks.Keys, 2)
 				assert.NotEmpty(t, ks.Keys[0].Key)
 				assert.NotEmpty(t, ks.Keys[1].Key)
 				assert.Equal(t, "sig", ks.Keys[0].Use)
@@ -107,18 +105,18 @@ func TestGenerator(t *testing.T) {
 			g:   &EdDSAGenerator{},
 			use: "enc",
 			check: func(ks *jose.JSONWebKeySet) {
-				assert.Len(t, ks, 2)
+				assert.Len(t, ks.Keys, 2)
 				assert.NotEmpty(t, ks.Keys[0].Key)
 				assert.NotEmpty(t, ks.Keys[1].Key)
-				assert.Equal(t, "sig", ks.Keys[0].Use)
-				assert.Equal(t, "sig", ks.Keys[1].Use)
+				assert.Equal(t, "enc", ks.Keys[0].Use)
+				assert.Equal(t, "enc", ks.Keys[1].Use)
 			},
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
 			keys, err := c.g.Generate("foo", c.use)
 			require.NoError(t, err)
-			if err != nil {
+			if err == nil {
 				c.check(keys)
 			}
 		})


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
The tests for jwk generators had a logic flip and checks were never executed. Fixed that and some basic test logic.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
