### PR TITLE
fix: handle server error when refresh token requests come same time

### DIFF
--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -20,9 +20,10 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/ory/fosite"
-	"github.com/ory/hydra/oauth2"
 	"github.com/ory/x/sqlcon"
 	"github.com/ory/x/stringsx"
+
+	"github.com/ory/hydra/oauth2"
 )
 
 var _ oauth2.AssertionJWTReader = &Persister{}
@@ -252,10 +253,20 @@ func (p *Persister) deleteSessionBySignature(ctx context.Context, signature stri
 	signature = p.hashSignature(signature, table)
 
 	/* #nosec G201 table is static */
-	return sqlcon.HandleError(
-		p.Connection(ctx).
-			RawQuery(fmt.Sprintf("DELETE FROM %s WHERE signature=?", OAuth2RequestSQL{Table: table}.TableName()), signature).
-			Exec())
+	if err := p.Connection(ctx).
+		RawQuery(fmt.Sprintf("DELETE FROM %s WHERE signature=?", OAuth2RequestSQL{Table: table}.TableName()), signature).
+		Exec(); errors.Is(err, sql.ErrNoRows) {
+		return errorsx.WithStack(fosite.ErrNotFound)
+	} else if err := sqlcon.HandleError(err); err != nil {
+		if errors.Is(err, sqlcon.ErrConcurrentUpdate) {
+			return errors.Wrap(fosite.ErrSerializationFailure, err.Error())
+		} else if strings.Contains(err.Error(), "Error 1213") { // InnoDB Deadlock?
+			return errors.Wrap(fosite.ErrSerializationFailure, err.Error())
+		}
+		return err
+	}
+	return nil
+
 }
 
 func (p *Persister) deleteSessionByRequestID(ctx context.Context, id string, table tableName) error {


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

Handle server error when refresh token requests come same time.
Hydra usually handles this as `ErrInactiveToken`. But sometimes, when requests come very bad timing, this will be `ErrServerError` with very poor error log (`{msg: 'An error occurred',  error: {debug: 'server_error', status: 'Internal Server Error'}}` ).

As stack trace log (debug mode), it turns out that `Persister.deleteSessionBySignature` returns `sqlconn` 's error without any handling.  If it's `forsite` 's error, fosite will handle error as `ErrInvalidRequest` at [RefreshTokenGrantHandler.handleRefreshTokenEndpointStorageError](https://github.com/ory/fosite/blob/16614014a42b3905d065188c8f1f45433c4353f9/handler/oauth2/flow_refresh.go#L235-L239).

<details>
  <summary>StackTrace(debug mode)</summary>

```
github.com/ory/x/sqlcon.handlePostgres
	/go/pkg/mod/github.com/ory/x@v0.0.368/sqlcon/error.go:54
github.com/ory/x/sqlcon.HandleError
	/go/pkg/mod/github.com/ory/x@v0.0.368/sqlcon/error.go:75
github.com/ory/hydra/persistence/sql.(*Persister).deleteSessionBySignature
	/project/persistence/sql/persister_oauth2.go:255
github.com/ory/hydra/persistence/sql.(*Persister).DeleteRefreshTokenSession
	/project/persistence/sql/persister_oauth2.go:330
github.com/ory/fosite/handler/oauth2.(*RefreshTokenGrantHandler).handleRefreshTokenReuse
	/go/pkg/mod/github.com/ory/fosite@v0.42.2/handler/oauth2/flow_refresh.go:206
github.com/ory/fosite/handler/oauth2.(*RefreshTokenGrantHandler).HandleTokenEndpointRequest
	/go/pkg/mod/github.com/ory/fosite@v0.42.2/handler/oauth2/flow_refresh.go:69
github.com/ory/fosite.(*Fosite).NewAccessRequest
	/go/pkg/mod/github.com/ory/fosite@v0.42.2/access_request_handler.go:108
github.com/ory/hydra/oauth2.(*Handler).TokenHandler
	/project/oauth2/handler.go:584
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/julienschmidt/httprouter.(*Router).Handler.func1
	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:275
github.com/julienschmidt/httprouter.(*Router).ServeHTTP
	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387
github.com/urfave/negroni.Wrap.func1
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:46
github.com/urfave/negroni.HandlerFunc.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:29
github.com/urfave/negroni.middleware.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/ory/hydra/x.RejectInsecureRequests.func1
	/project/x/tls_termination.go:90
github.com/urfave/negroni.HandlerFunc.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:29
github.com/urfave/negroni.middleware.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/metricsx.(*Service).ServeHTTP
	/go/pkg/mod/github.com/ory/x@v0.0.368/metricsx/middleware.go:275
github.com/urfave/negroni.middleware.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerResponseSize.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:198
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:101
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:68
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:76
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerRequestSize.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:165
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2047
github.com/ory/x/prometheusx.Metrics.instrumentHandlerStatusBucket.func1
	/go/pkg/mod/github.com/ory/x@v0.0.368/prometheusx/metrics.go:108
```

</details>

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
