### PR TITLE
fix: correctly pass multiple token audiences and prompt parameters wh…

### DIFF
--- a/cmd/cmd_perform_authorization_code.go
+++ b/cmd/cmd_perform_authorization_code.go
@@ -152,9 +152,9 @@ and success, unless if the --no-shutdown flag is provided.`,
 
 				authCodeURL := conf.AuthCodeURL(
 					state,
-					oauth2.SetAuthURLParam("audience", strings.Join(audience, "+")),
+					oauth2.SetAuthURLParam("audience", strings.Join(audience, " ")),
 					oauth2.SetAuthURLParam("nonce", string(nonce)),
-					oauth2.SetAuthURLParam("prompt", strings.Join(prompt, "+")),
+					oauth2.SetAuthURLParam("prompt", strings.Join(prompt, " ")),
 					oauth2.SetAuthURLParam("max_age", strconv.Itoa(maxAge)),
 				)
 				return authCodeURL, state


### PR DESCRIPTION
…en performing the authorization code flow from the CLI

Tested manually