### PR TITLE
feat: add metrics to disabled access log

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -201,7 +201,7 @@ func setup(ctx context.Context, d driver.Registry, cmd *cobra.Command) (admin *h
 		NewMiddlewareFromLogger(d.Logger(),
 			fmt.Sprintf("hydra/admin: %s", d.Config().IssuerURL(ctx).String()))
 	if d.Config().DisableHealthAccessLog(config.AdminInterface) {
-		adminLogger = adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
+		adminLogger = adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath, "/admin" + prometheus.MetricsPrometheusPath)
 	}
 
 	adminmw.Use(adminLogger)

--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -201,7 +201,7 @@ func setup(ctx context.Context, d driver.Registry, cmd *cobra.Command) (admin *h
 		NewMiddlewareFromLogger(d.Logger(),
 			fmt.Sprintf("hydra/admin: %s", d.Config().IssuerURL(ctx).String()))
 	if d.Config().DisableHealthAccessLog(config.AdminInterface) {
-		adminLogger = adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath, "/admin" + prometheus.MetricsPrometheusPath)
+		adminLogger = adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath, "/admin"+prometheus.MetricsPrometheusPath)
 	}
 
 	adminmw.Use(adminLogger)

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -139,7 +139,7 @@ serve:
 
     # Access Log configuration for public server.
     request_log:
-      # Disable access log for health endpoints.
+      # Disable access log for health and metrics endpoints.
       disable_for_health: false
 
   # admin controls the admin daemon serving admin API endpoints like /jwk, /client, ...


### PR DESCRIPTION
##  Motivation 

Following https://github.com/ory/hydra/pull/3496, logs were reduce drastically.

The last unneeded logs are those generated when prometheus endpoint is scraped.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
