### PR TITLE
fix: Backchannel Logout: Fix error log when RP responds with status code 204

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -791,8 +791,8 @@ func (s *DefaultStrategy) executeBackChannelLogout(r *http.Request, subject, sid
 		}
 		defer res.Body.Close()
 
-		if res.StatusCode != http.StatusOK {
-			log.WithError(errors.Errorf("expected HTTP status code %d but got %d", http.StatusOK, res.StatusCode)).
+		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+			log.WithError(errors.Errorf("expected HTTP status code %d or %d but got %d", http.StatusOK, http.StatusNoContent, res.StatusCode)).
 				Error("Unable to execute OpenID Connect Back-Channel Logout Request")
 			return
 		} else {


### PR DESCRIPTION
According to the specification at https://openid.net/specs/openid-connect-backchannel-1_0.html#BCResponse the Relying Party must respond with a status code 200. However, it also notes that the OpenID Provider should be prepared to handle status code 204 (No Content) as a successful response as well.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

This is a previously unknown bug.

Reproduction:

1. Configure backchannel logout
2. The relying party responds with a 204 status code on the backchannel logout request
3. Hydra logs an error

Note that this does not change any behaviour. The logged error does not have an influence whether the user is logged out or not.

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
5. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
6. implements a new feature, link the issue containing the design document in the format of `#1234`;
7. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works. -- Since this is only related to logging. Adding a test is difficult for me.
- [x] I have added or changed [the documentation](https://github.com/ory/docs). -- I don't think this is necessary

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
