### PR TITLE
chore: compile a static binary in Docker

### DIFF
--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -9,17 +9,16 @@ RUN apt-get update && apt-get upgrade -y &&\
 COPY go.mod go.sum ./
 COPY internal/httpclient/go.* ./internal/httpclient/
 
-ENV GO111MODULE on
-ENV CGO_ENABLED 1
+ENV CGO_ENABLED=1
 
 RUN go mod download
 
 COPY . .
-RUN go build -tags sqlite,json1 -o /usr/bin/hydra
+RUN go build -ldflags="-extldflags=-static" -tags sqlite,json1,sqlite_omit_load_extension -o /usr/bin/hydra
 
 #########################
 
-FROM gcr.io/distroless/base-nossl-debian12:nonroot AS runner
+FROM gcr.io/distroless/static-debian12:nonroot AS runner
 
 COPY --from=builder --chown=nonroot:nonroot /var/lib/sqlite /var/lib/sqlite
 COPY --from=builder /usr/bin/hydra /usr/bin/hydra

--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -14,7 +14,7 @@ ENV CGO_ENABLED=1
 RUN go mod download
 
 COPY . .
-RUN go build -ldflags="-extldflags=-static" -tags sqlite,json1,sqlite_omit_load_extension -o /usr/bin/hydra
+RUN go build -ldflags="-extldflags=-static" -tags sqlite,sqlite_omit_load_extension -o /usr/bin/hydra
 
 #########################
 

--- a/.docker/Dockerfile-hsm
+++ b/.docker/Dockerfile-hsm
@@ -18,7 +18,7 @@ COPY . .
 ###############################
 
 FROM builder as build-hydra
-RUN go build -tags sqlite,json1,hsm -o /usr/bin/hydra
+RUN go build -tags sqlite,hsm -o /usr/bin/hydra
 
 ###############################
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Run go-acc (tests)
         run: |
           make .bin/go-acc
-          .bin/go-acc -o coverage.out ./... -- -failfast -timeout=20m -tags sqlite,json1
+          .bin/go-acc -o coverage.out ./... -- -failfast -timeout=20m -tags sqlite,json1,sqlite_omit_load_extension
       - name: Submit to Codecov
         run: |
           bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Run go-acc (tests)
         run: |
           make .bin/go-acc
-          .bin/go-acc -o coverage.out ./... -- -failfast -timeout=20m -tags sqlite,json1,sqlite_omit_load_extension
+          .bin/go-acc -o coverage.out ./... -- -failfast -timeout=20m -tags sqlite,sqlite_omit_load_extension
       - name: Submit to Codecov
         run: |
           bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint: .bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
 .PHONY: test
 test: .bin/go-acc
 	make test-resetdb
-	source scripts/test-env.sh && go-acc ./... -- -failfast -timeout=20m -tags sqlite,json1,sqlite_omit_load_extension
+	source scripts/test-env.sh && go-acc ./... -- -failfast -timeout=20m -tags sqlite,sqlite_omit_load_extension
 	docker rm -f hydra_test_database_mysql
 	docker rm -f hydra_test_database_postgres
 	docker rm -f hydra_test_database_cockroach
@@ -84,7 +84,7 @@ e2e: node_modules test-resetdb
 # Runs tests in short mode, without database adapters
 .PHONY: quicktest
 quicktest:
-	go test -failfast -short -tags sqlite,json1,sqlite_omit_load_extension ./...
+	go test -failfast -short -tags sqlite,sqlite_omit_load_extension ./...
 
 .PHONY: quicktest-hsm
 quicktest-hsm:
@@ -92,7 +92,7 @@ quicktest-hsm:
 
 .PHONY: refresh
 refresh:
-	UPDATE_SNAPSHOTS=true go test -failfast -short -tags sqlite,json1,sqlite_omit_load_extension ./...
+	UPDATE_SNAPSHOTS=true go test -failfast -short -tags sqlite,sqlite_omit_load_extension ./...
 
 authors:  # updates the AUTHORS file
 	curl https://raw.githubusercontent.com/ory/ci/master/authors/authors.sh | env PRODUCT="Ory Hydra" bash
@@ -178,14 +178,14 @@ install-stable:
 	HYDRA_LATEST=$$(git describe --abbrev=0 --tags)
 	git checkout $$HYDRA_LATEST
 	go install \
-		-tags sqlite,json1,sqlite_omit_load_extension \
+		-tags sqlite,sqlite_omit_load_extension \
 		-ldflags "-X github.com/ory/hydra/v2/driver/config.Version=$$HYDRA_LATEST -X github.com/ory/hydra/v2/driver/config.Date=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/hydra/v2/driver/config.Commit=`git rev-parse HEAD`" \
 		.
 	git checkout master
 
 .PHONY: install
 install:
-	go install -tags sqlite,json1,sqlite_omit_load_extension .
+	go install -tags sqlite,sqlite_omit_load_extension .
 
 .PHONY: post-release
 post-release: .bin/yq

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint: .bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
 .PHONY: test
 test: .bin/go-acc
 	make test-resetdb
-	source scripts/test-env.sh && go-acc ./... -- -failfast -timeout=20m -tags sqlite,json1
+	source scripts/test-env.sh && go-acc ./... -- -failfast -timeout=20m -tags sqlite,json1,sqlite_omit_load_extension
 	docker rm -f hydra_test_database_mysql
 	docker rm -f hydra_test_database_postgres
 	docker rm -f hydra_test_database_cockroach
