### PR TITLE
Fix table names in sql migration file

### DIFF
--- a/persistence/sql/migrations/20240403121110000001_add_expire_columns.up.sql
+++ b/persistence/sql/migrations/20240403121110000001_add_expire_columns.up.sql
@@ -5,7 +5,7 @@ ALTER TABLE hydra_oauth2_code ADD COLUMN expires_at TIMESTAMP NULL;
 ALTER TABLE hydra_oauth2_pkce ADD COLUMN expires_at TIMESTAMP NULL;
 
 CREATE INDEX hydra_oauth2_oidc_expires_at_idx ON hydra_oauth2_oidc (expires_at);
-CREATE INDEX hydra_oauth2_access_expires_at_idx ON hydra_oauth2_oidc (expires_at);
-CREATE INDEX hydra_oauth2_refresh_expires_at_idx ON hydra_oauth2_oidc (expires_at);
-CREATE INDEX hydra_oauth2_code_expires_at_idx ON hydra_oauth2_oidc (expires_at);
-CREATE INDEX hydra_oauth2_pkce_expires_at_idx ON hydra_oauth2_oidc (expires_at);
+CREATE INDEX hydra_oauth2_access_expires_at_idx ON hydra_oauth2_access (expires_at);
+CREATE INDEX hydra_oauth2_refresh_expires_at_idx ON hydra_oauth2_refresh (expires_at);
+CREATE INDEX hydra_oauth2_code_expires_at_idx ON hydra_oauth2_code (expires_at);
+CREATE INDEX hydra_oauth2_pkce_expires_at_idx ON hydra_oauth2_pkce (expires_at);


### PR DESCRIPTION
Fix table names in sql migration file so that the indexes are actually used by tables other than hydra_oauth2_oidc.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
