### PR TITLE
feat: add ability to revoke login sessions by SessionID

### DIFF
--- a/consent/handler.go
+++ b/consent/handler.go
@@ -230,7 +230,6 @@ type revokeOAuth2LoginSessions struct {
 	// The subject to revoke authentication sessions for.
 	//
 	// in: query
-	// required: true
 	Subject string `json:"subject"`
 
 	// OAuth 2.0 Subject

--- a/consent/handler.go
+++ b/consent/handler.go
@@ -149,6 +149,7 @@ type listOAuth2ConsentSessions struct {
 	// in: query
 	// required: true
 	Subject string `json:"subject"`
+
 	// The login session id to list the consent sessions for.
 	//
 	// in: query
@@ -231,15 +232,27 @@ type revokeOAuth2LoginSessions struct {
 	// in: query
 	// required: true
 	Subject string `json:"subject"`
+
+	// OAuth 2.0 Subject
+	//
+	// The subject to revoke authentication sessions for.
+	//
+	// in: query
+	SessionID string `json:"sid"`
 }
 
 // swagger:route DELETE /admin/oauth2/auth/sessions/login oAuth2 revokeOAuth2LoginSessions
 //
-// # Revokes All OAuth 2.0 Login Sessions of a Subject
+// # Revokes OAuth 2.0 Login Sessions by either a Subject or a SessionID
 //
-// This endpoint invalidates a subject's authentication session. After revoking the authentication session, the subject
-// has to re-authenticate at the Ory OAuth2 Provider. This endpoint does not invalidate any tokens and
-// does not work with OpenID Connect Front- or Back-channel logout.
+// This endpoint invalidates authentication sessions. After revoking the authentication session(s), the subject
+// has to re-authenticate at the Ory OAuth2 Provider. This endpoint does not invalidate any tokens.
+//
+// If you send the subject in a query param, all authentication sessions that belong to that subject are revoked.
+// No OpennID Connect Front- or Back-channel logout is performed in this case.
+//
+// Alternatively, you can send a SessionID via `sid` query param, in which case, only the session that is connected
+// to that SessionID is revoked. OpenID Connect Back-channel logout is performed in this case.
 //
 //	Consumes:
 //	- application/json
@@ -253,6 +266,17 @@ type revokeOAuth2LoginSessions struct {
 //	  204: emptyResponse
 //	  default: errorOAuth2
 func (h *Handler) revokeOAuth2LoginSessions(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	sid := r.URL.Query().Get("sid")
+	if sid != "" {
+		if err := h.r.ConsentStrategy().HandleHeadlessLogout(r.Context(), w, r, sid); err != nil {
+			h.r.Writer().WriteError(w, r, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	subject := r.URL.Query().Get("subject")
 	if subject == "" {
 		h.r.Writer().WriteError(w, r, errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(`Query parameter 'subject' is not defined but should have been.`)))

--- a/consent/handler.go
+++ b/consent/handler.go
@@ -266,6 +266,13 @@ type revokeOAuth2LoginSessions struct {
 //	  default: errorOAuth2
 func (h *Handler) revokeOAuth2LoginSessions(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	sid := r.URL.Query().Get("sid")
+	subject := r.URL.Query().Get("subject")
+
+	if sid == "" && subject == "" {
+		h.r.Writer().WriteError(w, r, errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(`Either 'subject' or 'sid' query parameters need to be defined.`)))
+		return
+	}
+
 	if sid != "" {
 		if err := h.r.ConsentStrategy().HandleHeadlessLogout(r.Context(), w, r, sid); err != nil {
 			h.r.Writer().WriteError(w, r, err)
@@ -273,12 +280,6 @@ func (h *Handler) revokeOAuth2LoginSessions(w http.ResponseWriter, r *http.Reque
 		}
 
 		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	subject := r.URL.Query().Get("subject")
-	if subject == "" {
-		h.r.Writer().WriteError(w, r, errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(`Query parameter 'subject' is not defined but should have been.`)))
 		return
 	}
 

--- a/consent/strategy.go
+++ b/consent/strategy.go
@@ -15,5 +15,6 @@ var _ Strategy = new(DefaultStrategy)
 type Strategy interface {
 	HandleOAuth2AuthorizationRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, req fosite.AuthorizeRequester) (*AcceptOAuth2ConsentRequest, error)
 	HandleOpenIDConnectLogout(ctx context.Context, w http.ResponseWriter, r *http.Request) (*LogoutResult, error)
+	HandleHeadlessLogout(ctx context.Context, w http.ResponseWriter, r *http.Request, sid string) error
 	ObfuscateSubjectIdentifier(ctx context.Context, cl fosite.Client, subject, forcedIdentifier string) (string, error)
 }

--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -1006,6 +1006,7 @@ func (s *DefaultStrategy) HandleHeadlessLogout(ctx context.Context, w http.Respo
 	s.r.AuditLogger().
 		WithRequest(r).
 		WithField("subject", loginSession.Subject).
+		WithField("sid", sid).
 		Info("User logout completed via headless flow!")
 
 	return nil

--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -899,6 +899,25 @@ func (s *DefaultStrategy) issueLogoutVerifier(ctx context.Context, w http.Respon
 	return nil, errorsx.WithStack(ErrAbortOAuth2Request)
 }
 
+func (s *DefaultStrategy) performBackChannelLogoutAndDeleteSession(ctx context.Context, r *http.Request, subject string, sessionID string) error {
+	if err := s.executeBackChannelLogout(r.Context(), r, subject, sessionID); err != nil {
+		return err
+	}
+
+	// We delete the session after back channel log out has worked as the session is otherwise removed
+	// from the store which will break the query for finding all the channels.
+	//
+	// executeBackChannelLogout only fails on system errors so not on URL errors, so this should be fine
+	// even if an upstream URL fails!
+	if err := s.r.ConsentManager().DeleteLoginSession(r.Context(), sessionID); errors.Is(err, sqlcon.ErrNoRows) {
+		// This is ok (session probably already revoked), do nothing!
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *DefaultStrategy) completeLogout(ctx context.Context, w http.ResponseWriter, r *http.Request) (*LogoutResult, error) {
 	verifier := r.URL.Query().Get("logout_verifier")
 
@@ -948,18 +967,7 @@ func (s *DefaultStrategy) completeLogout(ctx context.Context, w http.ResponseWri
 		return nil, err
 	}
 
-	if err := s.executeBackChannelLogout(r.Context(), r, lr.Subject, lr.SessionID); err != nil {
-		return nil, err
-	}
-
-	// We delete the session after back channel log out has worked as the session is otherwise removed
-	// from the store which will break the query for finding all the channels.
-	//
-	// executeBackChannelLogout only fails on system errors so not on URL errors, so this should be fine
-	// even if an upstream URL fails!
-	if err := s.r.ConsentManager().DeleteLoginSession(r.Context(), lr.SessionID); errors.Is(err, sqlcon.ErrNoRows) {
-		// This is ok (session probably already revoked), do nothing!
-	} else if err != nil {
+	if err := s.performBackChannelLogoutAndDeleteSession(r.Context(), r, lr.Subject, lr.SessionID); err != nil {
 		return nil, err
 	}
 
@@ -983,33 +991,22 @@ func (s *DefaultStrategy) HandleOpenIDConnectLogout(ctx context.Context, w http.
 	return s.completeLogout(ctx, w, r)
 }
 
-func (s *DefaultStrategy) HandleHeadlessLogout(ctx context.Context, w http.ResponseWriter, r *http.Request, sid string) error {
-	loginSession, lsErr := s.r.ConsentManager().GetRememberedLoginSession(ctx, sid)
+func (s *DefaultStrategy) HandleHeadlessLogout(ctx context.Context, w http.ResponseWriter, r *http.Request, sessionId string) error {
+	loginSession, lsErr := s.r.ConsentManager().GetRememberedLoginSession(ctx, sessionId)
 
 	// This is ok (session probably already revoked), do nothing!
 	if lsErr != nil {
 		return nil
 	}
 
-	if err := s.executeBackChannelLogout(r.Context(), r, loginSession.Subject, sid); err != nil {
-		return err
-	}
-
-	// We delete the session after back channel log out has worked as the session is otherwise removed
-	// from the store which will break the query for finding all the channels.
-	//
-	// executeBackChannelLogout only fails on system errors so not on URL errors, so this should be fine
-	// even if an upstream URL fails!
-	if err := s.r.ConsentManager().DeleteLoginSession(r.Context(), sid); errors.Is(err, sqlcon.ErrNoRows) {
-		// This is ok (session probably already revoked), do nothing!
-	} else if err != nil {
+	if err := s.performBackChannelLogoutAndDeleteSession(r.Context(), r, loginSession.Subject, sessionId); err != nil {
 		return err
 	}
 
 	s.r.AuditLogger().
 		WithRequest(r).
 		WithField("subject", loginSession.Subject).
-		Info("User logout completed!")
+		Info("User logout completed via headless flow!")
 
 	return nil
 }

--- a/consent/strategy_logout_test.go
+++ b/consent/strategy_logout_test.go
@@ -101,7 +101,7 @@ func TestLogoutFlows(t *testing.T) {
 
 	makeHeadlessLogoutRequest := func(t *testing.T, hc *http.Client, values url.Values) (body string, resp *http.Response) {
 		var err error
-		req, err := http.NewRequest(http.MethodDelete, adminTS.URL+"/oauth2/auth/sessions/login?"+values.Encode(), nil)
+		req, err := http.NewRequest(http.MethodDelete, adminTS.URL+"/admin/oauth2/auth/sessions/login?"+values.Encode(), nil)
 		require.NoError(t, err)
 
 		resp, err = hc.Do(req)

--- a/oauth2/oauth2_helper_test.go
+++ b/oauth2/oauth2_helper_test.go
@@ -49,6 +49,10 @@ func (c *consentMock) HandleOpenIDConnectLogout(ctx context.Context, w http.Resp
 	panic("not implemented")
 }
 
+func (c *consentMock) HandleHeadlessLogout(ctx context.Context, w http.ResponseWriter, r *http.Request, sid string) error {
+	panic("not implemented")
+}
+
 func (c *consentMock) ObfuscateSubjectIdentifier(ctx context.Context, cl fosite.Client, subject, forcedIdentifier string) (string, error) {
 	if c, ok := cl.(*client.Client); ok && c.SubjectType == "pairwise" {
 		panic("not implemented")


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
Added support to `revokeOAuth2LoginSessions` API to revoke a single session by a SessionID (`sid` claim in the id_token) and execute an OpenID Connect Back-channel logout.

## Related issue(s)
https://github.com/ory/hydra/issues/3448

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
