### PR TITLE
feat: add ability to allow token refresh from hook without overriding the session claims

### DIFF
--- a/oauth2/hook.go
+++ b/oauth2/hook.go
@@ -95,7 +95,10 @@ func RefreshTokenHook(config *config.DefaultProvider) AccessRequestHook {
 
 		switch resp.StatusCode {
 		case http.StatusOK:
-			// We only accept '200 OK' here. Any other status code is considered an error.
+			// Token refresh permitted with new session data
+		case http.StatusNoContent:
+			// Token refresh is permitted without overriding session data
+			return nil
 		case http.StatusForbidden:
 			return errorsx.WithStack(
 				fosite.ErrAccessDenied.


### PR DESCRIPTION
The refresh token hook currently requires a 200 response code with an updated session payload. There is no way to permit the token refresh without overriding the session data. It's useful, however, to be able to use the token refresh hook in order to accept/reject token refreshes without the need to update the session data.

This adds the ability for the token refresh hook to return a `204 No Content` response code to indicate that the token refresh is permitted, but not to update the session data.

The documentation has also been updated with PR https://github.com/ory/docs/pull/863

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

#3082 

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security.
      vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the
      maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
In the future, the token refresh hook request payload could be expanded to include the existing session data and allow for the `sid` to be set on the refreshed id token as described in #3082, but this is a quick workaround that'll continue to be useful even if that is implemented.