### PR TITLE
fix: add "form_post" to list of supported response modes

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -495,7 +495,7 @@ func (h *Handler) discoverOidcConfiguration(w http.ResponseWriter, r *http.Reque
 		IDTokenSignedResponseAlg:               []string{key.Algorithm},
 		UserinfoSignedResponseAlg:              []string{key.Algorithm},
 		GrantTypesSupported:                    []string{"authorization_code", "implicit", "client_credentials", "refresh_token"},
-		ResponseModesSupported:                 []string{"query", "fragment"},
+		ResponseModesSupported:                 []string{"query", "fragment", "form_post"},
 		UserinfoSigningAlgValuesSupported:      []string{"none", key.Algorithm},
 		RequestParameterSupported:              true,
 		RequestURIParameterSupported:           true,


### PR DESCRIPTION
Fosite supports this for some time. Not sure if Hydra on purpose does not support it or just does not list it?