### PR TITLE
feat(admin): add optional basic auth to admin router

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       matrix:
         database: ['memory', 'postgres', 'mysql', 'cockroach']
-        args: ['', '--jwt']
+        args: ['', '--jwt', '--admin-basic-auth']
     services:
       postgres:
         image: postgres:9.6

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ e2e: node_modules test-resetdb
 		for db in memory postgres mysql cockroach; do \
 			./test/e2e/circle-ci.bash "$${db}"; \
 			./test/e2e/circle-ci.bash "$${db}" --jwt; \
+			./test/e2e/circle-ci.bash "$${db}" --admin-basic-auth; \
 		done
 
 # Runs tests in short mode, without database adapters

--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -207,6 +207,14 @@ func setup(d driver.Registry, cmd *cobra.Command) (admin *x.RouterAdmin, public 
 	adminmw.Use(adminLogger)
 	adminmw.Use(d.PrometheusManager())
 
+	if d.Config().AdminBasicAuthRequired() {
+		basicAuthMiddleware := x.NewBasicAuthMiddleware(
+			d.Config().AdminBasicAuthUsername(),
+			d.Config().AdminBasicAuthPassword(),
+		)
+		adminmw.Use(basicAuthMiddleware)
+	}
+
 	publicLogger := reqlog.NewMiddlewareFromLogger(
 		d.Logger(),
 		fmt.Sprintf("hydra/public: %s", d.Config().IssuerURL().String()),

--- a/cypress/integration/admin/client_create.js
+++ b/cypress/integration/admin/client_create.js
@@ -6,6 +6,21 @@ describe('The Clients Admin Interface', function () {
     grant_types: ['client_credentials']
   })
 
+  if (Cypress.env('admin_basic_auth')) {
+    it('should return a 403 error if basic auth credentials are not provided', function () {
+      const client = nc()
+
+      cy.request({
+        method: 'POST',
+        url: Cypress.env('admin_url_noauth') + '/clients',
+        failOnStatusCode: false,
+        body: JSON.stringify(client)
+      }).then((response) => {
+        expect(response.status).to.equal(401)
+      })
+    })
+  }
+
   it('should return client_secret with length 26 for newly created clients without client_secret specified', function () {
     const client = nc()
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,7 +11,38 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+module.exports = (_on, config) => {
+  // Mimic Go's strconv.ParseBool() behavior which Hydra uses to evaluate boolean
+  // configuration values.
+  const parseBool = (str) => {
+    switch (str) {
+      case '1':
+      case 't':
+      case 'T':
+      case 'true':
+      case 'TRUE':
+      case 'True':
+        return true
+      default:
+        return false
+    }
+  }
+
+  // If admin basicauth is configured, change admin URL used by Cypress tests.
+  if (parseBool(process.env.SERVE_ADMIN_BASIC_AUTH_REQUIRED)) {
+    config.env.admin_basic_auth = true
+    config.env.admin_username = process.env.SERVE_ADMIN_BASIC_AUTH_USERNAME
+    config.env.admin_password = process.env.SERVE_ADMIN_BASIC_AUTH_PASSWORD
+
+    let u = new URL(config.env.admin_url)
+    u.username = ''
+    u.password = ''
+    config.env.admin_url_noauth = u.toString()
+
+    u.username = config.env.admin_username
+    u.password = config.env.admin_password
+    config.env.admin_url = u.toString()
+  }
+
+  return config
 }

--- a/driver/config/serve.go
+++ b/driver/config/serve.go
@@ -17,6 +17,9 @@ const (
 	KeySuffixSocketGroup            = "socket.group"
 	KeySuffixSocketMode             = "socket.mode"
 	KeySuffixDisableHealthAccessLog = "access_log.disable_for_health"
+	KeyBasicAuthRequired            = "basic_auth.required"
+	KeyBasicAuthUsername            = "basic_auth.username"
+	KeyBasicAuthPassword            = "basic_auth.password" // #nosec G101
 )
 
 var (
@@ -78,4 +81,28 @@ func (p *Provider) host(iface ServeInterface) string {
 
 func (p *Provider) port(iface ServeInterface) int {
 	return p.p.Int(iface.Key(KeySuffixListenOnPort))
+}
+
+func (p *Provider) AdminBasicAuthRequired() bool {
+	return p.basicAuthRequired(AdminInterface)
+}
+
+func (p *Provider) AdminBasicAuthUsername() string {
+	return p.basicAuthUsername(AdminInterface)
+}
+
+func (p *Provider) AdminBasicAuthPassword() string {
+	return p.basicAuthPassword(AdminInterface)
+}
+
+func (p *Provider) basicAuthRequired(iface ServeInterface) bool {
+	return p.p.BoolF(iface.Key(KeyBasicAuthRequired), false)
+}
+
+func (p *Provider) basicAuthUsername(iface ServeInterface) string {
+	return p.p.String(iface.Key(KeyBasicAuthUsername))
+}
+
+func (p *Provider) basicAuthPassword(iface ServeInterface) string {
+	return p.p.String(iface.Key(KeyBasicAuthPassword))
 }

--- a/spec/config.json
+++ b/spec/config.json
@@ -158,6 +158,28 @@
         }
       }
     },
+    "basic_auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Configures basic auth for admin endpoints.",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Sets whether basic auth is required.",
+          "default": false
+        },
+        "username": {
+          "type": "string",
+          "description": "Basic auth username",
+          "default": ""
+        },
+        "password": {
+          "type": "string",
+          "description": "Basic auth password",
+          "default": ""
+        }
+      }
+    },
     "cidr": {
       "description": "CIDR address range.",
       "type": "string",
@@ -388,6 +410,9 @@
             },
             "cors": {
               "$ref": "#/definitions/cors"
+            },
+            "basic_auth": {
+              "$ref": "#/definitions/basic_auth"
             },
             "socket": {
               "$ref": "#/definitions/socket"

--- a/x/middleware_basicauth.go
+++ b/x/middleware_basicauth.go
@@ -1,0 +1,29 @@
+package x
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+type BasicAuthMiddleware struct {
+	basicAuthUsername string
+	basicAuthPassword string
+}
+
+func NewBasicAuthMiddleware(username, password string) *BasicAuthMiddleware {
+	return &BasicAuthMiddleware{
+		basicAuthUsername: username,
+		basicAuthPassword: password,
+	}
+}
+
+func (m *BasicAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	gotUsername, gotPassword, hasAuth := r.BasicAuth()
+	validUsername := subtle.ConstantTimeCompare([]byte(gotUsername), []byte(m.basicAuthUsername)) == 1
+	validPassword := subtle.ConstantTimeCompare([]byte(gotPassword), []byte(m.basicAuthPassword)) == 1
+	if hasAuth && validUsername && validPassword {
+		next(rw, r)
+		return
+	}
+	http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+}

--- a/x/middleware_basicauth_test.go
+++ b/x/middleware_basicauth_test.go
@@ -1,0 +1,150 @@
+package x
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicAuthMiddleware_ServeHTTP(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiredUsername string
+		requiredPassword string
+		givenUsername    string
+		givenPassword    string
+		givenNoAuth      bool
+		expectedNext     bool
+		expectedStatus   int
+	}{{
+		name:             "valid username/password",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		givenUsername:    "foo",
+		givenPassword:    "bar",
+		expectedNext:     true,
+		expectedStatus:   http.StatusOK,
+	}, {
+		name:             "valid empty username",
+		requiredUsername: "",
+		requiredPassword: "bar",
+		givenUsername:    "",
+		givenPassword:    "bar",
+		expectedNext:     true,
+		expectedStatus:   http.StatusOK,
+	}, {
+		name:             "valid empty password",
+		requiredUsername: "foo",
+		requiredPassword: "",
+		givenUsername:    "foo",
+		givenPassword:    "",
+		expectedNext:     true,
+		expectedStatus:   http.StatusOK,
+	}, {
+		name:             "valid empty username/password",
+		requiredUsername: "",
+		requiredPassword: "",
+		givenUsername:    "",
+		givenPassword:    "",
+		expectedNext:     true,
+		expectedStatus:   http.StatusOK,
+	}, {
+		name:             "no username/password",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "invalid username/password",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		givenUsername:    "foo",
+		givenPassword:    "not-bar",
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "invalid username, valid password",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		givenUsername:    "not-foo",
+		givenPassword:    "bar",
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "valid username, invalid password",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		givenUsername:    "foo",
+		givenPassword:    "not-bar",
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "invalid empty username",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		givenUsername:    "",
+		givenPassword:    "bar",
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "invalid empty password",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		givenUsername:    "foo",
+		givenPassword:    "",
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "invalid empty username/password",
+		requiredUsername: "",
+		requiredPassword: "",
+		givenUsername:    "foo",
+		givenPassword:    "bar",
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "missing username/password",
+		requiredUsername: "foo",
+		requiredPassword: "bar",
+		givenNoAuth:      true,
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}, {
+		name:             "missing auth with empty required username/password",
+		requiredUsername: "",
+		requiredPassword: "",
+		givenNoAuth:      true,
+		expectedNext:     false,
+		expectedStatus:   http.StatusUnauthorized,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewBasicAuthMiddleware(tt.requiredUsername, tt.requiredPassword)
+
+			// add a next handler that sets nextCalled to true
+			nextCalled := false
+			next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+			})
+
+			// construct a request
+			req, err := http.NewRequest("GET", "", nil)
+			require.NoError(t, err)
+
+			// set the username and password
+			if !tt.givenNoAuth {
+				req.SetBasicAuth(tt.givenUsername, tt.givenPassword)
+			}
+
+			// serve the request
+			rw := httptest.NewRecorder()
+			m.ServeHTTP(rw, req, next.ServeHTTP)
+
+			// check the response and whether the next handler was called
+			require.Equal(t, tt.expectedNext, nextCalled)
+			require.Equal(t, tt.expectedStatus, rw.Code)
+		})
+	}
+}


### PR DESCRIPTION
Add optional Basic Auth support for securing the Admin API.

## Related issue(s)

- Discussion about securing Admin API: #2041
- Draft PR for adding basic auth support to the `hydra` CLI client, intended for when running Admin API behind a reverse proxy: #3035

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

This was put together rather quickly, but seems to work nicely. We definitely didn't wrap our heads around Cypress properly for this, so chances are testing is not up to scratch, and we're happy to address any feedback.

Documentation update was also left out, as it looks like docs now live in their own [repo](https://github.com/ory/docs).