### PR TITLE
fix: support allowed_cors_origins with client_secret_post

### DIFF
--- a/x/oauth2cors/cors.go
+++ b/x/oauth2cors/cors.go
@@ -81,8 +81,18 @@ func Middleware(
 				return true
 			}
 
-			username, _, ok := r.BasicAuth()
-			if !ok || username == "" {
+			var clientID string
+
+			// if the client uses client_secret_post auth it will provide its client ID in form data
+			clientID = r.PostFormValue("client_id")
+
+			// if the client uses client_secret_basic auth the client ID will be the username component
+			if clientID == "" {
+				clientID, _, _ = r.BasicAuth()
+			}
+
+			// otherwise, this may be a bearer auth request, in which case we can introspect the token
+			if clientID == "" {
 				token := fosite.AccessTokenFromRequest(r)
 				if token == "" {
 					return false
@@ -94,10 +104,10 @@ func Middleware(
 					return false
 				}
 
-				username = ar.GetClient().GetID()
+				clientID = ar.GetClient().GetID()
 			}
 
-			cl, err := reg.ClientManager().GetConcreteClient(ctx, username)
+			cl, err := reg.ClientManager().GetConcreteClient(ctx, clientID)
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

https://github.com/ory/hydra/issues/3456

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
-  ~I have added or changed [the documentation](https://github.com/ory/docs).~

## Further Comments

This shouldn't impact security, as the existing mechanism for determining client id using `client_secret_basic` does not validate any authentication.
