### PR TITLE
fix: swagger for dynamic client registration

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -108,7 +108,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	h.r.Writer().WriteCreated(w, r, ClientsHandlerPath+"/"+c.GetID(), &c)
 }
 
-// swagger:route POST /connect/register public dynamicClientRegistrationCreateOAuth2Client
+// swagger:route POST /oauth2/register public dynamicClientRegistrationCreateOAuth2Client
 //
 // Register an OAuth 2.0 Client using the OpenID / OAuth2 Dynamic Client Registration Management Protocol
 //
@@ -251,7 +251,7 @@ func (h *Handler) updateClient(ctx context.Context, c *Client, validator func(*C
 	return nil
 }
 
-// swagger:route PUT /connect/register/{id} public dynamicClientRegistrationUpdateOAuth2Client
+// swagger:route PUT /oauth2/register/{id} public dynamicClientRegistrationUpdateOAuth2Client
 //
 // Update an OAuth 2.0 Client using the OpenID / OAuth2 Dynamic Client Registration Management Protocol
 //
@@ -488,7 +488,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 	h.r.Writer().Write(w, r, c)
 }
 
-// swagger:route GET /connect/register/{id} public dynamicClientRegistrationGetOAuth2Client
+// swagger:route GET /oauth2/register/{id} public dynamicClientRegistrationGetOAuth2Client
 //
 // Get an OAuth 2.0 Client using the OpenID / OAuth2 Dynamic Client Registration Management Protocol
 //
@@ -566,7 +566,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// swagger:route DELETE /connect/register/{id} public dynamicClientRegistrationDeleteOAuth2Client
+// swagger:route DELETE /oauth2/register/{id} public dynamicClientRegistrationDeleteOAuth2Client
 //
 // Deletes an OAuth 2.0 Client using the OpenID / OAuth2 Dynamic Client Registration Management Protocol
 //


### PR DESCRIPTION
Fix swagger documentation of the OAuth2 / OpenID Dynamic Client registration.
The endpoint was specified at `/connect/register`, but Ory Hydra exposes it at `/oauth2/register`.

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments
Once this PR is merged, the documentation should also be updated: [Ory Hydra docs](https://github.com/ory/docs/blob/master/docs/hydra/guides/openid-connect-dynamic-client-registration.mdx)
Will sign the CLA once clarified with my superior.