@@ -84,7 +84,7 @@ e2e: node_modules test-resetdb
 # Runs tests in short mode, without database adapters
 .PHONY: quicktest
 quicktest:
-	go test -failfast -short -tags sqlite,json1 ./...
+	go test -failfast -short -tags sqlite,json1,sqlite_omit_load_extension ./...
 
 .PHONY: quicktest-hsm
 quicktest-hsm:
@@ -92,7 +92,7 @@ quicktest-hsm:
 
 .PHONY: refresh
 refresh:
-	UPDATE_SNAPSHOTS=true go test -failfast -short -tags sqlite,json1 ./...
+	UPDATE_SNAPSHOTS=true go test -failfast -short -tags sqlite,json1,sqlite_omit_load_extension ./...
 
 authors:  # updates the AUTHORS file
 	curl https://raw.githubusercontent.com/ory/ci/master/authors/authors.sh | env PRODUCT="Ory Hydra" bash
@@ -177,15 +177,15 @@ $(MIGRATIONS_DST_DIR:%/=%-clean): $(MIGRATION_CLEAN_TARGETS)
 install-stable:
 	HYDRA_LATEST=$$(git describe --abbrev=0 --tags)
 	git checkout $$HYDRA_LATEST
-	GO111MODULE=on go install \
-		-tags sqlite,json1 \
+	go install \
+		-tags sqlite,json1,sqlite_omit_load_extension \
 		-ldflags "-X github.com/ory/hydra/v2/driver/config.Version=$$HYDRA_LATEST -X github.com/ory/hydra/v2/driver/config.Date=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/hydra/v2/driver/config.Commit=`git rev-parse HEAD`" \
 		.
 	git checkout master
 
 .PHONY: install
 install:
-	GO111MODULE=on go install -tags sqlite,json1 .
+	go install -tags sqlite,json1,sqlite_omit_load_extension .
 
 .PHONY: post-release
 post-release: .bin/yq

--- a/README.md
+++ b/README.md
@@ -849,24 +849,24 @@ It is recommended to use the make file to run your tests using `make quicktest`
 **Please note**:
 
 All tests run against a sqlite in-memory database, thus it is required to use
-the `-tags sqlite,json1` build tag.
+the `-tags sqlite` build tag.
 
 Short tests run fairly quickly. You can either test all of the code at once:
 
 ```shell script
-go test -v -failfast -short -tags sqlite,json1 ./...
+go test -v -failfast -short -tags sqlite ./...
 ```
 
 or test just a specific module:
 
 ```shell script
-go test -v -failfast -short -tags sqlite,json1 ./client
+go test -v -failfast -short -tags sqlite ./client
 ```
 
 or a specific test:
 
 ```shell script
-go test -v -failfast -short -tags sqlite,json1 -run ^TestName$ ./...
+go test -v -failfast -short -tags sqlite -run ^TestName$ ./...
 ```
 
 ##### Regular Tests

--- a/scripts/db-diff.sh
+++ b/scripts/db-diff.sh
@@ -107,7 +107,7 @@ function dump_sqlite {
 	hydra::util::ensure-sqlite
 
 	rm "$SQLITE_PATH" > /dev/null 2>&1 || true
-	go run -tags sqlite,json1 . migrate sql "sqlite://$SQLITE_PATH?_fk=true" --yes > /dev/null 2>&1 || true
+	go run -tags sqlite,json1,sqlite_omit_load_extension . migrate sql "sqlite://$SQLITE_PATH?_fk=true" --yes > /dev/null 2>&1 || true
 	echo '.dump' | sqlite3 "$SQLITE_PATH"
 }
 

--- a/scripts/db-diff.sh
+++ b/scripts/db-diff.sh
@@ -107,7 +107,7 @@ function dump_sqlite {
 	hydra::util::ensure-sqlite
 
 	rm "$SQLITE_PATH" > /dev/null 2>&1 || true
-	go run -tags sqlite,json1,sqlite_omit_load_extension . migrate sql "sqlite://$SQLITE_PATH?_fk=true" --yes > /dev/null 2>&1 || true
+	go run -tags sqlite,sqlite_omit_load_extension . migrate sql "sqlite://$SQLITE_PATH?_fk=true" --yes > /dev/null 2>&1 || true
 	echo '.dump' | sqlite3 "$SQLITE_PATH"
 }
 

--- a/test/conformance/hydra/Dockerfile
+++ b/test/conformance/hydra/Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -tags sqlite,json1 -o /usr/bin/hydra
+RUN go build -tags sqlite -o /usr/bin/hydra
 
 VOLUME /var/lib/sqlite
 

--- a/test/e2e/circle-ci.bash
+++ b/test/e2e/circle-ci.bash
@@ -26,7 +26,7 @@ if [[ ! -d "../../node_modules/" ]]; then
     (cd ../..; npm ci)
 fi
 
-(cd ../../; go build -tags sqlite,json1 -o test/e2e/hydra . )
+(cd ../../; go build -tags sqlite -o test/e2e/hydra . )
 
 # Install oauth2-client
 if [[ ! -d "./oauth2-client/node_modules/" ]]; then


### PR DESCRIPTION
Move from distroless/static-debian12 to distroless/base-nossl-debian12 to get fewer CVE alerts

Uses the technique described in https://www.arp242.net/static-go.html
