### PR TITLE
Fix generated consent model

### DIFF
--- a/.schema/openapi/patches/oauth2.yaml
+++ b/.schema/openapi/patches/oauth2.yaml
@@ -1,6 +1,6 @@
 - op: remove
   path: /components/schemas/consentRequestSession/properties/access_token/additionalProperties
-  - op: remove
+- op: remove
   path: /components/schemas/consentRequestSession/properties/access_token/type
 - op: remove
   path: /components/schemas/consentRequestSession/properties/id_token/additionalProperties

--- a/.schema/openapi/patches/oauth2.yaml
+++ b/.schema/openapi/patches/oauth2.yaml
@@ -1,4 +1,4 @@
 - op: remove
-  path: /components/schemas/consentRequestSession/properties/access_token/type
+  path: /components/schemas/consentRequestSession/properties/access_token/additionalProperties
 - op: remove
-  path: /components/schemas/consentRequestSession/properties/id_token/type
+  path: /components/schemas/consentRequestSession/properties/id_token/additionalProperties

--- a/.schema/openapi/patches/oauth2.yaml
+++ b/.schema/openapi/patches/oauth2.yaml
@@ -1,4 +1,8 @@
 - op: remove
   path: /components/schemas/consentRequestSession/properties/access_token/additionalProperties
+  - op: remove
+  path: /components/schemas/consentRequestSession/properties/access_token/type
 - op: remove
   path: /components/schemas/consentRequestSession/properties/id_token/additionalProperties
+- op: remove
+  path: /components/schemas/consentRequestSession/properties/id_token/type

--- a/internal/httpclient-next/api/openapi.yaml
+++ b/internal/httpclient-next/api/openapi.yaml
@@ -2294,10 +2294,8 @@ components:
           - requested_scope
           - requested_scope
         session:
-          access_token:
-            key: '{}'
-          id_token:
-            key: '{}'
+          access_token: '{}'
+          id_token: '{}'
         grant_access_token_audience:
         - grant_access_token_audience
         - grant_access_token_audience
@@ -2603,13 +2601,10 @@ components:
       type: object
     consentRequestSession:
       example:
-        access_token:
-          key: '{}'
-        id_token:
-          key: '{}'
+        access_token: '{}'
+        id_token: '{}'
       properties:
         access_token:
-          additionalProperties: true
           description: |-
             AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the
             refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection.
@@ -2617,7 +2612,6 @@ components:
             can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!
           type: object
         id_token:
-          additionalProperties: true
           description: |-
             IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable
             by anyone that has access to the ID Challenge. Use with care!

--- a/internal/httpclient-next/api/openapi.yaml
+++ b/internal/httpclient-next/api/openapi.yaml
@@ -2294,8 +2294,8 @@ components:
           - requested_scope
           - requested_scope
         session:
-          access_token: '{}'
-          id_token: '{}'
+          access_token: ""
+          id_token: ""
         grant_access_token_audience:
         - grant_access_token_audience
         - grant_access_token_audience
@@ -2601,8 +2601,8 @@ components:
       type: object
     consentRequestSession:
       example:
-        access_token: '{}'
-        id_token: '{}'
+        access_token: ""
+        id_token: ""
       properties:
         access_token:
           description: |-
@@ -2610,12 +2610,10 @@ components:
             refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection.
             If only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties
             can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!
-          type: object
         id_token:
           description: |-
             IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable
             by anyone that has access to the ID Challenge. Use with care!
-          type: object
       title: Used to pass session data to a consent request.
       type: object
     flushInactiveOAuth2TokensRequest:

--- a/internal/httpclient-next/docs/ConsentRequestSession.md
+++ b/internal/httpclient-next/docs/ConsentRequestSession.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**AccessToken** | Pointer to **map[string]map[string]interface{}** | AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection. If only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care! | [optional] 
-**IdToken** | Pointer to **map[string]map[string]interface{}** | IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session&#39;id payloads are readable by anyone that has access to the ID Challenge. Use with care! | [optional] 
+**AccessToken** | Pointer to **map[string]interface{}** | AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection. If only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care! | [optional] 
+**IdToken** | Pointer to **map[string]interface{}** | IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session&#39;id payloads are readable by anyone that has access to the ID Challenge. Use with care! | [optional] 
 
 ## Methods
 
@@ -28,20 +28,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetAccessToken
 
-`func (o *ConsentRequestSession) GetAccessToken() map[string]map[string]interface{}`
+`func (o *ConsentRequestSession) GetAccessToken() map[string]interface{}`
 
 GetAccessToken returns the AccessToken field if non-nil, zero value otherwise.
 
 ### GetAccessTokenOk
 
-`func (o *ConsentRequestSession) GetAccessTokenOk() (*map[string]map[string]interface{}, bool)`
+`func (o *ConsentRequestSession) GetAccessTokenOk() (*map[string]interface{}, bool)`
 
 GetAccessTokenOk returns a tuple with the AccessToken field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetAccessToken
 
