### PR TITLE
fix: reduce SQL tracing noise

### DIFF
--- a/driver/registry_sql.go
+++ b/driver/registry_sql.go
@@ -72,6 +72,8 @@ func (m *RegistrySQL) Init(
 		if m.Tracer(ctx).IsLoaded() {
 			opts = []instrumentedsql.Opt{
 				instrumentedsql.WithTracer(otelsql.NewTracer()),
+				instrumentedsql.WithOmitArgs(), // don't risk leaking PII or secrets
+				instrumentedsql.WithOpsExcluded(instrumentedsql.OpSQLRowsNext),
 			}
 		}
 


### PR DESCRIPTION
This silences `sql-rows-next` spans in tracing, which don't have any real informational value but can make up a large portion of all spans.