### PR TITLE
fix: restore ability to override auth and token urls for exemplary app

### DIFF
--- a/cmd/cmd_perform_authorization_code.go
+++ b/cmd/cmd_perform_authorization_code.go
@@ -97,6 +97,8 @@ and success, unless if the --no-shutdown flag is provided.`,
 			prompt := flagx.MustGetStringSlice(cmd, "prompt")
 			maxAge := flagx.MustGetInt(cmd, "max-age")
 			redirectUrl := flagx.MustGetString(cmd, "redirect")
+			authUrl := flagx.MustGetString(cmd, "auth-url")
+			tokenUrl := flagx.MustGetString(cmd, "token-url")
 			audience := flagx.MustGetStringSlice(cmd, "audience")
 			noShutdown := flagx.MustGetBool(cmd, "no-shutdown")
 
@@ -118,15 +120,20 @@ and success, unless if the --no-shutdown flag is provided.`,
 				redirectUrl = serverLocation + "callback"
 			}
 
-			if err != nil {
-				return err
+			if authUrl == "" {
+				authUrl = urlx.AppendPaths(endpoint, "/oauth2/auth").String()
 			}
+
+			if tokenUrl == "" {
+				tokenUrl = urlx.AppendPaths(endpoint, "/oauth2/token").String()
+			}
+
 			conf := oauth2.Config{
 				ClientID:     clientID,
 				ClientSecret: clientSecret,
 				Endpoint: oauth2.Endpoint{
-					TokenURL: urlx.AppendPaths(endpoint, "/oauth2/token").String(),
-					AuthURL:  urlx.AppendPaths(endpoint, "/oauth2/auth").String(),
+					AuthURL:  authUrl,
+					TokenURL: tokenUrl,
 				},
 				RedirectURL: redirectUrl,
 				Scopes:      scopes,


### PR DESCRIPTION
Restore ability to override auth and token urls for exemplary app, looks like this was accidentally broken in the past.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).