### PR TITLE
Janitor optimization use requested at index

### DIFF
--- a/internal/testhelpers/janitor_test_helper.go
+++ b/internal/testhelpers/janitor_test_helper.go
@@ -507,7 +507,7 @@ func JanitorTests(conf *config.Provider, consentManager consent.Manager, clientM
 
 				// cleanup
 				t.Run("step=cleanup", func(t *testing.T) {
-					require.NoError(t, fositeManager.FlushInactiveLoginConsentRequests(ctx, time.Now().Round(time.Second), 2, 1))
+					require.NoError(t, fositeManager.FlushInactiveLoginConsentRequests(ctx, time.Now().Round(time.Second), 4, 1))
 				})
 
 				// validate

--- a/persistence/sql/migrations/20220516123200000000_oauth2.down.sql
+++ b/persistence/sql/migrations/20220516123200000000_oauth2.down.sql
@@ -1,4 +1,3 @@
-DROP INDEX hydra_oauth2_access_expiry;
-DROP INDEX hydra_oauth2_refresh_expiry;
-DROP INDEX hydra_oauth2_authentication_request_expiry;
-DROP INDEX hydra_oauth2_consent_request_expiry;
+DROP INDEX hydra_oauth2_refresh_requested_at_idx;
+DROP INDEX hydra_oauth2_authentication_request_requested_at_idx;
+DROP INDEX hydra_oauth2_consent_request_requested_at_idx;

--- a/persistence/sql/migrations/20220516123200000000_oauth2.down.sql
+++ b/persistence/sql/migrations/20220516123200000000_oauth2.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX hydra_oauth2_access_expiry;
+DROP INDEX hydra_oauth2_refresh_expiry;
+DROP INDEX hydra_oauth2_authentication_request_expiry;
+DROP INDEX hydra_oauth2_consent_request_expiry;

--- a/persistence/sql/migrations/20220516123200000000_oauth2.up.sql
+++ b/persistence/sql/migrations/20220516123200000000_oauth2.up.sql
@@ -1,4 +1,3 @@
-CREATE INDEX hydra_oauth2_access_expiry ON hydra_oauth2_access (requested_at);
-CREATE INDEX hydra_oauth2_refresh_expiry ON hydra_oauth2_refresh (requested_at);
-CREATE INDEX hydra_oauth2_authentication_request_expiry ON hydra_oauth2_authentication_request (requested_at);
-CREATE INDEX hydra_oauth2_consent_request_expiry ON hydra_oauth2_consent_request (requested_at);
+CREATE INDEX hydra_oauth2_refresh_requested_at_idx ON hydra_oauth2_refresh (requested_at);
+CREATE INDEX hydra_oauth2_authentication_request_requested_at_idx ON hydra_oauth2_authentication_request (requested_at);
+CREATE INDEX hydra_oauth2_consent_request_requested_at_idx ON hydra_oauth2_consent_request (requested_at);

--- a/persistence/sql/migrations/20220516123200000000_oauth2.up.sql
+++ b/persistence/sql/migrations/20220516123200000000_oauth2.up.sql
@@ -1,0 +1,4 @@
+CREATE INDEX hydra_oauth2_access_expiry ON hydra_oauth2_access (requested_at);
+CREATE INDEX hydra_oauth2_refresh_expiry ON hydra_oauth2_refresh (requested_at);
+CREATE INDEX hydra_oauth2_authentication_request_expiry ON hydra_oauth2_authentication_request (requested_at);
+CREATE INDEX hydra_oauth2_consent_request_expiry ON hydra_oauth2_consent_request (requested_at);

--- a/persistence/sql/persister_consent.go
+++ b/persistence/sql/persister_consent.go
@@ -455,6 +455,7 @@ func (p *Persister) FlushInactiveLoginConsentRequests(ctx context.Context, notAf
 	}
 
 	consent_challenges := []string{}
+	// Order by requested_at field to avoid full scan and use requested_at index
 	queryFormat := `
 	SELECT %[1]s.challenge
 	FROM %[1]s

--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -377,6 +377,7 @@ func (p *Persister) flushInactiveTokens(ctx context.Context, notAfter time.Time,
 	signatures := []string{}
 
 	// Select tokens' signatures with limit
+	// Order by requested_at field to avoid full scan and use requested_at index
 	q := p.Connection(ctx).RawQuery(
 		fmt.Sprintf("SELECT signature FROM %s WHERE requested_at < ? ORDER BY requested_at LIMIT %d",
 			OAuth2RequestSQL{Table: table}.TableName(), limit),

--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -378,7 +378,7 @@ func (p *Persister) flushInactiveTokens(ctx context.Context, notAfter time.Time,
 
 	// Select tokens' signatures with limit
 	q := p.Connection(ctx).RawQuery(
-		fmt.Sprintf("SELECT signature FROM %s WHERE requested_at < ? ORDER BY signature LIMIT %d",
+		fmt.Sprintf("SELECT signature FROM %s WHERE requested_at < ? ORDER BY requested_at LIMIT %d",
 			OAuth2RequestSQL{Table: table}.TableName(), limit),
 		notAfter,
 	)


### PR DESCRIPTION
Hi,

on large tables, janitor queries could take minutes.

Table like refresh_token can grow before there is some expired tokens.

By adding missing indexes on requested_at columns, and by ordering on this field we can avoid full table scan, and/or in memory sorting.

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