-`func (o *ConsentRequestSession) SetAccessToken(v map[string]map[string]interface{})`
+`func (o *ConsentRequestSession) SetAccessToken(v map[string]interface{})`
 
 SetAccessToken sets AccessToken field to given value.
 
@@ -53,20 +53,20 @@ HasAccessToken returns a boolean if a field has been set.
 
 ### GetIdToken
 
-`func (o *ConsentRequestSession) GetIdToken() map[string]map[string]interface{}`
+`func (o *ConsentRequestSession) GetIdToken() map[string]interface{}`
 
 GetIdToken returns the IdToken field if non-nil, zero value otherwise.
 
 ### GetIdTokenOk
 
-`func (o *ConsentRequestSession) GetIdTokenOk() (*map[string]map[string]interface{}, bool)`
+`func (o *ConsentRequestSession) GetIdTokenOk() (*map[string]interface{}, bool)`
 
 GetIdTokenOk returns a tuple with the IdToken field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIdToken
 
-`func (o *ConsentRequestSession) SetIdToken(v map[string]map[string]interface{})`
+`func (o *ConsentRequestSession) SetIdToken(v map[string]interface{})`
 
 SetIdToken sets IdToken field to given value.
 

--- a/internal/httpclient-next/docs/ConsentRequestSession.md
+++ b/internal/httpclient-next/docs/ConsentRequestSession.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**AccessToken** | Pointer to **map[string]interface{}** | AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection. If only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care! | [optional] 
-**IdToken** | Pointer to **map[string]interface{}** | IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session&#39;id payloads are readable by anyone that has access to the ID Challenge. Use with care! | [optional] 
+**AccessToken** | Pointer to **interface{}** | AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection. If only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care! | [optional] 
+**IdToken** | Pointer to **interface{}** | IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session&#39;id payloads are readable by anyone that has access to the ID Challenge. Use with care! | [optional] 
 
 ## Methods
 
@@ -28,20 +28,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetAccessToken
 
-`func (o *ConsentRequestSession) GetAccessToken() map[string]interface{}`
+`func (o *ConsentRequestSession) GetAccessToken() interface{}`
 
 GetAccessToken returns the AccessToken field if non-nil, zero value otherwise.
 
 ### GetAccessTokenOk
 
-`func (o *ConsentRequestSession) GetAccessTokenOk() (*map[string]interface{}, bool)`
+`func (o *ConsentRequestSession) GetAccessTokenOk() (*interface{}, bool)`
 
 GetAccessTokenOk returns a tuple with the AccessToken field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetAccessToken
 
-`func (o *ConsentRequestSession) SetAccessToken(v map[string]interface{})`
+`func (o *ConsentRequestSession) SetAccessToken(v interface{})`
 
 SetAccessToken sets AccessToken field to given value.
 
@@ -51,22 +51,32 @@ SetAccessToken sets AccessToken field to given value.
 
 HasAccessToken returns a boolean if a field has been set.
 
+### SetAccessTokenNil
+
+`func (o *ConsentRequestSession) SetAccessTokenNil(b bool)`
+
+ SetAccessTokenNil sets the value for AccessToken to be an explicit nil
+
+### UnsetAccessToken
+`func (o *ConsentRequestSession) UnsetAccessToken()`
+
+UnsetAccessToken ensures that no value is present for AccessToken, not even an explicit nil
 ### GetIdToken
 
-`func (o *ConsentRequestSession) GetIdToken() map[string]interface{}`
+`func (o *ConsentRequestSession) GetIdToken() interface{}`
 
 GetIdToken returns the IdToken field if non-nil, zero value otherwise.
 
 ### GetIdTokenOk
 
-`func (o *ConsentRequestSession) GetIdTokenOk() (*map[string]interface{}, bool)`
+`func (o *ConsentRequestSession) GetIdTokenOk() (*interface{}, bool)`
 
 GetIdTokenOk returns a tuple with the IdToken field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIdToken
 
-`func (o *ConsentRequestSession) SetIdToken(v map[string]interface{})`
+`func (o *ConsentRequestSession) SetIdToken(v interface{})`
 
 SetIdToken sets IdToken field to given value.
 
@@ -76,6 +86,16 @@ SetIdToken sets IdToken field to given value.
 
 HasIdToken returns a boolean if a field has been set.
 
