### PR TITLE
feat: add access token strategy parameter to cli

### DIFF
--- a/cmd/cmd_create_client.go
+++ b/cmd/cmd_create_client.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	flagClientAccessTokenStrategy               = "access-token-strategy"
 	flagClientAllowedCORSOrigin                 = "allowed-cors-origin"
 	flagClientAudience                          = "audience"
 	flagClientBackchannelLogoutCallback         = "backchannel-logout-callback"

--- a/cmd/cmd_helper_client.go
+++ b/cmd/cmd_helper_client.go
@@ -18,6 +18,7 @@ import (
 
 func clientFromFlags(cmd *cobra.Command) hydra.OAuth2Client {
 	return hydra.OAuth2Client{
+		AccessTokenStrategy:               pointerx.String(flagx.MustGetString(cmd, flagClientAccessTokenStrategy)),
 		AllowedCorsOrigins:                flagx.MustGetStringSlice(cmd, flagClientAllowedCORSOrigin),
 		Audience:                          flagx.MustGetStringSlice(cmd, flagClientAudience),
 		BackchannelLogoutSessionRequired:  pointerx.Bool(flagx.MustGetBool(cmd, flagClientBackChannelLogoutSessionRequired)),
@@ -81,6 +82,7 @@ func registerClientFlags(flags *pflag.FlagSet) {
 	flags.StringSlice(flagClientPostLogoutCallback, []string{}, "List of allowed URLs to be redirected to after a logout.")
 	flags.Bool(flagClientSkipConsent, false, "Boolean flag specifying whether to skip the consent screen for this client. If omitted, the default value is false.")
 	flags.Bool(flagClientLogoutSkipConsent, false, "Boolean flag specifying whether to skip the logout consent screen for this client. If omitted, the default value is false.")
+	flags.String(flagClientAccessTokenStrategy, "", "The strategy used to generate access tokens. Valid options are `opaque` and `jwt`.")
 
 	// back-channel logout options
 	flags.Bool(flagClientBackChannelLogoutSessionRequired, false, "Boolean flag specifying whether the client requires that a sid (session ID) Claim be included in the Logout Token to identify the client session with the OP when the backchannel-logout-callback is used. If omitted, the default value is false.")


### PR DESCRIPTION
This PR allows setting the access token strategy using the Hydra CLI: `--access-token-strategy jwt`.

## Related issue(s)
#3717

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

