### PR TITLE
feat: Refresh token expiration window

### DIFF
--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -101,6 +101,7 @@ const (
 	KeyExcludeNotBeforeClaim                     = "oauth2.exclude_not_before_claim"
 	KeyAllowedTopLevelClaims                     = "oauth2.allowed_top_level_claims"
 	KeyMirrorTopLevelClaims                      = "oauth2.mirror_top_level_claims"
+	KeyRefreshTokenRotationGracePeriod           = "oauth2.refresh_token_rotation.grace_period" // #nosec G101
 	KeyOAuth2GrantJWTIDOptional                  = "oauth2.grant.jwt.jti_optional"
 	KeyOAuth2GrantJWTIssuedDateOptional          = "oauth2.grant.jwt.iat_optional"
 	KeyOAuth2GrantJWTMaxDuration                 = "oauth2.grant.jwt.max_ttl"
@@ -648,4 +649,12 @@ func (p *DefaultProvider) cookieSuffix(ctx context.Context, key string) string {
 	}
 
 	return p.getProvider(ctx).String(key) + suffix
+}
+
+func (p *DefaultProvider) RefreshTokenRotationGracePeriod() time.Duration {
+	var duration = p.p.DurationF(KeyRefreshTokenRotationGracePeriod, 0)
+	if duration > time.Hour {
+		return time.Hour
+	}
+	return p.p.DurationF(KeyRefreshTokenRotationGracePeriod, 0)
 }

--- a/driver/config/provider_test.go
+++ b/driver/config/provider_test.go
@@ -291,6 +291,13 @@ func TestViperProviderValidates(t *testing.T) {
 	assert.Equal(t, "random_salt", c.SubjectIdentifierAlgorithmSalt(ctx))
 	assert.Equal(t, []string{"whatever"}, c.DefaultClientScope(ctx))
 
+	// refresh
+	assert.Equal(t, time.Duration(0), c.RefreshTokenRotationGracePeriod())
+	require.NoError(t, c.Set(ctx, KeyRefreshTokenRotationGracePeriod, "1s"))
+	assert.Equal(t, time.Second, c.RefreshTokenRotationGracePeriod())
+	require.NoError(t, c.Set(ctx, KeyRefreshTokenRotationGracePeriod, "2h"))
+	assert.Equal(t, time.Hour, c.RefreshTokenRotationGracePeriod())
+
 	// urls
 	assert.Equal(t, urlx.ParseOrPanic("https://issuer"), c.IssuerURL(ctx))
 	assert.Equal(t, urlx.ParseOrPanic("https://public/"), c.PublicURL(ctx))

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -402,6 +402,19 @@ oauth2:
   session:
     # store encrypted data in database, default true
     encrypt_at_rest: true
+    ## refresh_token_rotation
+  # By default Refresh Tokens are rotated and invalidated with each use. See https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.13.2 for more details
+  refresh_token_rotation:
+    #
+    ## grace_period
+    # 
+    # Set the grace period for a refresh token to allow it to be used for the duration of this configuration after its
+    #	first use. New refresh tokens will continue to be issued. 
+    #
+    # Examples:
+    # - 5s
+    # - 1m
+    grace_period: 0s
 
 # The secrets section configures secrets used for encryption and signing of several systems. All secrets can be rotated,
 # for more information on this topic navigate to:

--- a/persistence/sql/migrations/20220214121000000000_add_refresh_token_in_grace_period_flag.down.sql
+++ b/persistence/sql/migrations/20220214121000000000_add_refresh_token_in_grace_period_flag.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_refresh DROP COLUMN in_grace_period;

--- a/persistence/sql/migrations/20220214121000000000_add_refresh_token_in_grace_period_flag.up.sql
+++ b/persistence/sql/migrations/20220214121000000000_add_refresh_token_in_grace_period_flag.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hydra_oauth2_refresh ADD in_grace_period bool DEFAULT false;

--- a/spec/config.json
+++ b/spec/config.json
@@ -1121,9 +1121,24 @@
               "$ref": "#/definitions/webhook_config"
             }
           ]
+        },
+        "refresh_token_rotation": {
+        "type": "object",
+        "properties": {
+          "grace_period": {
+            "title": "Refresh Token Rotation Grace Period",
+            "description": "Configures how long a Refresh Token remains valid after it has been used. The maximum value is one hour.",
+            "default": "0h",
+            "allOf": [
+              {
+                "$ref": "#/definitions/duration"
+              }
+            ]
+          }
         }
       }
-    },
+    }
+  },
     "secrets": {
       "type": "object",
       "additionalProperties": false,

--- a/x/fosite_storer.go
+++ b/x/fosite_storer.go
@@ -18,15 +18,12 @@ import (
 type FositeStorer interface {
 	fosite.Storage
 	oauth2.CoreStorage
+	oauth2.TokenRevocationStorage
 	openid.OpenIDConnectRequestStorage
 	pkce.PKCERequestStorage
 	rfc7523.RFC7523KeyStorage
 	verifiable.NonceManager
 	oauth2.ResourceOwnerPasswordCredentialsGrantStorage
-
-	RevokeRefreshToken(ctx context.Context, requestID string) error
-
-	RevokeAccessToken(ctx context.Context, requestID string) error
 
 	// flush the access token requests from the database.
 	// no data will be deleted after the 'notAfter' timeframe.


### PR DESCRIPTION
This is a rebase, squash merge and fix of the previous PR here: #2827 

Introduce optional configuration value oauth2.refresh_token_rotation.grace_period that can be set as a duration (1m,
Add a new migration: boolean used SQL column in hydra_oauth2_refresh

When grace_period has positive duration the act of using a refresh token will not invalidate the token and instead mark it as used in the database and set its expiration time to the UTCNOW + the value of the grace period. This will allow a client to continue to use a refresh token for the duration of the grace period.

## Related issue(s)
#1831
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X ] I have read the [security policy](../security/policy).
- [ X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
