### PR TITLE
feat: support different jwt scope claim strategies

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -781,6 +781,18 @@
           "description": "Defines access token type. jwt is a bad idea, see https://www.ory.sh/docs/hydra/advanced#json-web-tokens",
           "enum": ["opaque", "jwt"],
           "default": "opaque"
+        },
+        "jwt": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scope_claim": {
+              "type": "string",
+              "description": "Defines how the scope claim is represented within a JWT access token",
+              "enum": ["list", "string", "both"],
+              "default": "list"
+            }
+          }
         }
       }
     },

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export PATH 					:= .bin:${PATH}
 export PWD 						:= $(shell pwd)
 export IMAGE_TAG 			:= $(if $(IMAGE_TAG),$(IMAGE_TAG),latest)
 
-GOLANGCI_LINT_VERSION = 1.53.2
+GOLANGCI_LINT_VERSION = 1.53.3
 
 GO_DEPENDENCIES = github.com/ory/go-acc \
 				  github.com/golang/mock/mockgen \

--- a/cmd/cmd_list_clients.go
+++ b/cmd/cmd_list_clients.go
@@ -31,6 +31,7 @@ func NewListClientsCmd() *cobra.Command {
 				return err
 			}
 
+			// nolint:bodyclose
 			list, resp, err := m.OAuth2Api.ListOAuth2Clients(cmd.Context()).PageSize(int64(pageSize)).PageToken(pageToken).Execute()
 			if err != nil {
 				return cmdx.PrintOpenAPIError(cmd, err)

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -79,6 +79,7 @@ const (
 	KeyAdminURL                                  = "urls.self.admin"
 	KeyIssuerURL                                 = "urls.self.issuer"
 	KeyAccessTokenStrategy                       = "strategies.access_token"
+	KeyJWTScopeClaimStrategy                     = "strategies.jwt.scope_claim"
 	KeyDBIgnoreUnknownTableColumns               = "db.ignore_unknown_table_columns"
 	KeySubjectIdentifierAlgorithmSalt            = "oidc.subject_identifiers.pairwise.salt"
 	KeyPublicAllowDynamicRegistration            = "oidc.dynamic_client_registration.enabled"

--- a/driver/config/provider_fosite.go
+++ b/driver/config/provider_fosite.go
@@ -93,14 +93,16 @@ func (p *DefaultProvider) GetScopeStrategy(ctx context.Context) fosite.ScopeStra
 var _ fosite.JWTScopeFieldProvider = (*DefaultProvider)(nil)
 
 func (p *DefaultProvider) GetJWTScopeField(ctx context.Context) jwt.JWTScopeFieldEnum {
-	strategy := strings.ToLower(p.getProvider(ctx).String(KeyJWTScopeClaimStrategy))
-	if strategy == "string" {
+	switch strings.ToLower(p.getProvider(ctx).String(KeyJWTScopeClaimStrategy)) {
+	case "string":
 		return jwt.JWTScopeFieldString
-	}
-	if strategy == "both" {
+	case "both":
 		return jwt.JWTScopeFieldBoth
+	case "list":
+		return jwt.JWTScopeFieldList
+	default:
+		return jwt.JWTScopeFieldUnset
 	}
-	return jwt.JWTScopeFieldList
 }
 
 func (p *DefaultProvider) GetUseLegacyErrorFormat(context.Context) bool {

--- a/driver/config/provider_fosite.go
+++ b/driver/config/provider_fosite.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ory/fosite"
+	"github.com/ory/fosite/token/jwt"
 	"github.com/ory/hydra/v2/x"
 )
 
@@ -87,6 +88,19 @@ func (p *DefaultProvider) GetScopeStrategy(ctx context.Context) fosite.ScopeStra
 		return fosite.WildcardScopeStrategy
 	}
 	return fosite.ExactScopeStrategy
+}
+
+var _ fosite.JWTScopeFieldProvider = (*DefaultProvider)(nil)
+
+func (p *DefaultProvider) GetJWTScopeField(ctx context.Context) jwt.JWTScopeFieldEnum {
+	strategy := strings.ToLower(p.getProvider(ctx).String(KeyJWTScopeClaimStrategy))
+	if strategy == "string" {
+		return jwt.JWTScopeFieldString
+	}
+	if strategy == "both" {
+		return jwt.JWTScopeFieldBoth
+	}
+	return jwt.JWTScopeFieldList
 }
 
 func (p *DefaultProvider) GetUseLegacyErrorFormat(context.Context) bool {

--- a/driver/config/provider_test.go
+++ b/driver/config/provider_test.go
@@ -475,6 +475,8 @@ func TestJWTScopeClaimStrategy(t *testing.T) {
 	ctx := context.Background()
 
 	assert.Equal(t, jwt.JWTScopeFieldList, p.GetJWTScopeField(ctx))
+	p.MustSet(ctx, KeyJWTScopeClaimStrategy, "list")
+	assert.Equal(t, jwt.JWTScopeFieldList, p.GetJWTScopeField(ctx))
 	p.MustSet(ctx, KeyJWTScopeClaimStrategy, "string")
 	assert.Equal(t, jwt.JWTScopeFieldString, p.GetJWTScopeField(ctx))
 	p.MustSet(ctx, KeyJWTScopeClaimStrategy, "both")

--- a/driver/config/provider_test.go
+++ b/driver/config/provider_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/fosite/token/jwt"
 	"github.com/ory/x/configx"
 	"github.com/ory/x/otelx"
 
@@ -305,6 +306,7 @@ func TestViperProviderValidates(t *testing.T) {
 	assert.False(t, c.GetScopeStrategy(ctx)([]string{"openid.*"}, "openid.email"), "should us fosite.ExactScopeStrategy")
 	assert.Equal(t, AccessTokenDefaultStrategy, c.AccessTokenStrategy(ctx))
 	assert.Equal(t, false, c.GrantAllClientCredentialsScopesPerDefault(ctx))
+	assert.Equal(t, jwt.JWTScopeFieldList, c.GetJWTScopeField(ctx))
 
 	// ttl
 	assert.Equal(t, 2*time.Hour, c.ConsentRequestMaxAge(ctx))
@@ -463,4 +465,18 @@ func TestJWTBearer(t *testing.T) {
 	assert.Equal(t, 24.0, p2.GetJWTMaxDuration(ctx).Hours())
 	assert.Equal(t, true, p2.GetGrantTypeJWTBearerIssuedDateOptional(ctx))
 	assert.Equal(t, true, p2.GetGrantTypeJWTBearerIDOptional(ctx))
+}
+
+func TestJWTScopeClaimStrategy(t *testing.T) {
+	l := logrusx.New("", "")
+	l.Logrus().SetOutput(io.Discard)
+	p := MustNew(context.Background(), l)
+
+	ctx := context.Background()
+
+	assert.Equal(t, jwt.JWTScopeFieldList, p.GetJWTScopeField(ctx))
+	p.MustSet(ctx, KeyJWTScopeClaimStrategy, "string")
+	assert.Equal(t, jwt.JWTScopeFieldString, p.GetJWTScopeField(ctx))
+	p.MustSet(ctx, KeyJWTScopeClaimStrategy, "both")
+	assert.Equal(t, jwt.JWTScopeFieldBoth, p.GetJWTScopeField(ctx))
 }

--- a/fositex/config.go
+++ b/fositex/config.go
@@ -189,7 +189,7 @@ func (c *Config) GetAccessTokenIssuer(ctx context.Context) string {
 }
 
 func (c *Config) GetJWTScopeField(ctx context.Context) jwt.JWTScopeFieldEnum {
-	return jwt.JWTScopeFieldList
+	return c.deps.Config().GetJWTScopeField(ctx)
 }
 
 func (c *Config) GetFormPostHTMLTemplate(ctx context.Context) *template.Template {

--- a/spec/config.json
+++ b/spec/config.json
@@ -781,6 +781,18 @@
           "description": "Defines access token type. jwt is a bad idea, see https://www.ory.sh/docs/hydra/advanced#json-web-tokens",
           "enum": ["opaque", "jwt"],
           "default": "opaque"
+        },
+        "jwt": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scope_claim": {
+              "type": "string",
+              "description": "Defines how the scope claim is represented within a JWT access token",
+              "enum": ["list", "string", "both"],
+              "default": "list"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
Adds a `strategies.jwt.scope_claim` optional configuration property that controls how the scope claim is represented in JWT access tokens. It can be set to one of `list`, `string`, or `both`. `list` (the default behavior) matches the current behavior of using a `scp` claim that is an array of strings. `string` uses a `scope` claim as defined in [this RFC](https://datatracker.ietf.org/doc/html/rfc9068#section-2.2.3), a single space-delimited string. `both` will include both the `scp` and `scope` claim in the token.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->
#3524 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
These different scope claim strategies were already available in `fosite`, this PR is just exposing them through a Hydra configuration property. Open to suggestions on configuration property naming! Will update docs but wanted to get this PR settled first to know what to add to the docs.