### PR TITLE
fix: ENV based Open Tracing provider configuration support

### DIFF
--- a/spec/config.json
+++ b/spec/config.json
@@ -1166,6 +1166,29 @@
                   "server_url": "http://localhost:9411/api/v2/spans"
                 }
               ]
+            },
+            "otlp": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Configures the Open Telemetry tracing backend.",
+              "properties": {
+                "server_url": {
+                  "type": "string",
+                  "description": ""
+                },
+                "insecure": {
+                  "type": "boolean"
+                },
+                "sampling": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sampling_ratio": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

I've been trying to configure hydra for open telemetry with New Relic and am running into some issues.

I've identified one that this resolves. It's currently not possible to set the open telemetry server url (or any of the open telemetry tracing provider options from https://github.com/ory/x/blob/f6df4499d0545937d3de211c97116671f431d60f/otelx/config.go#L44) through environment variables because the configuration schema does not know about them (and the json schema is used to parse env vars).

Adding that config to the schema fixes the env var parsing. (However I'm still working on getting open tracing working overall for my use case)

I think this'll also update docs

I have not added tests, as I'm expecting the codebase is already exercising the env var parsing logic through the example jaeger config files, and I didn't see an equivalent for zipkin.