### PR TITLE
fix: fixing persister_grant_jwk having an OR statement without bracket leading to not using the last part of the query

### DIFF
--- a/persistence/sql/persister_grant_jwk.go
+++ b/persistence/sql/persister_grant_jwk.go
@@ -113,7 +113,7 @@ func (p *Persister) GetPublicKey(ctx context.Context, issuer string, subject str
 	var data trust.SQLData
 	query := p.QueryWithNetwork(ctx).
 		Where("issuer = ?", issuer).
-		Where("subject = ? OR allow_any_subject IS TRUE", subject).
+		Where("(subject = ? OR allow_any_subject IS TRUE)", subject).
 		Where("key_id = ?", keyId).
 		Where("nid = ?", p.NetworkID(ctx))
 	if err := query.First(&data); err != nil {
@@ -135,7 +135,7 @@ func (p *Persister) GetPublicKeys(ctx context.Context, issuer string, subject st
 	grantsData := make([]trust.SQLData, 0)
 	query := p.QueryWithNetwork(ctx).
 		Where("issuer = ?", issuer).
-		Where("subject = ? OR allow_any_subject IS TRUE", subject).
+		Where("(subject = ? OR allow_any_subject IS TRUE)", subject).
 		Where("nid = ?", p.NetworkID(ctx))
 
 	if err := query.All(&grantsData); err != nil {
@@ -170,7 +170,7 @@ func (p *Persister) GetPublicKeyScopes(ctx context.Context, issuer string, subje
 	var data trust.SQLData
 	query := p.QueryWithNetwork(ctx).
 		Where("issuer = ?", issuer).
-		Where("subject = ? OR allow_any_subject IS TRUE", subject).
+		Where("(subject = ? OR allow_any_subject IS TRUE)", subject).
 		Where("key_id = ?", keyId).
 		Where("nid = ?", p.NetworkID(ctx))
 


### PR DESCRIPTION
No breaking change, just a fix

## Related issue(s)
#3498 

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

None
