### PR TITLE
Fix fosite refresh scope narrowing

### DIFF
--- a/cypress/integration/oauth2/refresh_token.js
+++ b/cypress/integration/oauth2/refresh_token.js
@@ -89,4 +89,48 @@ describe("The OAuth 2.0 Refresh Token Grant", function () {
       })
     })
   })
+
+  it("should narrow Refresh Token scopes correctly", function () {
+    const referrer = `${Cypress.env("client_url")}/empty`
+    cy.visit(referrer, {
+      failOnStatusCode: false,
+    })
+
+    createClient({
+      scope: "offline_access openid foo bar baz",
+      redirect_uris: [referrer],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }).then((client) => {
+      cy.authCodeFlowBrowser(client, {
+        consent: { scope: ["offline_access openid foo bar baz"] },
+        createClient: false,
+      }).then((originalResponse) => {
+        expect(originalResponse.status).to.eq(200)
+        expect(originalResponse.body.refresh_token).to.not.be.empty
+        expect(originalResponse.body.scope).to.eq("offline_access openid foo bar baz")
+
+        const originalToken = originalResponse.body.refresh_token
+
+        cy.refreshTokenBrowserScope(client, originalToken, "offline_access openid foo").then(
+          (refreshedResponse) => {
+            expect(refreshedResponse.status).to.eq(200)
+            expect(refreshedResponse.body.refresh_token).to.not.be.empty
+            expect(refreshedResponse.body.scope).to.eq("offline_access openid foo")
+
+            const refreshedToken = refreshedResponse.body.refresh_token
+
+            cy.refreshTokenBrowserScope(client, refreshedToken, "offline_access openid foo bar baz").then(
+              (finalRefreshedResponse) => {
+                expect(finalRefreshedResponse.status).to.eq(200)
+                expect(finalRefreshedResponse.body.refresh_token).to.not.be.empty
+                expect(finalRefreshedResponse.body.scope).to.eq("offline_access openid foo bar baz")
+              },
+            )
+          },
+        )
+      })
+    })
+  })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -216,3 +216,18 @@ Cypress.Commands.add("refreshTokenBrowser", (client, token) =>
     failOnStatusCode: false,
   }),
 )
+
+Cypress.Commands.add("refreshTokenBrowserScope", (client, token, scope) =>
+  cy.request({
+    url: `${Cypress.env("public_url")}/oauth2/token`,
+    method: "POST",
+    form: true,
+    body: {
+      grant_type: "refresh_token",
+      client_id: client.client_id,
+      refresh_token: token,
+      scope: scope,
+    },
+    failOnStatusCode: false,
+  }),
+)

--- a/go.mod
+++ b/go.mod
@@ -271,3 +271,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect
 )
+
+replace github.com/ory/fosite => github.com/james-d-elliott/fosite v0.42.2-0.20230102000600-1b13725b7055

--- a/go.sum
+++ b/go.sum
@@ -640,6 +640,8 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/james-d-elliott/fosite v0.42.2-0.20230102000600-1b13725b7055 h1:O7o+kTtgNjE1ITdljrxhJIiq6EV3Mylr9aGKzWbtYIQ=
+github.com/james-d-elliott/fosite v0.42.2-0.20230102000600-1b13725b7055/go.mod h1:o/G4kAeNn65l6MCod2+KmFfU6JQBSojS7eXys6lKGzM=
 github.com/jandelgado/gcov2lcov v1.0.4/go.mod h1:NnSxK6TMlg1oGDBfGelGbjgorT5/L3cchlbtgFYZSss=
 github.com/jandelgado/gcov2lcov v1.0.5 h1:rkBt40h0CVK4oCb8Dps950gvfd1rYvQ8+cWa346lVU0=
 github.com/jandelgado/gcov2lcov v1.0.5/go.mod h1:NnSxK6TMlg1oGDBfGelGbjgorT5/L3cchlbtgFYZSss=
@@ -856,8 +858,6 @@ github.com/ory/analytics-go/v4 v4.0.3 h1:2zNBQLlm3UiD8U7DdUGLLUBm62ZA5GtbEJ3S5U+
 github.com/ory/analytics-go/v4 v4.0.3/go.mod h1:A3Chm/3TmM8jw4nqRss+gFhAYHRI5j/HFYH3C1FRahU=
 github.com/ory/dockertest/v3 v3.9.1 h1:v4dkG+dlu76goxMiTT2j8zV7s4oPPEppKT8K8p2f1kY=
 github.com/ory/dockertest/v3 v3.9.1/go.mod h1:42Ir9hmvaAPm0Mgibk6mBPi7SFvTXxEcnztDYOJ//uM=
-github.com/ory/fosite v0.44.0 h1:Z3UjyO11/wlIoa3BotOqcTkfm7kUNA8F7dd8mOMfx0o=
-github.com/ory/fosite v0.44.0/go.mod h1:o/G4kAeNn65l6MCod2+KmFfU6JQBSojS7eXys6lKGzM=
 github.com/ory/go-acc v0.2.6/go.mod h1:4Kb/UnPcT8qRAk3IAxta+hvVapdxTLWtrr7bFLlEgpw=
 github.com/ory/go-acc v0.2.8 h1:rOHHAPQjf0u7eHFGWpiXK+gIu/e0GRSJNr9pDukdNC4=
 github.com/ory/go-acc v0.2.8/go.mod h1:iCRZUdGb/7nqvSn8xWZkhfVrtXRZ9Wru2E5rabCjFPI=


### PR DESCRIPTION
This is a proof of conformance e2e test for the related issues.

## Related issue(s)

https://github.com/ory/fosite/issues/696
https://github.com/ory/fosite/pull/718

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

This is my first time working with cypress, and there may be a better way to handle the `refreshTokenBrowserScope` or I may have completely bungled it. The intent is for the flow to get an initial refresh token, narrow the scope, then broaden the scope again.
