### PR TITLE
feat: hot-reload Oauth2 CORS settings

### DIFF
--- a/driver/registry.go
+++ b/driver/registry.go
@@ -5,6 +5,7 @@ package driver
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/ory/x/httprouterx"
 
@@ -68,6 +69,7 @@ type Registry interface {
 	ConsentHandler() *consent.Handler
 	OAuth2Handler() *oauth2.Handler
 	HealthHandler() *healthx.Handler
+	OAuth2AwareMiddleware() func(h http.Handler) http.Handler
 
 	OAuth2HMACStrategy() *foauth2.HMACSHAStrategy
 	WithOAuth2Provider(f fosite.OAuth2Provider)

--- a/driver/registry_base.go
+++ b/driver/registry_base.go
@@ -119,9 +119,9 @@ func (m *RegistryBase) WithBuildInfo(version, hash, date string) Registry {
 	return m.r
 }
 
-func (m *RegistryBase) OAuth2AwareMiddleware(ctx context.Context) func(h http.Handler) http.Handler {
+func (m *RegistryBase) OAuth2AwareMiddleware() func(h http.Handler) http.Handler {
 	if m.oa2mw == nil {
-		m.oa2mw = oauth2cors.Middleware(ctx, m.r)
+		m.oa2mw = oauth2cors.Middleware(m.r)
 	}
 	return m.oa2mw
 }
@@ -150,9 +150,9 @@ func (m *RegistryBase) RegisterRoutes(ctx context.Context, admin *httprouterx.Ro
 	admin.Handler("GET", prometheus.MetricsPrometheusPath, promhttp.Handler())
 
 	m.ConsentHandler().SetRoutes(admin)
-	m.KeyHandler().SetRoutes(admin, public, m.OAuth2AwareMiddleware(ctx))
+	m.KeyHandler().SetRoutes(admin, public, m.OAuth2AwareMiddleware())
 	m.ClientHandler().SetRoutes(admin, public)
-	m.OAuth2Handler().SetRoutes(admin, public, m.OAuth2AwareMiddleware(ctx))
+	m.OAuth2Handler().SetRoutes(admin, public, m.OAuth2AwareMiddleware())
 	m.JWTGrantHandler().SetRoutes(admin)
 }
 

--- a/x/oauth2cors/cors.go
+++ b/x/oauth2cors/cors.go
@@ -4,8 +4,6 @@
 package oauth2cors
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -21,113 +19,129 @@ import (
 )
 
 func Middleware(
-	ctx context.Context,
 	reg interface {
 		x.RegistryLogger
 		oauth2.Registry
 		client.Registry
 	}) func(h http.Handler) http.Handler {
-	opts, enabled := reg.Config().CORS(ctx, config.PublicInterface)
-	if !enabled {
-		return func(h http.Handler) http.Handler {
-			return h
-		}
-	}
-
-	var alwaysAllow = len(opts.AllowedOrigins) == 0
-	var patterns []glob.Glob
-	for _, o := range opts.AllowedOrigins {
-		if o == "*" {
-			alwaysAllow = true
-		}
-		// if the protocol (http or https) is specified, but the url is wildcard, use special ** glob, which ignore the '.' separator.
-		// This way g := glob.Compile("http://**") g.Match("http://google.com") returns true.
-		if splittedO := strings.Split(o, "://"); len(splittedO) != 1 && splittedO[1] == "*" {
-			o = fmt.Sprintf("%s://**", splittedO[0])
-		}
-		g, err := glob.Compile(strings.ToLower(o), '.')
-		if err != nil {
-			reg.Logger().WithError(err).Fatalf("Unable to parse cors origin: %s", o)
-		}
-
-		patterns = append(patterns, g)
-	}
-
-	options := cors.Options{
-		AllowedOrigins:     opts.AllowedOrigins,
-		AllowedMethods:     opts.AllowedMethods,
-		AllowedHeaders:     opts.AllowedHeaders,
-		ExposedHeaders:     opts.ExposedHeaders,
-		MaxAge:             opts.MaxAge,
-		AllowCredentials:   opts.AllowCredentials,
-		OptionsPassthrough: opts.OptionsPassthrough,
-		Debug:              opts.Debug,
-		AllowOriginRequestFunc: func(r *http.Request, origin string) bool {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			if alwaysAllow {
-				return true
+
+			opts, enabled := reg.Config().CORS(ctx, config.PublicInterface)
+			if !enabled {
+				reg.Logger().Debug("not enhancing CORS per client, as CORS is disabled")
+				h.ServeHTTP(w, r)
+				return
 			}
 
-			origin = strings.ToLower(origin)
-			for _, p := range patterns {
-				if p.Match(origin) {
-					return true
-				}
-			}
-
-			// pre-flight requests do not contain credentials (cookies, HTTP authorization)
-			// so we return true in all cases here.
-			if r.Method == http.MethodOptions {
-				return true
-			}
-
-			var clientID string
-
-			// if the client uses client_secret_post auth it will provide its client ID in form data
-			clientID = r.PostFormValue("client_id")
-
-			// if the client uses client_secret_basic auth the client ID will be the username component
-			if clientID == "" {
-				clientID, _, _ = r.BasicAuth()
-			}
-
-			// otherwise, this may be a bearer auth request, in which case we can introspect the token
-			if clientID == "" {
-				token := fosite.AccessTokenFromRequest(r)
-				if token == "" {
-					return false
-				}
-
-				session := oauth2.NewSessionWithCustomClaims("", reg.Config().AllowedTopLevelClaims(ctx))
-				_, ar, err := reg.OAuth2Provider().IntrospectToken(ctx, token, fosite.AccessToken, session)
-				if err != nil {
-					return false
-				}
-
-				clientID = ar.GetClient().GetID()
-			}
-
-			cl, err := reg.ClientManager().GetConcreteClient(ctx, clientID)
-			if err != nil {
-				return false
-			}
-
-			for _, o := range cl.AllowedCORSOrigins {
+			alwaysAllow := len(opts.AllowedOrigins) == 0
+			patterns := make([]glob.Glob, 0, len(opts.AllowedOrigins))
+			for _, o := range opts.AllowedOrigins {
 				if o == "*" {
-					return true
+					alwaysAllow = true
+					break
+				}
+				// if the protocol (http or https) is specified, but the url is wildcard, use special ** glob, which ignore the '.' separator.
+				// This way g := glob.Compile("http://**") g.Match("http://google.com") returns true.
+				if scheme, rest, found := strings.Cut(o, "://"); found && rest == "*" {
+					o = scheme + "://**"
 				}
 				g, err := glob.Compile(strings.ToLower(o), '.')
 				if err != nil {
-					return false
+					reg.Logger().WithError(err).WithField("pattern", o).Error("Unable to parse CORS origin")
+					h.ServeHTTP(w, r)
+					return
 				}
-				if g.Match(origin) {
-					return true
-				}
+
+				patterns = append(patterns, g)
 			}
 
-			return false
-		},
-	}
+			options := cors.Options{
+				AllowedOrigins:     opts.AllowedOrigins,
+				AllowedMethods:     opts.AllowedMethods,
+				AllowedHeaders:     opts.AllowedHeaders,
+				ExposedHeaders:     opts.ExposedHeaders,
+				MaxAge:             opts.MaxAge,
+				AllowCredentials:   opts.AllowCredentials,
+				OptionsPassthrough: opts.OptionsPassthrough,
+				Debug:              opts.Debug,
+				AllowOriginRequestFunc: func(r *http.Request, origin string) bool {
+					ctx := r.Context()
+					if alwaysAllow {
+						return true
+					}
 
-	return cors.New(options).Handler
+					origin = strings.ToLower(origin)
+					for _, p := range patterns {
+						if p.Match(origin) {
+							return true
+						}
+					}
+
+					// pre-flight requests do not contain credentials (cookies, HTTP authorization)
+					// so we return true in all cases here.
+					if r.Method == http.MethodOptions {
+						return true
+					}
+
+					var clientID string
+
+					// if the client uses client_secret_post auth it will provide its client ID in form data
+					clientID = r.PostFormValue("client_id")
+
+					// if the client uses client_secret_basic auth the client ID will be the username component
+					if clientID == "" {
+						clientID, _, _ = r.BasicAuth()
+					}
+
+					// otherwise, this may be a bearer auth request, in which case we can introspect the token
+					if clientID == "" {
+						token := fosite.AccessTokenFromRequest(r)
+						if token == "" {
+							return false
+						}
+
+						session := oauth2.NewSessionWithCustomClaims("", reg.Config().AllowedTopLevelClaims(ctx))
+						_, ar, err := reg.OAuth2Provider().IntrospectToken(ctx, token, fosite.AccessToken, session)
+						if err != nil {
+							return false
+						}
+
+						clientID = ar.GetClient().GetID()
+					}
+
+					cl, err := reg.ClientManager().GetConcreteClient(ctx, clientID)
+					if err != nil {
+						return false
+					}
+
+					for _, o := range cl.AllowedCORSOrigins {
+						if o == "*" {
+							return true
+						}
+
+						// if the protocol (http or https) is specified, but the url is wildcard, use special ** glob, which ignore the '.' separator.
+						// This way g := glob.Compile("http://**") g.Match("http://google.com") returns true.
+						if scheme, rest, found := strings.Cut(o, "://"); found && rest == "*" {
+							o = scheme + "://**"
+						}
+
+						g, err := glob.Compile(strings.ToLower(o), '.')
+						if err != nil {
+							return false
+						}
+						if g.Match(origin) {
+							return true
+						}
+					}
+
+					return false
+				},
+			}
+
+			reg.Logger().Debug("enhancing CORS per client")
+			cors.New(options).Handler(h).ServeHTTP(w, r)
+		})
+	}
 }

--- a/x/oauth2cors/cors.go
+++ b/x/oauth2cors/cors.go
@@ -49,9 +49,8 @@ func Middleware(
 				}
 				g, err := glob.Compile(strings.ToLower(o), '.')
 				if err != nil {
-					reg.Logger().WithError(err).WithField("pattern", o).Error("Unable to parse CORS origin")
-					h.ServeHTTP(w, r)
-					return
+					reg.Logger().WithError(err).WithField("pattern", o).Error("Unable to parse CORS origin, ignoring it")
+					continue
 				}
 
 				patterns = append(patterns, g)

--- a/x/oauth2cors/cors_test.go
+++ b/x/oauth2cors/cors_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/ory/hydra/v2/driver"
-	"github.com/ory/hydra/v2/x/oauth2cors"
 	"github.com/ory/x/contextx"
 
 	"github.com/ory/hydra/v2/x"
@@ -30,8 +29,10 @@ import (
 )
 
 func TestOAuth2AwareCORSMiddleware(t *testing.T) {
+	ctx := context.Background()
 	r := internal.NewRegistryMemory(t, internal.NewConfigurationWithDefaults(), &contextx.Default{})
-	token, signature, _ := r.OAuth2HMACStrategy().GenerateAccessToken(context.Background(), nil)
+	token, signature, _ := r.OAuth2HMACStrategy().GenerateAccessToken(ctx, nil)
+
 	for k, tc := range []struct {
 		prep         func(*testing.T, driver.Registry)
 		d            string
@@ -52,8 +53,8 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should reject when basic auth but client does not exist and cors enabled",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo", "bar"))}},
@@ -62,11 +63,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should reject when post auth client exists but origin not allowed",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-2", Secret: "bar", AllowedCORSOrigins: []string{"http://not-foobar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-2", Secret: "bar", AllowedCORSOrigins: []string{"http://not-foobar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Content-Type": {"application/x-www-form-urlencoded"}},
@@ -77,11 +78,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept when post auth client exists and origin allowed",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-3", Secret: "bar", AllowedCORSOrigins: []string{"http://foobar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-3", Secret: "bar", AllowedCORSOrigins: []string{"http://foobar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Content-Type": {"application/x-www-form-urlencoded"}},
@@ -92,11 +93,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should reject when basic auth client exists but origin not allowed",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-2", Secret: "bar", AllowedCORSOrigins: []string{"http://not-foobar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-2", Secret: "bar", AllowedCORSOrigins: []string{"http://not-foobar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-2", "bar"))}},
@@ -105,10 +106,10 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept when basic auth client exists and origin allowed",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-3", Secret: "bar", AllowedCORSOrigins: []string{"http://foobar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-3", Secret: "bar", AllowedCORSOrigins: []string{"http://foobar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-3", "bar"))}},
@@ -117,11 +118,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept when basic auth client exists and origin allowed",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-3", Secret: "bar", AllowedCORSOrigins: []string{"http://foobar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-3", Secret: "bar", AllowedCORSOrigins: []string{"http://foobar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-3", "bar"))}},
@@ -130,11 +131,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept when basic auth client exists and origin (with partial wildcard) is allowed per client",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-4", Secret: "bar", AllowedCORSOrigins: []string{"http://*.foobar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-4", Secret: "bar", AllowedCORSOrigins: []string{"http://*.foobar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foo.foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-4", "bar"))}},
@@ -143,11 +144,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept when basic auth client exists and origin (with full wildcard) is allowed globally",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"*"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"*"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-5", Secret: "bar", AllowedCORSOrigins: []string{"http://barbar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-5", Secret: "bar", AllowedCORSOrigins: []string{"http://barbar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"*"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-5", "bar"))}},
@@ -156,11 +157,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept when basic auth client exists and origin (with partial wildcard) is allowed globally",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://*.foobar.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://*.foobar.com"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-6", Secret: "bar", AllowedCORSOrigins: []string{"http://barbar.com"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-6", Secret: "bar", AllowedCORSOrigins: []string{"http://barbar.com"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foo.foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-6", "bar"))}},
@@ -169,11 +170,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept when basic auth client exists and origin (with full wildcard) allowed per client",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-7", Secret: "bar", AllowedCORSOrigins: []string{"*"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-7", Secret: "bar", AllowedCORSOrigins: []string{"*"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-7", "bar"))}},
@@ -182,8 +183,8 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should succeed on pre-flight request when token introspection fails",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Bearer 1234"}},
@@ -193,8 +194,8 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should fail when token introspection fails",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Bearer 1234"}},
@@ -203,8 +204,8 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should work when token introspection returns a session",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://not-test-domain.com"})
 				sess := oauth2.NewSession("foo-9")
 				sess.SetExpiresAt(fosite.AccessToken, time.Now().Add(time.Hour))
 				ar := fosite.NewAccessRequest(sess)
