### PR TITLE
fix: oauth2-client get client: fix example --json option

### DIFF
--- a/cmd/cmd_get_client.go
+++ b/cmd/cmd_get_client.go
@@ -20,7 +20,7 @@ func NewGetClientsCmd() *cobra.Command {
 		Long:    `This command gets all the details about an OAuth 2.0 Client. You can use this command in combination with jq.`,
 		Example: `To get the OAuth 2.0 Client's secret, run:
 
-	{{ .CommandPath }} <your-client-id> --json | jq -r '.client_secret'`,
+	{{ .CommandPath }} <your-client-id> --format json | jq -r '.client_secret'`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			m, _, err := cliclient.NewClient(cmd)
 			if err != nil {


### PR DESCRIPTION
The --json option does not exist in the current version of hydra. The --format json option had been added in place of the --json option. However, the --json option was left in the example. So, I fixed it.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
