### PR TITLE
feat: add config flag to allow specifying clientId on client creation

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
-	"github.com/ory/hydra/driver/config"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/ory/hydra/driver/config"
 
 	"github.com/ory/x/pagination/tokenpagination"
 

--- a/client/handler_test.go
+++ b/client/handler_test.go
@@ -55,7 +55,8 @@ func getClientID(body string) string {
 func TestHandler(t *testing.T) {
 	ctx := context.Background()
 	reg := internal.NewMockedRegistry(t, &contextx.Default{})
-	h := client.NewHandler(reg)
+	conf := internal.NewConfigurationWithDefaults()
+	h := client.NewHandler(reg, conf)
 	reg.WithContextualizer(&contextx.TestContextualizer{})
 
 	t.Run("create client registration tokens", func(t *testing.T) {

--- a/client/sdk_test.go
+++ b/client/sdk_test.go
@@ -74,7 +74,7 @@ func TestClientSDK(t *testing.T) {
 
 	routerAdmin := x.NewRouterAdmin(conf.AdminURL)
 	routerPublic := x.NewRouterPublic()
-	handler := client.NewHandler(r)
+	handler := client.NewHandler(r, conf)
 	handler.SetRoutes(routerAdmin, routerPublic)
 	server := httptest.NewServer(routerAdmin)
 	conf.MustSet(ctx, config.KeyAdminURL, server.URL)

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	KeyRoot                                      = ""
+	KeyAllowSpecifyingChosenClientId             = "allow_specifying_client_id"
 	HSMEnabled                                   = "hsm.enabled"
 	HSMLibraryPath                               = "hsm.library"
 	HSMPin                                       = "hsm.pin"
@@ -268,6 +269,10 @@ func (p *DefaultProvider) EncryptSessionData(ctx context.Context) bool {
 
 func (p *DefaultProvider) ExcludeNotBeforeClaim(ctx context.Context) bool {
 	return p.getProvider(ctx).BoolF(KeyExcludeNotBeforeClaim, false)
+}
+
+func (p *DefaultProvider) AllowSpecifyingClientId(ctx context.Context) bool {
+	return p.getProvider(ctx).BoolF(KeyAllowSpecifyingChosenClientId, false)
 }
 
 func (p *DefaultProvider) CookieSecure(ctx context.Context) bool {

--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -231,7 +231,7 @@ func (m *RegistryBase) ClientHasher() fosite.Hasher {
 
 func (m *RegistryBase) ClientHandler() *client.Handler {
 	if m.ch == nil {
-		m.ch = client.NewHandler(m.r)
+		m.ch = client.NewHandler(m.r, m.Config())
 	}
 	return m.ch
 }


### PR DESCRIPTION
Add a configuration flag to override the new change in Hydra v2.0, which made it no longer possible to choose the OAuth 2.0 Client ID. 
With this change, we will still enforce that the Client ID has to be a UUID, but it gives more flexibility to the users of Hydra.
A lot of the arguments for allowing such a flag is already detailed and discussed in the related issue.

## Related issue(s)
https://github.com/ory/hydra/issues/2911

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).