### PR TITLE
feat: built-in login/consent UI for `hydra perform authorization-code`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
           GOGC: 100
         with:
           args: --timeout 10m0s
-          version: v1.55.2
+          version: v1.61.0
           skip-pkg-cache: true
       - name: Run go-acc (tests)
         run: |

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -40,7 +40,7 @@
         },
         "mode": {
           "type": "integer",
-          "description": "Mode of unix socket in numeric form",
+          "description": "Mode of unix socket in numeric form, base 10.",
           "default": 493,
           "minimum": 0,
           "maximum": 511

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export PATH 					:= .bin:${PATH}
 export PWD 						:= $(shell pwd)
 export IMAGE_TAG 			:= $(if $(IMAGE_TAG),$(IMAGE_TAG),latest)
 
-GOLANGCI_LINT_VERSION = 1.55.2
+GOLANGCI_LINT_VERSION = 1.61.0
 
 GO_DEPENDENCIES = github.com/ory/go-acc \
 				  github.com/golang/mock/mockgen \

--- a/spec/config.json
+++ b/spec/config.json
@@ -40,7 +40,7 @@
         },
         "mode": {
           "type": "integer",
-          "description": "Mode of unix socket in numeric form",
+          "description": "Mode of unix socket in numeric form, base 10.",
           "default": 493,
           "minimum": 0,
           "maximum": 511

--- a/x/int_to_bytes.go
+++ b/x/int_to_bytes.go
@@ -12,7 +12,7 @@ import (
 // IntToBytes converts an int64 to a byte slice. It is the inverse of BytesToInt.
 func IntToBytes(i int64) []byte {
 	b := make([]byte, 8)
-	binary.LittleEndian.PutUint64(b, uint64(i))
+	binary.LittleEndian.PutUint64(b, uint64(i)) //nolint:gosec
 
 	return b
 }
@@ -22,5 +22,5 @@ func BytesToInt(b []byte) (int64, error) {
 	if len(b) != 8 {
 		return 0, errors.New("byte slice must be 8 bytes long")
 	}
-	return int64(binary.LittleEndian.Uint64(b)), nil
+	return int64(binary.LittleEndian.Uint64(b)), nil //nolint:gosec
 }


### PR DESCRIPTION
This allows you to easily test an Authorization Code flow against hydra without having to have a consent UI otherwise available.

If you want to use the built-in UI, configure the login+consent UIs to point to the same server as the redirect URI:
```sh
ory patch oauth2-config --project $PROJECT_ID --replace '/urls/login="http://127.0.0.1:4446/login"' --replace '/urls/consent="http://127.0.0.1:4446/consent"'
```

Then run
```sh
ory perform authorization-code --project $PROJECT_ID --client-id xyz --client-secret abc
```
or
```sh
hydra perform authorization-code --client-id xyz --client-secret abc --auth-url http://... --token-url http://...
```