### PR TITLE
fix: allowed_top_level_claims default to nil

### DIFF
--- a/oauth2/session.go
+++ b/oauth2/session.go
@@ -78,7 +78,9 @@ func (s *Session) GetJWTClaims() jwt.JWTClaimsContainer {
 
 	//setting every allowed claim top level in jwt with respective value
 	for _, allowedClaim := range allowedClaimsFromConfigWithoutReserved {
-		topLevelExtraWithMirrorExt[allowedClaim] = s.Extra[allowedClaim]
+		if cl, ok := s.Extra[allowedClaim]; ok {
+			topLevelExtraWithMirrorExt[allowedClaim] = cl
+		}
 	}
 
 	//for every other claim that was already reserved and for mirroring, add original extra under "ext"


### PR DESCRIPTION
allowed_top_level_claims were set to nil if claim was not present

## Related issue(s)

When allowed_top_level_claims are configured, they are always present in the token, with value null if they were never set.

This PR  fixes this and adds a regression test


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).


