### PR TITLE
fix: advertise support for response_mode=form_post in OIDC discovery document

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -497,7 +497,7 @@ func (h *Handler) discoverOidcConfiguration(w http.ResponseWriter, r *http.Reque
 		IDTokenSignedResponseAlg:               []string{key.Algorithm},
 		UserinfoSignedResponseAlg:              []string{key.Algorithm},
 		GrantTypesSupported:                    []string{"authorization_code", "implicit", "client_credentials", "refresh_token"},
-		ResponseModesSupported:                 []string{"query", "fragment"},
+		ResponseModesSupported:                 []string{"query", "fragment", "form_post"},
 		UserinfoSigningAlgValuesSupported:      []string{"none", key.Algorithm},
 		RequestParameterSupported:              true,
 		RequestURIParameterSupported:           true,


### PR DESCRIPTION
This has been supported in Hydra for a while, but was missing from `/.well-known/openid-configuration`.

Also added a flag to `hydra perform authorization-code`: `--response-mode` to test+debug this.