### PR TITLE
FIX: Add CORS healthcheck handlers for alive/ready

### DIFF
--- a/health/handler_test.go
+++ b/health/handler_test.go
@@ -1,0 +1,87 @@
+package health
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ory/x/contextx"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/hydra/driver/config"
+	"github.com/ory/hydra/internal"
+	"github.com/ory/hydra/x"
+	"github.com/ory/x/healthx"
+)
+
+func TestPublicHealthHandler(t *testing.T) {
+	ctx := context.Background()
+
+	doCORSRequest := func(t *testing.T, endpoint string) *http.Response {
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		require.NoError(t, err)
+		req.Host = "example.com"
+		req.Header.Add("Origin", "https://example.com")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	expectCORSHeaders := func(t *testing.T, resp *http.Response) {
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "Origin", resp.Header.Get("Vary"))
+		assert.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+	}
+
+	expectNoCORSHeaders := func(t *testing.T, resp *http.Response) {
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotEqual(t, "Origin", resp.Header.Get("Vary"))
+		assert.Equal(t, "", resp.Header.Get("Access-Control-Allow-Origin"))
+	}
+
+	for _, tc := range []struct {
+		name           string
+		config         map[string]interface{}
+		verifyResponse func(t *testing.T, resp *http.Response)
+	}{
+		{
+			name: "with CORS enabled",
+			config: map[string]interface{}{
+				"cors.allowed_origins":   []string{"https://example.com"},
+				"cors.enabled":           true,
+				"cors.allowed_methods":   []string{"GET"},
+				"cors.allow_credentials": true,
+			},
+			verifyResponse: expectCORSHeaders,
+		},
+		{
+			name: "with CORS disabled",
+			config: map[string]interface{}{
+				"cors.enabled": false,
+			},
+			verifyResponse: expectNoCORSHeaders,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := internal.NewConfigurationWithDefaults()
+			for k, v := range tc.config {
+				conf.MustSet(ctx, config.PublicInterface.Key(k), v)
+			}
+
+			reg := internal.NewRegistryMemory(t, conf, &contextx.Default{})
+
+			public := x.NewRouterPublic()
+			reg.RegisterRoutes(ctx, x.NewRouterAdmin(), public)
+
+			ts := httptest.NewServer(public)
+
+			tc.verifyResponse(t, doCORSRequest(t, ts.URL+healthx.AliveCheckPath))
+			tc.verifyResponse(t, doCORSRequest(t, ts.URL+healthx.ReadyCheckPath))
+		})
+	}
+}


### PR DESCRIPTION
defines and implements the
healthcheck struct to create a
definitive wrapper around the healthx handlers

also adds a cors middleware wrapper
for http.Handler types withouth the
iface defaults (might need changing)

## Related issue(s)
#2989  

## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

Needed another PR due to a partially pushed (amended git commit) on the older branch that'd need a force push, hence this.