### PR TITLE
fix: tweak the format of the verifiable credential JWT

### DIFF
--- a/oauth2/verifiable_credentials.go
+++ b/oauth2/verifiable_credentials.go
@@ -1,0 +1,87 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"encoding/json"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/ory/fosite"
+)
+
+// Request a Verifiable Credential
+//
+// swagger:parameters createVerifiableCredential
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
+type createVerifiableCredentialRequest struct {
+	// in: body
+	Body CreateVerifiableCredentialRequestBody
+}
+
+// CreateVerifiableCredentialRequestBody contains the request body to request a verifiable credential.
+//
+// swagger:parameters createVerifiableCredentialRequestBody
+type CreateVerifiableCredentialRequestBody struct {
+	Format string                     `json:"format"`
+	Types  []string                   `json:"types"`
+	Proof  *VerifiableCredentialProof `json:"proof"`
+}
+
+// VerifiableCredentialProof contains the proof of a verifiable credential.
+//
+// swagger:parameters verifiableCredentialProof
+type VerifiableCredentialProof struct {
+	ProofType string `json:"proof_type"`
+	JWT       string `json:"jwt"`
+}
+
+// VerifiableCredentialResponse contains the verifiable credential.
+//
+// swagger:model verifiableCredentialResponse
+type VerifiableCredentialResponse struct {
+	Format     string `json:"format"`
+	Credential string `json:"credential_draft_00"`
+}
+
+// VerifiableCredentialPrimingResponse contains the nonce to include in the proof-of-possession JWT.
+//
+// swagger:model verifiableCredentialPrimingResponse
+type VerifiableCredentialPrimingResponse struct {
+	Format         string `json:"format"`
+	Nonce          string `json:"c_nonce"`
+	NonceExpiresIn int64  `json:"c_nonce_expires_in"`
+
+	fosite.RFC6749ErrorJson
+}
+
+type VerifableCredentialClaims struct {
+	jwt.RegisteredClaims
+	VerifiableCredential VerifiableCredentialClaim `json:"vc"`
+}
+type VerifiableCredentialClaim struct {
+	Context []string       `json:"@context"`
+	Subject map[string]any `json:"credentialSubject"`
+	Type    []string       `json:"type"`
+}
+
+func (v *VerifableCredentialClaims) GetAudience() (jwt.ClaimStrings, error) {
+	return jwt.ClaimStrings{}, nil
+}
+
+func (v *VerifableCredentialClaims) ToMapClaims() (res map[string]any, err error) {
+	res = map[string]any{}
+
+	bs, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(bs, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
This PR implements the following tweaks to the format of the JWT:

* The JWT should have an `exp` claim.  
* The JWT should have an `nbf` claim in addition to `iat` (OK if these are the same)
* The top-level `sub` would have to be the `did:jwk` value.  But it's OK to have the real `sub` if it's inside `credentialSubject`.
* The `aud` claim should be deleted, since it represents the intended verifier, not the client to whom the VC is issued.  (An important difference from normal OIDC is that these are different!)  In the Webex case, it's OK, since the app issuing the VC is the same as the app verifying it.  But that's not true in general.
* The UserInfo claims (`email`, `email_verified`, `updated_at`) should be inside `vc.credentialSubject`.

---

For reference, an example JWT VC looks like this:

```
eyJhbGciOiJFUzI1NiIsImtpZCI6Imh5ZHJhLm9wZW5pZC5pZC10b2tlbiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEuNjkyNzkzODg4ZSswOSwiaWF0IjoxLjY5Mjc5MDI4OGUrMDksImlzcyI6Imh0dHA6Ly8xMjcuMC4wLjE6NTkxMjMiLCJqdGkiOiJhZjYzOGE4My00ZjU3LTQ3YzQtYjdlMy0wOTIxY2I4NDIyYmEiLCJuYmYiOjEuNjkyNzkwMjg4ZSswOSwic3ViIjoiZGlkOmp3azpleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2lZV3huSWpvaVJWTXlOVFlpTENKNElqb2lTR3hGUVdkQ05tUmllbkowYUZSNU5HeGxiVWxqUlZSNlpFZGFkM0pQTXpSWVltdHVhRU4wVmpFd2F5SXNJbmtpT2lKaVlVdHZPWGMzUlZaWlowRjJlVnBZWDIxRWVtaEVhSGRWZFhOWVZ6TTNSa1JLTm0xVlRXaFlNa3BaSW4wIiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiYmFyIjoiYmF6IiwiZW1haWwiOiJmb29AYmFyLmNvbSIsImlkIjoiZGlkOmp3azpleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TWpVMklpd2lZV3huSWpvaVJWTXlOVFlpTENKNElqb2lTR3hGUVdkQ05tUmllbkowYUZSNU5HeGxiVWxqUlZSNlpFZGFkM0pQTXpSWVltdHVhRU4wVmpFd2F5SXNJbmtpT2lKaVlVdHZPWGMzUlZaWlowRjJlVnBZWDIxRWVtaEVhSGRWZFhOWVZ6TTNSa1JLTm0xVlRXaFlNa3BaSW4wIiwic2lkIjoiMmNiOGQ2YjctZmU0Mi00MjM4LTg5ZGItOGE1M2YzYTQxZThlIiwic3ViIjoiYWVuZWFzLXJla2thcyJ9LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVXNlckluZm9DcmVkZW50aWFsIl19fQ.q8KBPvqBTQgO5_mkoGYklPg-0GDm1hJo9xMtU2rrYLKUzRWPAMqdjEHuVztrA9dYhB_qXtIa8cylA19bD508pw
```

which decodes to the following claims:

```json
{
  "exp": 1692793888,
  "iat": 1692790288,
  "iss": "http://127.0.0.1:59123",
  "jti": "af638a83-4f57-47c4-b7e3-0921cb8422ba",
  "nbf": 1692790288,
  "sub": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwiYWxnIjoiRVMyNTYiLCJ4IjoiSGxFQWdCNmRienJ0aFR5NGxlbUljRVR6ZEdad3JPMzRYYmtuaEN0VjEwayIsInkiOiJiYUtvOXc3RVZZZ0F2eVpYX21EemhEaHdVdXNYVzM3RkRKNm1VTWhYMkpZIn0",
  "vc": {
    "@context": [
      "https://www.w3.org/2018/credentials/v1"
    ],
    "credentialSubject": {
      "bar": "baz",
      "email": "foo@bar.com",
      "id": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwiYWxnIjoiRVMyNTYiLCJ4IjoiSGxFQWdCNmRienJ0aFR5NGxlbUljRVR6ZEdad3JPMzRYYmtuaEN0VjEwayIsInkiOiJiYUtvOXc3RVZZZ0F2eVpYX21EemhEaHdVdXNYVzM3RkRKNm1VTWhYMkpZIn0",
      "sid": "2cb8d6b7-fe42-4238-89db-8a53f3a41e8e",
      "sub": "aeneas-rekkas"
    },
    "type": [
      "VerifiableCredential",
      "UserInfoCredential"
    ]
  }
}
```