+### SetIdTokenNil
+
+`func (o *ConsentRequestSession) SetIdTokenNil(b bool)`
+
+ SetIdTokenNil sets the value for IdToken to be an explicit nil
+
+### UnsetIdToken
+`func (o *ConsentRequestSession) UnsetIdToken()`
+
+UnsetIdToken ensures that no value is present for IdToken, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/internal/httpclient-next/model_consent_request_session.go
+++ b/internal/httpclient-next/model_consent_request_session.go
@@ -18,9 +18,9 @@ import (
 // ConsentRequestSession struct for ConsentRequestSession
 type ConsentRequestSession struct {
 	// AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection. If only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!
-	AccessToken map[string]map[string]interface{} `json:"access_token,omitempty"`
+	AccessToken map[string]interface{} `json:"access_token,omitempty"`
 	// IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable by anyone that has access to the ID Challenge. Use with care!
-	IdToken map[string]map[string]interface{} `json:"id_token,omitempty"`
+	IdToken map[string]interface{} `json:"id_token,omitempty"`
 }
 
 // NewConsentRequestSession instantiates a new ConsentRequestSession object
@@ -41,9 +41,9 @@ func NewConsentRequestSessionWithDefaults() *ConsentRequestSession {
 }
 
 // GetAccessToken returns the AccessToken field value if set, zero value otherwise.
-func (o *ConsentRequestSession) GetAccessToken() map[string]map[string]interface{} {
+func (o *ConsentRequestSession) GetAccessToken() map[string]interface{} {
 	if o == nil || o.AccessToken == nil {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.AccessToken
@@ -51,7 +51,7 @@ func (o *ConsentRequestSession) GetAccessToken() map[string]map[string]interface
 
 // GetAccessTokenOk returns a tuple with the AccessToken field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConsentRequestSession) GetAccessTokenOk() (map[string]map[string]interface{}, bool) {
+func (o *ConsentRequestSession) GetAccessTokenOk() (map[string]interface{}, bool) {
 	if o == nil || o.AccessToken == nil {
 		return nil, false
 	}
@@ -67,15 +67,15 @@ func (o *ConsentRequestSession) HasAccessToken() bool {
 	return false
 }
 
-// SetAccessToken gets a reference to the given map[string]map[string]interface{} and assigns it to the AccessToken field.
-func (o *ConsentRequestSession) SetAccessToken(v map[string]map[string]interface{}) {
+// SetAccessToken gets a reference to the given map[string]interface{} and assigns it to the AccessToken field.
+func (o *ConsentRequestSession) SetAccessToken(v map[string]interface{}) {
 	o.AccessToken = v
 }
 
 // GetIdToken returns the IdToken field value if set, zero value otherwise.
-func (o *ConsentRequestSession) GetIdToken() map[string]map[string]interface{} {
+func (o *ConsentRequestSession) GetIdToken() map[string]interface{} {
 	if o == nil || o.IdToken == nil {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.IdToken
@@ -83,7 +83,7 @@ func (o *ConsentRequestSession) GetIdToken() map[string]map[string]interface{} {
 
 // GetIdTokenOk returns a tuple with the IdToken field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConsentRequestSession) GetIdTokenOk() (map[string]map[string]interface{}, bool) {
+func (o *ConsentRequestSession) GetIdTokenOk() (map[string]interface{}, bool) {
 	if o == nil || o.IdToken == nil {
 		return nil, false
 	}
@@ -99,8 +99,8 @@ func (o *ConsentRequestSession) HasIdToken() bool {
 	return false
 }
 
-// SetIdToken gets a reference to the given map[string]map[string]interface{} and assigns it to the IdToken field.
-func (o *ConsentRequestSession) SetIdToken(v map[string]map[string]interface{}) {
+// SetIdToken gets a reference to the given map[string]interface{} and assigns it to the IdToken field.
+func (o *ConsentRequestSession) SetIdToken(v map[string]interface{}) {
 	o.IdToken = v
 }
 

--- a/internal/httpclient-next/model_consent_request_session.go
+++ b/internal/httpclient-next/model_consent_request_session.go
@@ -18,9 +18,9 @@ import (
 // ConsentRequestSession struct for ConsentRequestSession
 type ConsentRequestSession struct {
 	// AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the refresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection. If only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties can access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!
-	AccessToken map[string]interface{} `json:"access_token,omitempty"`
+	AccessToken interface{} `json:"access_token,omitempty"`
 	// IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable by anyone that has access to the ID Challenge. Use with care!
-	IdToken map[string]interface{} `json:"id_token,omitempty"`
+	IdToken interface{} `json:"id_token,omitempty"`
 }
 
 // NewConsentRequestSession instantiates a new ConsentRequestSession object
@@ -40,10 +40,10 @@ func NewConsentRequestSessionWithDefaults() *ConsentRequestSession {
 	return &this
 }
 
-// GetAccessToken returns the AccessToken field value if set, zero value otherwise.
-func (o *ConsentRequestSession) GetAccessToken() map[string]interface{} {
-	if o == nil || o.AccessToken == nil {
-		var ret map[string]interface{}
+// GetAccessToken returns the AccessToken field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ConsentRequestSession) GetAccessToken() interface{} {
+	if o == nil {
+		var ret interface{}
 		return ret
 	}
 	return o.AccessToken
@@ -51,11 +51,12 @@ func (o *ConsentRequestSession) GetAccessToken() map[string]interface{} {
 
 // GetAccessTokenOk returns a tuple with the AccessToken field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConsentRequestSession) GetAccessTokenOk() (map[string]interface{}, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ConsentRequestSession) GetAccessTokenOk() (*interface{}, bool) {
 	if o == nil || o.AccessToken == nil {
 		return nil, false
 	}
-	return o.AccessToken, true
+	return &o.AccessToken, true
 }
 
 // HasAccessToken returns a boolean if a field has been set.
@@ -67,15 +68,15 @@ func (o *ConsentRequestSession) HasAccessToken() bool {
 	return false
 }
 
-// SetAccessToken gets a reference to the given map[string]interface{} and assigns it to the AccessToken field.
-func (o *ConsentRequestSession) SetAccessToken(v map[string]interface{}) {
+// SetAccessToken gets a reference to the given interface{} and assigns it to the AccessToken field.
+func (o *ConsentRequestSession) SetAccessToken(v interface{}) {
 	o.AccessToken = v
 }
 
-// GetIdToken returns the IdToken field value if set, zero value otherwise.
-func (o *ConsentRequestSession) GetIdToken() map[string]interface{} {
-	if o == nil || o.IdToken == nil {
-		var ret map[string]interface{}
+// GetIdToken returns the IdToken field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ConsentRequestSession) GetIdToken() interface{} {
+	if o == nil {
+		var ret interface{}
 		return ret
 	}
 	return o.IdToken
@@ -83,11 +84,12 @@ func (o *ConsentRequestSession) GetIdToken() map[string]interface{} {
 
 // GetIdTokenOk returns a tuple with the IdToken field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConsentRequestSession) GetIdTokenOk() (map[string]interface{}, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ConsentRequestSession) GetIdTokenOk() (*interface{}, bool) {
 	if o == nil || o.IdToken == nil {
 		return nil, false
 	}
-	return o.IdToken, true
+	return &o.IdToken, true
 }
 
 // HasIdToken returns a boolean if a field has been set.
@@ -99,8 +101,8 @@ func (o *ConsentRequestSession) HasIdToken() bool {
 	return false
 }
 
-// SetIdToken gets a reference to the given map[string]interface{} and assigns it to the IdToken field.
-func (o *ConsentRequestSession) SetIdToken(v map[string]interface{}) {
+// SetIdToken gets a reference to the given interface{} and assigns it to the IdToken field.
+func (o *ConsentRequestSession) SetIdToken(v interface{}) {
 	o.IdToken = v
 }
 

--- a/spec/api.json
+++ b/spec/api.json
@@ -314,12 +314,12 @@
       "consentRequestSession": {
         "properties": {
           "access_token": {
-            "additionalProperties": true,
-            "description": "AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the\nrefresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection.\nIf only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties\ncan access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!"
+            "description": "AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the\nrefresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection.\nIf only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties\ncan access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!",
+            "type": "object"
           },
           "id_token": {
-            "additionalProperties": true,
-            "description": "IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable\nby anyone that has access to the ID Challenge. Use with care!"
+            "description": "IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable\nby anyone that has access to the ID Challenge. Use with care!",
+            "type": "object"
           }
         },
         "title": "Used to pass session data to a consent request.",

--- a/spec/api.json
+++ b/spec/api.json
@@ -314,12 +314,10 @@
       "consentRequestSession": {
         "properties": {
           "access_token": {
-            "description": "AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the\nrefresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection.\nIf only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties\ncan access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!",
-            "type": "object"
+            "description": "AccessToken sets session data for the access and refresh token, as well as any future tokens issued by the\nrefresh grant. Keep in mind that this data will be available to anyone performing OAuth 2.0 Challenge Introspection.\nIf only your services can perform OAuth 2.0 Challenge Introspection, this is usually fine. But if third parties\ncan access that endpoint as well, sensitive data from the session might be exposed to them. Use with care!"
           },
           "id_token": {
-            "description": "IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable\nby anyone that has access to the ID Challenge. Use with care!",
-            "type": "object"
+            "description": "IDToken sets session data for the OpenID Connect ID token. Keep in mind that the session'id payloads are readable\nby anyone that has access to the ID Challenge. Use with care!"
           }
         },
         "title": "Used to pass session data to a consent request.",


### PR DESCRIPTION
Fixes generated oauth2 accept consent session models

Seems like a bug with the client generator but the upstream repository has an issue open about this since 2018.

Based on #3074, updated the patch to keep `type` but remove the `additionalProperties` field

## Related issue(s)

#3058
https://github.com/ory/sdk/issues/12
#3074

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).