### PR TITLE
feat: add hsm key set prefix to support multiple hydra instances on t…

### DIFF
--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -29,6 +29,7 @@ const (
 	HsmLibraryPath                               = "hsm.library"
 	HsmPin                                       = "hsm.pin"
 	HsmSlotNumber                                = "hsm.slot"
+	HsmKeySetPrefix                              = "hsm.key_set_prefix"
 	HsmTokenLabel                                = "hsm.token_label" // #nosec G101
 	KeyWellKnownKeys                             = "webfinger.jwks.broadcast_keys"
 	KeyOAuth2ClientRegistrationURL               = "webfinger.oidc_discovery.client_registration_url"
@@ -467,6 +468,10 @@ func (p *Provider) HsmPin() string {
 
 func (p *Provider) HsmTokenLabel() string {
 	return p.p.String(HsmTokenLabel)
+}
+
+func (p *Provider) HsmKeyPrefix() string {
+	return p.p.String(HsmKeySetPrefix)
 }
 
 func (p *Provider) GrantTypeJWTBearerIDOptional() bool {

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -470,7 +470,7 @@ func (p *Provider) HsmTokenLabel() string {
 	return p.p.String(HsmTokenLabel)
 }
 
-func (p *Provider) HsmKeyPrefix() string {
+func (p *Provider) HsmKeySetPrefix() string {
 	return p.p.String(HsmKeySetPrefix)
 }
 

--- a/driver/registry_sql.go
+++ b/driver/registry_sql.go
@@ -86,7 +86,7 @@ func (m *RegistrySQL) Init(ctx context.Context) error {
 		}
 
 		if m.C.HsmEnabled() {
-			hardwareKeyManager := hsm.NewKeyManager(m.HsmContext(), m.C.HsmKeyPrefix())
+			hardwareKeyManager := hsm.NewKeyManager(m.HsmContext(), m.C)
 			m.defaultKeyManager = jwk.NewManagerStrategy(hardwareKeyManager, m.persister)
 		} else {
 			m.defaultKeyManager = m.persister

--- a/driver/registry_sql.go
+++ b/driver/registry_sql.go
@@ -86,7 +86,7 @@ func (m *RegistrySQL) Init(ctx context.Context) error {
 		}
 
 		if m.C.HsmEnabled() {
-			hardwareKeyManager := hsm.NewKeyManager(m.HsmContext())
+			hardwareKeyManager := hsm.NewKeyManager(m.HsmContext(), m.C.HsmKeyPrefix())
 			m.defaultKeyManager = jwk.NewManagerStrategy(hardwareKeyManager, m.persister)
 		} else {
 			m.defaultKeyManager = m.persister

--- a/hsm/manager_hsm.go
+++ b/hsm/manager_hsm.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	"github.com/ory/hydra/driver/config"
 	"net/http"
 	"sync"
 
@@ -33,7 +34,7 @@ type KeyManager struct {
 	jwk.Manager
 	sync.RWMutex
 	Context
-	KeyPrefix string
+	KeySetPrefix string
 }
 
 var ErrPreGeneratedKeys = &fosite.RFC6749Error{
@@ -42,10 +43,10 @@ var ErrPreGeneratedKeys = &fosite.RFC6749Error{
 	DescriptionField: "Cannot add/update pre generated keys on Hardware Security Module",
 }
 
-func NewKeyManager(hsm Context, keyPrefix string) *KeyManager {
+func NewKeyManager(hsm Context, config *config.Provider) *KeyManager {
 	return &KeyManager{
-		Context:   hsm,
-		KeyPrefix: keyPrefix,
+		Context:      hsm,
+		KeySetPrefix: config.HsmKeySetPrefix(),
 	}
 }
 
@@ -324,5 +325,5 @@ func createKeys(key crypto11.Signer, kid, alg, use string) []jose.JSONWebKey {
 }
 
 func (m *KeyManager) prefixKeySet(set string) string {
-	return fmt.Sprintf("%s%s", m.KeyPrefix, set)
+	return fmt.Sprintf("%s%s", m.KeySetPrefix, set)
 }

--- a/hsm/manager_hsm_test.go
+++ b/hsm/manager_hsm_test.go
@@ -54,7 +54,7 @@ func TestDefaultKeyManager_HsmEnabled(t *testing.T) {
 	assert.IsType(t, &sql.Persister{}, reg.SoftwareKeyManager())
 }
 
-func TestKeyManager_HsmKeyPrefix(t *testing.T) {
+func TestKeyManager_HsmKeySetPrefix(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	hsmContext := NewMockContext(ctrl)
 	defer ctrl.Finish()
@@ -73,12 +73,12 @@ func TestKeyManager_HsmKeyPrefix(t *testing.T) {
 
 	var kid = uuid.New()
 
-	keyPrefix := "application_specific_prefix."
-	expectedPrefixedOpenIDConnectKeyName := fmt.Sprintf("%s%s", keyPrefix, x.OpenIDConnectKeyName)
+	keySetPrefix := "application_specific_prefix."
+	expectedPrefixedOpenIDConnectKeyName := fmt.Sprintf("%s%s", keySetPrefix, x.OpenIDConnectKeyName)
 
 	m := &hsm.KeyManager{
-		Context:   hsmContext,
-		KeyPrefix: keyPrefix,
+		Context:      hsmContext,
+		KeySetPrefix: keySetPrefix,
 	}
 
 	t.Run("case=GenerateAndPersistKeySet", func(t *testing.T) {

--- a/hsm/manager_nohsm.go
+++ b/hsm/manager_nohsm.go
@@ -24,6 +24,7 @@ type KeyManager struct {
 	jwk.Manager
 	sync.RWMutex
 	Context
+	KeyPrefix string
 }
 
 var ErrOpSysNotSupported = errors.New("Hardware Security Module is not supported on this platform.")
@@ -33,7 +34,7 @@ func NewContext(c *config.Provider, l *logrusx.Logger) Context {
 	return nil
 }
 
-func NewKeyManager(hsm Context) *KeyManager {
+func NewKeyManager(hsm Context, keyPrefix string) *KeyManager {
 	return nil
 }
 

--- a/hsm/manager_nohsm.go
+++ b/hsm/manager_nohsm.go
@@ -24,7 +24,7 @@ type KeyManager struct {
 	jwk.Manager
 	sync.RWMutex
 	Context
-	KeyPrefix string
+	KeySetPrefix string
 }
 
 var ErrOpSysNotSupported = errors.New("Hardware Security Module is not supported on this platform.")
@@ -34,7 +34,7 @@ func NewContext(c *config.Provider, l *logrusx.Logger) Context {
 	return nil
 }
 
-func NewKeyManager(hsm Context, keyPrefix string) *KeyManager {
+func NewKeyManager(hsm Context, config *config.Provider) *KeyManager {
 	return nil
 }
 

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -275,6 +275,10 @@ hsm:
   pin: token-pin-code
   slot: 0
   token_label: hydra
+  # Key set prefix can be used in case of multiple Ory Hydra instances need to store keys on the same HSM partition.
+  # For example if `hsm.key_set_prefix=app1.` then key set `hydra.openid.id-token` would be generated/requested/deleted
+  # on HSM with `CKA_LABEL=app1.hydra.openid.id-token`.
+  key_set_prefix: app1.
 
 # webfinger configures ./well-known/ settings
 webfinger:

--- a/spec/config.json
+++ b/spec/config.json
@@ -479,6 +479,11 @@
         "token_label": {
           "type": "string",
           "description": "Label of the token to use (if slot is not specified). If both slot and label are set, token label takes preference over slot. In this case first slot, that contains this label is used."
+        },
+        "key_set_prefix": {
+          "type": "string",
+          "description": "Key set prefix can be used in case of multiple Ory Hydra instances need to store keys on the same HSM partition. For example if `hsm.key_set_prefix=app1.` then key set `hydra.openid.id-token` would be generated/requested/deleted on HSM with `CKA_LABEL=app1.hydra.openid.id-token`.",
+          "default": ""
         }
       }
     },


### PR DESCRIPTION
This pull request adds configuration option `hsm.key_set_prefix` to support multiple Ory Hydra instances to store keys on the same HSM partition. For example if `hsm.key_set_prefix=app1.` then key set `hydra.openid.id-token` would be generated/requested/deleted on HSM with `CKA_LABEL=app1.hydra.openid.id-token`

This will not affect Hydra API in any way. `GET /keys/hydra.openid.id-token` will return key set from HSM with label `app1.hydra.openid.id-token`

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
