### PR TITLE
fix: scope type should be string instead of int

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -824,7 +824,7 @@ type oAuth2TokenExchange struct {
 	ExpiresIn int `json:"expires_in"`
 
 	// The scope of the access token
-	Scope int `json:"scope"`
+	Scope string `json:"scope"`
 
 	// To retrieve a refresh token request the id_token scope.
 	IDToken int `json:"id_token"`


### PR DESCRIPTION
## Problem description

Since the v2.0.1 update, the `oauth2_token_response` model has been renamed and updated to `o_auth2_token_exchange`. Along with that, an issue occurred where the `scope` field of the token response was expected to be of type `int` (for some reason) instead of `string` as it should be, based on [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.3) and [previous versions of hydra SDK](https://github.com/ory/sdk/tree/97372e5028598744784ed126129c16a012cac6d7).

## Root of the problem

As figured out by @aeneasr and @jonas-jonas in https://github.com/ory/sdk/pull/223, this problem seems to be caused by [handler.go#L827](https://github.com/ory/hydra/blob/925013e39508c22d1038560ef552a0764f2b0177/oauth2/handler.go#L827). As mentioned earlier, the scope field should be of type `string` instead of `int`, as seen in the proposed change of this PR.

## Examples of the problem

These examples show how this change affected the generated python and go clients, but the same behaviour can be found in the rest of the clients. I compare the previous version 1.11.0, which worked with no issues, to the latest version 2.0.1, which cannot complete the token exchange flow successfully.

### Python Client

Before ([oauth2_token_response.py#L88](https://github.com/ory/sdk/blob/97372e5028598744784ed126129c16a012cac6d7/clients/hydra/python/ory_hydra_client/model/oauth2_token_response.py#L88))

```python
return {
    'access_token': (str,),  # noqa: E501
    'expires_in': (int,),  # noqa: E501
    'id_token': (int,),  # noqa: E501
    'refresh_token': (str,),  # noqa: E501
--> 'scope': (str,),  # noqa: E501
    'token_type': (str,),  # noqa: E501
}
```

After ([o_auth2_token_exchange.py#L89](https://github.com/ory/sdk/blob/master/clients/hydra/python/ory_hydra_client/model/o_auth2_token_exchange.py#L89))

```python
return {
    'access_token': (str,),  # noqa: E501
    'expires_in': (int,),  # noqa: E501
    'id_token': (int,),  # noqa: E501
    'refresh_token': (str,),  # noqa: E501
--> 'scope': (int,),  # noqa: E501
    'token_type': (str,),  # noqa: E501
}
```

### Go Client

Before ([model_oauth2_token_response.go#L23](https://github.com/ory/sdk/blob/97372e5028598744784ed126129c16a012cac6d7/clients/hydra/go/model_oauth2_token_response.go#L23))

```go
type Oauth2TokenResponse struct {
	AccessToken *string `json:"access_token,omitempty"`
	ExpiresIn *int64 `json:"expires_in,omitempty"`
	IdToken *string `json:"id_token,omitempty"`
	RefreshToken *string `json:"refresh_token,omitempty"`
    --> Scope *string `json:"scope,omitempty"`
	TokenType *string `json:"token_type,omitempty"`
}
```

After ([model_o_auth2_token_exchange.go#L29](https://github.com/ory/sdk/blob/master/clients/hydra/go/model_o_auth2_token_exchange.go#L29))

```go
type OAuth2TokenResponse struct {
	AccessToken *string `json:"access_token,omitempty"`
	ExpiresIn *int64 `json:"expires_in,omitempty"`
	IdToken *int64 `json:"id_token,omitempty"`
	RefreshToken *string `json:"refresh_token,omitempty"`
    --> Scope *int64 `json:"scope,omitempty"`
	TokenType *string `json:"token_type,omitempty"`
}
```

## Related issue(s)
This PR came out from https://github.com/ory/sdk/issues/220 and https://github.com/ory/sdk/pull/223.

## Importance of the solution
In my opinion, the proposed solution is of high importance. Right now, with the current version of the generated clients, the token change flow, which is the core function of this library, is not working. Hopefully, the suggested update is going to solve this type mismatch and bring the token flows back to normal.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
