### PR TITLE
feat: add --skip-consent flag to hydra cli

### DIFF
--- a/cmd/cmd_create_client.go
+++ b/cmd/cmd_create_client.go
@@ -38,6 +38,7 @@ const (
 	flagClientResponseType                      = "response-type"
 	flagClientScope                             = "scope"
 	flagClientSectorIdentifierURI               = "sector-identifier-uri"
+	flagClientSkipConsent                       = "skip-consent"
 	flagClientSubjectType                       = "subject-type"
 	flagClientTokenEndpointAuthMethod           = "token-endpoint-auth-method"
 	flagClientSecret                            = "secret"

--- a/cmd/cmd_helper_client.go
+++ b/cmd/cmd_helper_client.go
@@ -40,6 +40,7 @@ func clientFromFlags(cmd *cobra.Command) hydra.OAuth2Client {
 		RequestUris:                       flagx.MustGetStringSlice(cmd, flagClientRequestURI),
 		ResponseTypes:                     flagx.MustGetStringSlice(cmd, flagClientResponseType),
 		Scope:                             pointerx.String(strings.Join(flagx.MustGetStringSlice(cmd, flagClientScope), " ")),
+		SkipConsent:                       pointerx.Bool(flagx.MustGetBool(cmd, flagClientSkipConsent)),
 		SectorIdentifierUri:               pointerx.String(flagx.MustGetString(cmd, flagClientSectorIdentifierURI)),
 		SubjectType:                       pointerx.String(flagx.MustGetString(cmd, flagClientSubjectType)),
 		TokenEndpointAuthMethod:           pointerx.String(flagx.MustGetString(cmd, flagClientTokenEndpointAuthMethod)),
@@ -77,6 +78,7 @@ func registerClientFlags(flags *pflag.FlagSet) {
 	flags.String(flagClientSecret, "", "Provide the client's secret.")
 	flags.String(flagClientName, "", "The client's name.")
 	flags.StringSlice(flagClientPostLogoutCallback, []string{}, "List of allowed URLs to be redirected to after a logout.")
+	flags.Bool(flagClientSkipConsent, false, "Boolean flag specifying whether to skip the consent screen for this client. If omitted, the default value is false.")
 
 	// back-channel logout options
 	flags.Bool(flagClientBackChannelLogoutSessionRequired, false, "Boolean flag specifying whether the client requires that a sid (session ID) Claim be included in the Logout Token to identify the client session with the OP when the backchannel-logout-callback is used. If omitted, the default value is false.")


### PR DESCRIPTION
Skip consent feature was released in v2.1.0, but is missing as an available flag in the CLI.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

