### PR TITLE
feat: support alternate hashing algorithms for client secrets

### DIFF
--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -215,7 +215,7 @@ func (m *RegistryBase) AuditLogger() *logrusx.Logger {
 
 func (m *RegistryBase) ClientHasher() fosite.Hasher {
 	if m.fh == nil {
-		m.fh = x.NewBCrypt(m.Config())
+		m.fh = x.NewHasher(m.Config())
 	}
 	return m.fh
 }

--- a/go.mod
+++ b/go.mod
@@ -63,13 +63,13 @@ require (
 	github.com/ory/go-acc v0.2.8
 	github.com/ory/graceful v0.1.1
 	github.com/ory/herodot v0.9.13
-	github.com/ory/x v0.0.415
+	github.com/ory/x v0.0.420
 	github.com/pborman/uuid v1.2.1
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/rs/cors v1.8.0
+	github.com/rs/cors v1.8.2
 	github.com/sawadashota/encrypta v0.0.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.8.2 // indirect
@@ -78,6 +78,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/tidwall/gjson v1.14.0
+	github.com/tidwall/sjson v1.2.4
 	github.com/toqueteos/webbrowser v1.2.0
 	github.com/urfave/negroni v1.0.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -516,7 +516,6 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
-github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
 github.com/gin-gonic/gin v1.7.0/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -654,10 +653,8 @@ github.com/go-pdf/fpdf v0.5.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhO
 github.com/go-pg/pg/v10 v10.0.0/go.mod h1:XHU1AkQW534GFuUdSiQ46+Xw6Ah+9+b8DlT4YwhiXL8=
 github.com/go-pg/zerochecker v0.2.0/go.mod h1:NJZ4wKL0NmTtz0GKCoJ8kym6Xn/EQzXRl2OnAe7MmDo=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
-github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
-github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
@@ -1280,7 +1277,6 @@ github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8c
 github.com/labstack/echo/v4 v4.2.0/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/labstack/gommon v0.3.1/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
-github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1564,8 +1560,8 @@ github.com/ory/x v0.0.93/go.mod h1:lfcTaGXpTZs7IEQAW00r9EtTCOxD//SiP5uWtNiz31g=
 github.com/ory/x v0.0.110/go.mod h1:DJfkE3GdakhshNhw4zlKoRaL/ozg/lcTahA9OCih2BE=
 github.com/ory/x v0.0.127/go.mod h1:FwUujfFuCj5d+xgLn4fGMYPnzriR5bdAIulFXMtnK0M=
 github.com/ory/x v0.0.214/go.mod h1:aRl57gzyD4GF0HQCekovXhv0xTZgAgiht3o8eVhsm9Q=
-github.com/ory/x v0.0.415 h1:er86z/KGP8mHxsepoDh3XxpI7wXZstwApIzcWhzoPMw=
-github.com/ory/x v0.0.415/go.mod h1:Rchv+ANloKAhmN3LZ5KUIAU2TIRlHPF7EYEB2i3xL0Q=
+github.com/ory/x v0.0.420 h1:TL1rho9LCQ25TYq+29cZa6b5mbtyL2Twe41DSAru3jM=
+github.com/ory/x v0.0.420/go.mod h1:+CZc3VvpVc34WyDRMcvm9hZ9MV36FVdbRFzRQou8Bo8=
 github.com/parnurzeal/gorequest v0.2.15/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1677,8 +1673,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/rs/cors v1.8.0 h1:P2KMzcFwrPoSjkF1WLRPsp3UMLyql8L4v9hQpVeK5so=
-github.com/rs/cors v1.8.0/go.mod h1:EBwu+T5AvHOcXwvZIkQFjUN6s8Czyqw12GL/Y0tUyRM=
+github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
+github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
@@ -2764,7 +2760,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/mold.v2 v2.2.0/go.mod h1:XMyyRsGtakkDPbxXbrA5VODo6bUXyvoDjLd5l3T0XoA=
-gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df/go.mod h1:LRQQ+SO6ZHR7tOkpBDuZnXENFzX8qRjMDMyPD6BRkCw=
 gopkg.in/gorp.v1 v1.7.2/go.mod h1:Wo3h+DBQZIxATwftsglhdD/62zRFPhGhTiu5jUJmCaw=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=

--- a/spec/config.json
+++ b/spec/config.json
@@ -890,12 +890,22 @@
         "hashers": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Configures hashing algorithms. Supports only BCrypt at the moment.",
+          "description": "Configures hashing algorithms. Supports only BCrypt and PKBDF2 at the moment.",
           "properties": {
+            "algorithm": {
+              "title": "Password hashing algorithm",
+              "description": "One of the values: pkdbf2, bcrypt.\n\nWarning! This value can not be changed once set as all existing OAuth 2.0 Clients will not be able to sign in any more.",
+              "type": "string",
+              "default": "pkdbf2",
+              "enum": [
+                "pkdbf2",
+                "bcrypt"
+              ]
+            },
             "bcrypt": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Configures the BCrypt hashing algorithm used for hashing Client Secrets.",
+              "description": "Configures the BCrypt hashing algorithm used for hashing OAuth 2.0 Client Secrets.",
               "properties": {
                 "cost": {
                   "type": "integer",
@@ -903,6 +913,31 @@
                   "default": 10,
                   "minimum": 4,
                   "maximum": 31
+                }
+              }
+            },
+            "pkdbf2": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Configures the PKDBF2 hashing algorithm used for hashing OAuth 2.0 Client Secrets.",
+              "properties": {
+                "iterations": {
+                  "type": "integer",
+                  "description": "Sets the PKDBF2 iterations. The higher the value, the more CPU time is being used to generate hashes.",
+                  "default": 20000,
+                  "minimum": 1
+                },
+                "salt_length": {
+                  "type": "integer",
+                  "description": "Sets the PKDBF2 salt length.",
+                  "default": 32,
+                  "minimum": 16
+                },
+                "key_length": {
+                  "type": "integer",
+                  "description": "Sets the PKDBF2 hey length.",
+                  "default": 32,
+                  "minimum": 16
                 }
               }
             }

--- a/x/hasher.go
+++ b/x/hasher.go
@@ -22,53 +22,66 @@ package x
 
 import (
 	"context"
+	"github.com/ory/fosite"
+	"github.com/ory/x/hashersx"
 
 	"go.opentelemetry.io/otel"
 
 	"github.com/ory/x/errorsx"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
-const defaultBCryptWorkFactor = 12
 const tracingComponent = "github.com/ory/hydra/x"
 
-// BCrypt implements a BCrypt hasher.
-type BCrypt struct {
-	c config
+var _ fosite.Hasher = (*Hasher)(nil)
+
+type HashAlgorithm string
+
+const (
+	HashAlgorithmBCrypt = HashAlgorithm("bcrypt")
+	HashAlgorithmPBKDF2 = HashAlgorithm("pbkdf2")
+)
+
+// Hasher implements fosite.Hasher.
+type Hasher struct {
+	c      config
+	bcrypt *hashersx.Bcrypt
+	pbkdf2 *hashersx.PBKDF2
 }
 
 type config interface {
-	GetBCryptCost(ctx context.Context) int
+	hashersx.PBKDF2Configurator
+	hashersx.BCryptConfigurator
+	GetHasherAlgorithm(ctx context.Context) HashAlgorithm
 }
 
-// NewBCrypt returns a new BCrypt instance.
-func NewBCrypt(c config) *BCrypt {
-	return &BCrypt{
-		c: c,
+// NewHasher returns a new BCrypt instance.
+func NewHasher(c config) *Hasher {
+	return &Hasher{
+		c:      c,
+		bcrypt: hashersx.NewHasherBcrypt(c),
+		pbkdf2: hashersx.NewHasherPBKDF2(c),
 	}
 }
 
-func (b *BCrypt) Hash(ctx context.Context, data []byte) ([]byte, error) {
+func (b *Hasher) Hash(ctx context.Context, data []byte) ([]byte, error) {
 	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "x.hasher.Hash")
 	defer span.End()
 
-	cf := b.c.GetBCryptCost(ctx)
-	if cf == 0 {
-		cf = defaultBCryptWorkFactor
+	switch b.c.GetHasherAlgorithm(ctx) {
+	case HashAlgorithmBCrypt:
+		return b.bcrypt.Generate(ctx, data)
+	case HashAlgorithmPBKDF2:
+		fallthrough
+	default:
+		return b.pbkdf2.Generate(ctx, data)
 	}
-	s, err := bcrypt.GenerateFromPassword(data, cf)
-	if err != nil {
-		return nil, errorsx.WithStack(err)
-	}
-	return s, nil
 }
 
-func (b *BCrypt) Compare(ctx context.Context, hash, data []byte) error {
+func (b *Hasher) Compare(ctx context.Context, hash, data []byte) error {
 	_, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "x.hasher.Hash")
 	defer span.End()
 
-	if err := bcrypt.CompareHashAndPassword(hash, data); err != nil {
+	if err := hashersx.Compare(ctx, data, hash); err != nil {
 		return errorsx.WithStack(err)
 	}
 	return nil

--- a/x/hasher_test.go
+++ b/x/hasher_test.go
@@ -18,7 +18,7 @@ func (c hasherConfig) GetBCryptCost(ctx context.Context) int {
 
 func TestHasher(t *testing.T) {
 	for _, cost := range []int{1, 8, 10, 16} {
-		result, err := NewBCrypt(&hasherConfig{cost: cost}).Hash(context.Background(), []byte("foobar"))
+		result, err := NewHasher(&hasherConfig{cost: cost}).Hash(context.Background(), []byte("foobar"))
 		require.NoError(t, err)
 		require.NotEmpty(t, result)
 	}
@@ -28,7 +28,7 @@ func BenchmarkHasher(b *testing.B) {
 	for cost := 1; cost <= 16; cost++ {
 		b.Run(fmt.Sprintf("cost=%d", cost), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				result, err := NewBCrypt(&hasherConfig{cost: cost}).Hash(context.Background(), []byte("foobar"))
+				result, err := NewHasher(&hasherConfig{cost: cost}).Hash(context.Background(), []byte("foobar"))
 				require.NoError(b, err)
 				require.NotEmpty(b, result)
 			}


### PR DESCRIPTION
This patch adds support for hashing client secrets using pbkdf2 instead of bcrypt, which might be a more appropriate algorithm in certain settings. As we assume that most environments fall in this category, we also changed the default to pbkdf2 with 25.000 rounds (roughly 1-3ms per hash on an Apple M1 Max core).

High hash costs are needed when hashing user-chosen passwords, as users often reuse passwords across sites. A high hash cost will make it much harder for the attacker to guess the user-chosen password and try using it on other sites (e.g. Google).

As most client secrets are auto-generated, using high hash costs is not useful. The password (OAuth2 Client Secret) is not user chosen and unlikely to be reused. As such, there is little point in using excessive hash costs to protect users. High hash costs in a system like Ory Hydra will cause high CPU costs from mostly automated traffic (OAuth2 Client interactions). It has also been a point of critizism from some who wish for better RPS on specific endpoints.

Other systems like Keycloak do not [hash client secrets at all](https://groups.google.com/g/keycloak-dev/c/TmsNfnol0_g), referencing more secure authentication mechanisms such as assertion-based client authentication.