### PR TITLE
fix: broken JSON round-tripping for custom claims

### DIFF
--- a/oauth2/.snapshots/TestUnmarshalSession-v1.11.8.json
+++ b/oauth2/.snapshots/TestUnmarshalSession-v1.11.8.json
@@ -17,7 +17,8 @@
       "amr": [],
       "c_hash": "",
       "ext": {
-        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d"
+        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d",
+        "timestamp": 1723546027
       }
     },
     "headers": {

--- a/oauth2/.snapshots/TestUnmarshalSession-v1.11.9.json
+++ b/oauth2/.snapshots/TestUnmarshalSession-v1.11.9.json
@@ -17,7 +17,8 @@
       "amr": [],
       "c_hash": "",
       "ext": {
-        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d"
+        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d",
+        "timestamp": 1723546027
       }
     },
     "headers": {

--- a/oauth2/fixtures/v1.11.8-session.json
+++ b/oauth2/fixtures/v1.11.8-session.json
@@ -15,7 +15,8 @@
       "AuthenticationMethodsReferences": [],
       "CodeHash": "",
       "Extra": {
-        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d"
+        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d",
+        "timestamp": 1723546027
       }
     },
     "Headers": {

--- a/oauth2/fixtures/v1.11.9-session.json
+++ b/oauth2/fixtures/v1.11.9-session.json
@@ -15,7 +15,8 @@
       "amr": [],
       "c_hash": "",
       "ext": {
-        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d"
+        "sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d",
+        "timestamp": 1723546027
       }
     },
     "headers": {

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -665,7 +665,7 @@ func (h *Handler) getOidcUserInfo(w http.ResponseWriter, r *http.Request) {
 		interim["jti"] = uuid.New()
 		interim["iat"] = time.Now().Unix()
 
-		keyID, err := h.r.OpenIDJWTStrategy().GetPublicKeyID(r.Context())
+		keyID, err := h.r.OpenIDJWTStrategy().GetPublicKeyID(ctx)
 		if err != nil {
 			h.r.Writer().WriteError(w, r, err)
 			return
@@ -727,7 +727,7 @@ type revokeOAuth2Token struct {
 //	  default: errorOAuth2
 func (h *Handler) revokeOAuth2Token(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	events.Trace(r.Context(), events.AccessTokenRevoked)
+	events.Trace(ctx, events.AccessTokenRevoked)
 
 	err := h.r.OAuth2Provider().NewRevocationRequest(ctx, r)
 	if err != nil {
@@ -980,13 +980,13 @@ func (h *Handler) oauth2TokenExchange(w http.ResponseWriter, r *http.Request) {
 		}
 		session.ClientID = accessRequest.GetClient().GetID()
 		session.KID = accessTokenKeyID
-		session.DefaultSession.Claims.Issuer = h.c.IssuerURL(r.Context()).String()
+		session.DefaultSession.Claims.Issuer = h.c.IssuerURL(ctx).String()
 		session.DefaultSession.Claims.IssuedAt = time.Now().UTC()
 
 		scopes := accessRequest.GetRequestedScopes()
 
 		// Added for compatibility with MITREid
-		if h.c.GrantAllClientCredentialsScopesPerDefault(r.Context()) && len(scopes) == 0 {
+		if h.c.GrantAllClientCredentialsScopesPerDefault(ctx) && len(scopes) == 0 {
 			for _, scope := range accessRequest.GetClient().GetScopes() {
 				accessRequest.GrantScope(scope)
 			}
@@ -1089,7 +1089,7 @@ func (h *Handler) oAuth2Authorize(w http.ResponseWriter, r *http.Request, _ http
 	}
 
 	var accessTokenKeyID string
-	if h.c.AccessTokenStrategy(r.Context(), client.AccessTokenStrategySource(authorizeRequest.GetClient())) == "jwt" {
+	if h.c.AccessTokenStrategy(ctx, client.AccessTokenStrategySource(authorizeRequest.GetClient())) == "jwt" {
 		accessTokenKeyID, err = h.r.AccessTokenJWTStrategy().GetPublicKeyID(ctx)
 		if err != nil {
 			x.LogError(r, err, h.r.Logger())

--- a/oauth2/session_test.go
+++ b/oauth2/session_test.go
@@ -49,7 +49,8 @@ func TestUnmarshalSession(t *testing.T) {
 				AuthenticationMethodsReferences:     []string{},
 				CodeHash:                            "",
 				Extra: map[string]interface{}{
-					"sid": "177e1f44-a1e9-415c-bfa3-8b62280b182d",
+					"sid":       "177e1f44-a1e9-415c-bfa3-8b62280b182d",
+					"timestamp": 1723546027,
 				},
 			},
 			Headers: &jwt.Headers{Extra: map[string]interface{}{
@@ -85,7 +86,7 @@ func TestUnmarshalSession(t *testing.T) {
 		snapshotx.SnapshotTExcept(t, &actual, nil)
 	})
 
-	t.Run("v1.11.9", func(t *testing.T) {
+	t.Run("v1.11.9" /* and later versions */, func(t *testing.T) {
 		var actual Session
 		require.NoError(t, json.Unmarshal(v1119Session, &actual))
 		assertx.EqualAsJSON(t, expect, &actual)


### PR DESCRIPTION
Adding custom claims with numerical types (think JavaScript Number) previously did not
round-trip through Hydra correctly. For example, passing UNIX timestamps in custom claims
would end up as floating points in exponential notation in the final token. That, in turn,
confused or broke downstream consumers of the token, including Kratos.

Ref https://github.com/go-jose/go-jose/issues/144