### PR TITLE
feat: remove login session by id

### DIFF
--- a/consent/manager.go
+++ b/consent/manager.go
@@ -53,7 +53,8 @@ type Manager interface {
 	GetRememberedLoginSession(ctx context.Context, id string) (*LoginSession, error)
 	CreateLoginSession(ctx context.Context, session *LoginSession) error
 	DeleteLoginSession(ctx context.Context, id string) error
-	RevokeSubjectLoginSession(ctx context.Context, user string) error
+	RevokeSubjectLoginSessionBySubject(ctx context.Context, user string) error
+	RevokeSubjectLoginSessionById(ctx context.Context, user string) error
 	ConfirmLoginSession(ctx context.Context, id string, authTime time.Time, subject string, remember bool) error
 
 	CreateLoginRequest(ctx context.Context, req *LoginRequest) error

--- a/consent/manager_test_helpers.go
+++ b/consent/manager_test_helpers.go
@@ -519,7 +519,7 @@ func ManagerTests(m Manager, clientManager client.Manager, fositeManager x.Fosit
 				},
 			} {
 				t.Run(fmt.Sprintf("case=%d/subject=%s", i, tc.subject), func(t *testing.T) {
-					require.NoError(t, m.RevokeSubjectLoginSession(context.Background(), tc.subject))
+					require.NoError(t, m.RevokeSubjectLoginSessionBySubject(context.Background(), tc.subject))
 
 					for _, id := range tc.ids {
 						t.Run(fmt.Sprintf("id=%s", id), func(t *testing.T) {

--- a/internal/httpclient-next/api/openapi.yaml
+++ b/internal/httpclient-next/api/openapi.yaml
@@ -1318,10 +1318,17 @@ paths:
       - explode: true
         in: query
         name: subject
-        required: true
+        required: false
         schema:
           type: string
         style: form
+     - explode: true
+       in: query
+       name: sessionId
+       required: false
+       schema:
+         type: string
+       style: form
       responses:
         "204":
           description: |-

--- a/persistence/sql/persister_consent.go
+++ b/persistence/sql/persister_consent.go
@@ -84,7 +84,16 @@ func (p *Persister) revokeConsentSession(whereStmt string, whereArgs ...interfac
 	}
 }
 
-func (p *Persister) RevokeSubjectLoginSession(ctx context.Context, subject string) error {
+func (p *Persister) RevokeSubjectLoginSessionById(ctx context.Context, id string) error {
+	if err := p.Connection(ctx).RawQuery("DELETE FROM hydra_oauth2_authentication_session WHERE id = ?", id).Exec(); errors.Is(err, sql.ErrNoRows) {
+		return errorsx.WithStack(x.ErrNotFound)
+	} else if err != nil {
+		return sqlcon.HandleError(err)
+	}
+	return nil
+}
+
+func (p *Persister) RevokeSubjectLoginSessionBySubject(ctx context.Context, subject string) error {
 	if err := p.Connection(ctx).RawQuery("DELETE FROM hydra_oauth2_authentication_session WHERE subject = ?", subject).Exec(); errors.Is(err, sql.ErrNoRows) {
 		return errorsx.WithStack(x.ErrNotFound)
 	} else if err != nil {


### PR DESCRIPTION
**Use case:**

1. User logs in with subject "A"
2. User somehow manages to login with subject "B" (for example removing account A and creating account B)
3. Now user is blocked by "Field 'subject' does not match subject from previous authentication." error on accepting login

This feature allows to remove login session on step (3) which will allow user to start auth from scratch.

## Related issue(s)

A simpler version of https://github.com/ory/hydra/pull/2876

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments
