### PR TITLE
chore: persistent dependency installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ export GO111MODULE := on
 export PATH := .bin:${PATH}
 export PWD := $(shell pwd)
 
+GOLANGCI_LINT_VERSION = 1.46.2
+
 GO_DEPENDENCIES = github.com/ory/go-acc \
 				  github.com/golang/mock/mockgen \
 				  github.com/go-swagger/go-swagger/cmd/swagger \
@@ -15,8 +17,9 @@ define make-go-dependency
 		GOBIN=$(PWD)/.bin/ go install $1
 endef
 
-.bin/golangci-lint: Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v1.46.2
+.bin/golangci-lint-$(GOLANGCI_LINT_VERSION):
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v$(GOLANGCI_LINT_VERSION)
+	mv .bin/golangci-lint .bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 $(foreach dep, $(GO_DEPENDENCIES), $(eval $(call make-go-dependency, $(dep))))
 
@@ -45,8 +48,8 @@ docs/cli: .bin/clidoc
 	touch .bin/ory
 
 .PHONY: lint
-lint: .bin/golangci-lint
-	golangci-lint run -v ./...
+lint: .bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
+	.bin/golangci-lint-$(GOLANGCI_LINT_VERSION) run -v ./...
 
 # Runs full test suite including tests where databases are enabled
 .PHONY: test


### PR DESCRIPTION
A problem with the way the Makefile currenly installs external dependencies is that each time any change happens in the Makefile, it re-installs all dependencies. This gets annoying in repos that see a lot of changes to their Makefiles. This PR installs dependencies only when really needed, i.e. when they aren't installed or when their required version changes.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
