### PR TITLE
Correct the tracing service name environment variable in `quickstart-tracing.yml`.

### DIFF
--- a/quickstart-tracing.yml
+++ b/quickstart-tracing.yml
@@ -20,6 +20,7 @@ services:
       # - zipkin
       # - datadog
     environment:
+      # - TRACING_SERVICE_NAME="Ory Hydra"
       - TRACING_PROVIDER=jaeger
       # - TRACING_PROVIDER=zipkin
       # - TRACING_PROVIDER=datadog
@@ -42,7 +43,6 @@ services:
       # - ELASTIC_APM_ENVIRONMENT="devel"
       ### Opentelemetry ###
       ### See env vars here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md ###
-      # - OTEL_SERVICE_NAME="Ory Hydra"
   jaeger:
     image: jaegertracing/all-in-one:1.19.2
     ports:


### PR DESCRIPTION
Correct the tracing service name environment variable in `quickstart-tracing.yml`.

While I believe this used to be specific to OTEL, it now appears to be
configurable "globally", according to `spec/config.json`.

## Related issue(s)
N/A - documentation update.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
