### PR TITLE
feat: add /.well-known/jwks.json caching for HSM key manager

### DIFF
--- a/driver/registry_sql.go
+++ b/driver/registry_sql.go
@@ -138,7 +138,7 @@ func (m *RegistrySQL) Init(
 		}
 
 		if m.Config().HSMEnabled() {
-			hardwareKeyManager := hsm.NewKeyManager(m.HSMContext(), m.Config())
+			hardwareKeyManager := hsm.NewKeyManager(m.HSMContext(), m.Config(), m.Logger())
 			m.defaultKeyManager = jwk.NewManagerStrategy(hardwareKeyManager, m.persister)
 		} else {
 			m.defaultKeyManager = m.persister
@@ -175,7 +175,7 @@ func (m *RegistrySQL) Init(
 		}
 
 		if m.Config().HSMEnabled() {
-			hardwareKeyManager := hsm.NewKeyManager(m.HSMContext(), m.Config())
+			hardwareKeyManager := hsm.NewKeyManager(m.HSMContext(), m.Config(), m.Logger())
 			m.defaultKeyManager = jwk.NewManagerStrategy(hardwareKeyManager, m.persister)
 		} else {
 			m.defaultKeyManager = m.persister

--- a/hsm/manager_nohsm.go
+++ b/hsm/manager_nohsm.go
@@ -37,7 +37,7 @@ func NewContext(c *config.DefaultProvider, l *logrusx.Logger) Context {
 	return nil
 }
 
-func NewKeyManager(hsm Context, config *config.DefaultProvider) *KeyManager {
+func NewKeyManager(hsm Context, config *config.DefaultProvider, l *logrusx.Logger) *KeyManager {
 	return nil
 }
 
@@ -50,6 +50,10 @@ func (m *KeyManager) GetKey(_ context.Context, set, kid string) (*jose.JSONWebKe
 }
 
 func (m *KeyManager) GetKeySet(_ context.Context, set string) (*jose.JSONWebKeySet, error) {
+	return nil, errors.WithStack(ErrOpSysNotSupported)
+}
+
+func (m *KeyManager) GetWellKnownKeys(_ context.Context) (*jose.JSONWebKeySet, error) {
 	return nil, errors.WithStack(ErrOpSysNotSupported)
 }
 

--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -83,11 +83,7 @@ func TestHandlerWellKnown(t *testing.T) {
 		var known jose.JSONWebKeySet
 		err = json.NewDecoder(res.Body).Decode(&known)
 		require.NoError(t, err, "problem in decoding response")
-		if conf.HSMEnabled() {
-			require.Len(t, known.Keys, 2)
-		} else {
-			require.Len(t, known.Keys, 1)
-		}
+		require.Len(t, known.Keys, 1)
 
 		knownKey := known.Key("test-id-2")[0]
 		require.NotNil(t, knownKey, "Could not find key public")

--- a/jwk/manager.go
+++ b/jwk/manager.go
@@ -42,6 +42,8 @@ type (
 
 		GetKeySet(ctx context.Context, set string) (*jose.JSONWebKeySet, error)
 
+		GetWellKnownKeys(ctx context.Context) (*jose.JSONWebKeySet, error)
+
 		DeleteKey(ctx context.Context, set, kid string) error
 
 		DeleteKeySet(ctx context.Context, set string) error

--- a/jwk/manager_mock_test.go
+++ b/jwk/manager_mock_test.go
@@ -133,10 +133,25 @@ func (m *MockManager) GetKeySet(ctx context.Context, set string) (*jose.JSONWebK
 	return ret0, ret1
 }
 
+// GetWellKnownKeys mocks base method.
+func (m *MockManager) GetWellKnownKeys(ctx context.Context) (*jose.JSONWebKeySet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWellKnownKeys", ctx)
+	ret0, _ := ret[0].(*jose.JSONWebKeySet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // GetKeySet indicates an expected call of GetKeySet.
 func (mr *MockManagerMockRecorder) GetKeySet(ctx, set interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeySet", reflect.TypeOf((*MockManager)(nil).GetKeySet), ctx, set)
+}
+
+// GetWellKnownKeys indicates an expected call of GetWellKnownKeys.
+func (mr *MockManagerMockRecorder) GetWellKnownKeys(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWellKnownKeys", reflect.TypeOf((*MockManager)(nil).GetWellKnownKeys), ctx)
 }
 
 // UpdateKey mocks base method.

--- a/jwk/manager_strategy.go
+++ b/jwk/manager_strategy.go
@@ -43,7 +43,7 @@ func (m ManagerStrategy) GenerateAndPersistKeySet(ctx context.Context, set, kid,
 }
 
 func (m ManagerStrategy) AddKey(ctx context.Context, set string, key *jose.JSONWebKey) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.AddKey")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -54,7 +54,7 @@ func (m ManagerStrategy) AddKey(ctx context.Context, set string, key *jose.JSONW
 }
 
 func (m ManagerStrategy) AddKeySet(ctx context.Context, set string, keys *jose.JSONWebKeySet) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.AddKeySet")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -65,7 +65,7 @@ func (m ManagerStrategy) AddKeySet(ctx context.Context, set string, keys *jose.J
 }
 
 func (m ManagerStrategy) UpdateKey(ctx context.Context, set string, key *jose.JSONWebKey) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.UpdateKey")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -76,7 +76,7 @@ func (m ManagerStrategy) UpdateKey(ctx context.Context, set string, key *jose.JS
 }
 
 func (m ManagerStrategy) UpdateKeySet(ctx context.Context, set string, keys *jose.JSONWebKeySet) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.UpdateKeySet")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -87,7 +87,7 @@ func (m ManagerStrategy) UpdateKeySet(ctx context.Context, set string, keys *jos
 }
 
 func (m ManagerStrategy) GetKey(ctx context.Context, set, kid string) (*jose.JSONWebKeySet, error) {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GetKey")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -106,7 +106,7 @@ func (m ManagerStrategy) GetKey(ctx context.Context, set, kid string) (*jose.JSO
 }
 
 func (m ManagerStrategy) GetKeySet(ctx context.Context, set string) (*jose.JSONWebKeySet, error) {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GetKeySet")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -123,8 +123,24 @@ func (m ManagerStrategy) GetKeySet(ctx context.Context, set string) (*jose.JSONW
 	}
 }
 
+func (m ManagerStrategy) GetWellKnownKeys(ctx context.Context) (*jose.JSONWebKeySet, error) {
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GetWellKnownKeys")
+	defer span.End()
+	attrs := map[string]string{}
+	span.SetAttributes(otelx.StringAttrs(attrs)...)
+
+	keySet, err := m.hardwareKeyManager.GetWellKnownKeys(ctx)
+	if err != nil && !errors.Is(err, x.ErrNotFound) {
+		return nil, err
+	} else if keySet != nil {
+		return keySet, nil
+	} else {
+		return m.softwareKeyManager.GetWellKnownKeys(ctx)
+	}
+}
+
 func (m ManagerStrategy) DeleteKey(ctx context.Context, set, kid string) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.DeleteKey")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -143,7 +159,7 @@ func (m ManagerStrategy) DeleteKey(ctx context.Context, set, kid string) error {
 }
 
 func (m ManagerStrategy) DeleteKeySet(ctx context.Context, set string) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.GenerateAndPersistKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "jwk.DeleteKeySet")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,


### PR DESCRIPTION
This PR adds caching for well known keys when using HSM key manager. Operations per sec on HSM are limited and caching well known keys would make sense. 
Also if I understand https://github.com/ThalesIgnite/crypto11/blob/master/crypto11.go correctly, then crypto.Signer is thread-safe and hsm.GetKey/hsm.GetKeySet could be cached also, but I will create another PR for this.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
