### PR TITLE
fix: no longer use separate `public` and `private` keys in HSM key manager

### DIFF
--- a/hsm/manager_hsm.go
+++ b/hsm/manager_hsm.go
@@ -187,7 +187,7 @@ func (m *KeyManager) GetKeySet(ctx context.Context, set string) (*jose.JSONWebKe
 }
 
 func (m *KeyManager) DeleteKey(ctx context.Context, set, kid string) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "hsm.GetKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "hsm.DeleteKey")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -217,7 +217,7 @@ func (m *KeyManager) DeleteKey(ctx context.Context, set, kid string) error {
 }
 
 func (m *KeyManager) DeleteKeySet(ctx context.Context, set string) error {
-	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "hsm.GetKeySet")
+	ctx, span := otel.GetTracerProvider().Tracer(tracingComponent).Start(ctx, "hsm.DeleteKeySet")
 	defer span.End()
 	attrs := map[string]string{
 		"set": set,
@@ -357,14 +357,6 @@ func createKeys(key crypto11.Signer, kid, alg, use string) []jose.JSONWebKey {
 		Algorithm:                   alg,
 		Use:                         use,
 		Key:                         cryptosigner.Opaque(key),
-		KeyID:                       kid,
-		Certificates:                []*x509.Certificate{},
-		CertificateThumbprintSHA1:   []uint8{},
-		CertificateThumbprintSHA256: []uint8{},
-	}, {
-		Algorithm:                   alg,
-		Use:                         use,
-		Key:                         key.Public(),
 		KeyID:                       kid,
 		Certificates:                []*x509.Certificate{},
 		CertificateThumbprintSHA1:   []uint8{},

--- a/hsm/manager_hsm_test.go
+++ b/hsm/manager_hsm_test.go
@@ -883,13 +883,5 @@ func createJSONWebKeys(keyPair *MockSignerDecrypter, kid string, alg string, use
 		Certificates:                []*x509.Certificate{},
 		CertificateThumbprintSHA1:   []uint8{},
 		CertificateThumbprintSHA256: []uint8{},
-	}, {
-		Algorithm:                   alg,
-		Use:                         use,
-		Key:                         keyPair.Public(),
-		KeyID:                       kid,
-		Certificates:                []*x509.Certificate{},
-		CertificateThumbprintSHA1:   []uint8{},
-		CertificateThumbprintSHA256: []uint8{},
 	}}
 }

--- a/jwk/handler_test.go
+++ b/jwk/handler_test.go
@@ -83,11 +83,7 @@ func TestHandlerWellKnown(t *testing.T) {
 		var known jose.JSONWebKeySet
 		err = json.NewDecoder(res.Body).Decode(&known)
 		require.NoError(t, err, "problem in decoding response")
-		if conf.HSMEnabled() {
-			require.Len(t, known.Keys, 2)
-		} else {
-			require.Len(t, known.Keys, 1)
-		}
+		require.Len(t, known.Keys, 1)
 
 		knownKey := known.Key("test-id-2")[0]
 		require.NotNil(t, knownKey, "Could not find key public")

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -119,9 +119,11 @@ func ExcludePrivateKeys(set *jose.JSONWebKeySet) *jose.JSONWebKeySet {
 
 func ExcludeOpaquePrivateKeys(set *jose.JSONWebKeySet) *jose.JSONWebKeySet {
 	keys := new(jose.JSONWebKeySet)
-	for _, k := range set.Keys {
-		if _, opaque := k.Key.(jose.OpaqueSigner); !opaque {
-			keys.Keys = append(keys.Keys, k)
+	for i := range set.Keys {
+		if _, opaque := set.Keys[i].Key.(jose.OpaqueSigner); opaque {
+			keys.Keys = append(keys.Keys, josex.ToPublicKey(&set.Keys[i]))
+		} else {
+			keys.Keys = append(keys.Keys, set.Keys[i])
 		}
 	}
 	return keys

--- a/jwk/helper_test.go
+++ b/jwk/helper_test.go
@@ -189,8 +189,13 @@ func TestExcludeOpaquePrivateKeys(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, opaqueKeys.Keys, 1)
 	opaqueKeys.Keys[0].Key = cryptosigner.Opaque(opaqueKeys.Keys[0].Key.(*rsa.PrivateKey))
+
 	keys := jwk.ExcludeOpaquePrivateKeys(opaqueKeys)
-	require.Len(t, keys.Keys, 0)
+
+	require.Len(t, keys.Keys, 1)
+	k := keys.Keys[0]
+	_, isPublic := k.Key.(*rsa.PublicKey)
+	assert.True(t, isPublic)
 }
 
 func TestGetOrGenerateKeys(t *testing.T) {


### PR DESCRIPTION
Similar refactoring for HSM key manager https://github.com/ory/hydra/commit/5e2ea0b6c65441983a7e85f9e8434f6068f4fcba otherwise /.well-known/jwks.json will show double public keys, when HSM enabled.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