@@ -212,8 +213,8 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 				ar.Client = cl
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), cl)
-				_ = r.OAuth2Storage().CreateAccessTokenSession(context.Background(), signature, ar)
+				_ = r.ClientManager().CreateClient(ctx, cl)
+				_ = r.OAuth2Storage().CreateAccessTokenSession(ctx, signature, ar)
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foobar.com"}, "Authorization": {"Bearer " + token}},
@@ -222,12 +223,12 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept any allowed specified origin protocol",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-11", Secret: "bar", AllowedCORSOrigins: []string{"*"}})
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://*", "https://*"})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-11", Secret: "bar", AllowedCORSOrigins: []string{"*"}})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://*", "https://*"})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://foo.foobar.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-11", "bar"))}},
@@ -236,11 +237,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept client origin when basic auth client exists and origin is set at the client as well as the server",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://**.example.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://**.example.com"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-12", Secret: "bar", AllowedCORSOrigins: []string{"http://myapp.example.biz"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-12", Secret: "bar", AllowedCORSOrigins: []string{"http://myapp.example.biz"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://myapp.example.biz"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-12", "bar"))}},
@@ -249,11 +250,11 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 		{
 			d: "should accept server origin when basic auth client exists and origin is set at the client as well as the server",
 			prep: func(t *testing.T, r driver.Registry) {
-				r.Config().MustSet(context.Background(), "serve.public.cors.enabled", true)
-				r.Config().MustSet(context.Background(), "serve.public.cors.allowed_origins", []string{"http://**.example.com"})
+				r.Config().MustSet(ctx, "serve.public.cors.enabled", true)
+				r.Config().MustSet(ctx, "serve.public.cors.allowed_origins", []string{"http://**.example.com"})
 
 				// Ignore unique violations
-				_ = r.ClientManager().CreateClient(context.Background(), &client.Client{LegacyClientID: "foo-13", Secret: "bar", AllowedCORSOrigins: []string{"http://myapp.example.biz"}})
+				_ = r.ClientManager().CreateClient(ctx, &client.Client{LegacyClientID: "foo-13", Secret: "bar", AllowedCORSOrigins: []string{"http://myapp.example.biz"}})
 			},
 			code:         http.StatusNotImplemented,
 			header:       http.Header{"Origin": {"http://client-app.example.com"}, "Authorization": {fmt.Sprintf("Basic %s", x.BasicAuth("foo-13", "bar"))}},
@@ -278,7 +279,7 @@ func TestOAuth2AwareCORSMiddleware(t *testing.T) {
 			}
 
 			res := httptest.NewRecorder()
-			oauth2cors.Middleware(context.Background(), r)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.OAuth2AwareMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNotImplemented)
 			})).ServeHTTP(res, req)
 			require.NoError(t, err)


### PR DESCRIPTION
As client settings change over time, this should be fully hot-reloadable. Resolves regression of #1754 on Ory Network.