### PR TITLE
feat: backchannel request logging

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -702,24 +702,24 @@ func (s *DefaultStrategy) executeBackChannelLogout(ctx context.Context, r *http.
 
 	var execute = func(t task) {
 		defer wg.Done()
+		l := s.r.Logger().WithRequest(r).
+			WithField("client_id", t.clientID).
+			WithField("token", t.token).
+			WithField("backchannel_logout_url", t.url)
 
 		res, err := hc.PostForm(t.url, url.Values{"logout_token": {t.token}})
 		if err != nil {
-			s.r.Logger().WithRequest(r).WithError(err).
-				WithField("client_id", t.clientID).
-				WithField("backchannel_logout_url", t.url).
-				Error("Unable to execute OpenID Connect Back-Channel Logout Request")
+			l.WithError(err).Error("Unable to execute OpenID Connect Back-Channel Logout Request")
 			return
 		}
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusOK {
-			s.r.Logger().WithError(errors.Errorf("expected HTTP status code %d but got %d", http.StatusOK, res.StatusCode)).
-				WithRequest(r).
-				WithField("client_id", t.clientID).
-				WithField("backchannel_logout_url", t.url).
+			l.WithError(errors.Errorf("expected HTTP status code %d but got %d", http.StatusOK, res.StatusCode)).
 				Error("Unable to execute OpenID Connect Back-Channel Logout Request")
 			return
+		} else {
+			l.Info("Back-Channel Logout Request")
 		}
 	}
 

--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -702,24 +702,23 @@ func (s *DefaultStrategy) executeBackChannelLogout(ctx context.Context, r *http.
 
 	var execute = func(t task) {
 		defer wg.Done()
-		l := s.r.Logger().WithRequest(r).
+		log := s.r.Logger().WithRequest(r).
 			WithField("client_id", t.clientID).
-			WithField("token", t.token).
 			WithField("backchannel_logout_url", t.url)
 
 		res, err := hc.PostForm(t.url, url.Values{"logout_token": {t.token}})
 		if err != nil {
-			l.WithError(err).Error("Unable to execute OpenID Connect Back-Channel Logout Request")
+			log.WithError(err).Error("Unable to execute OpenID Connect Back-Channel Logout Request")
 			return
 		}
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusOK {
-			l.WithError(errors.Errorf("expected HTTP status code %d but got %d", http.StatusOK, res.StatusCode)).
+			log.WithError(errors.Errorf("expected HTTP status code %d but got %d", http.StatusOK, res.StatusCode)).
 				Error("Unable to execute OpenID Connect Back-Channel Logout Request")
 			return
 		} else {
-			l.Info("Back-Channel Logout Request")
+			log.Info("Back-Channel Logout Request")
 		}
 	}
 


### PR DESCRIPTION
This pull request adds minor logging improvements. 

- Successful back-channel logout request logging. This is useful for [#2844](https://github.com/ory/hydra/pull/2844) when `trigger_backchannel_logout=true`. ~~Additionally log `token`  for both success/failed responses.~~
- ~~ID token logging in `POST /oauth2/token` endpoint~~

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [] I have added tests that prove my fix is effective or that my feature
      works.
- [] I have added or changed [the documentation](docs/docs).
