### PR TITLE
refactor: jwk aquire lock when generating

### DIFF
--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -44,12 +44,16 @@ func EnsureAsymmetricKeypairExists(ctx context.Context, r InternalRegistry, alg,
 }
 
 func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, kid, alg string) (private *jose.JSONWebKey, err error) {
-	getLock(set).Lock()
-	defer getLock(set).Unlock()
-
+	getLock(set).RLock()
 	keys, err := m.GetKeySet(ctx, set)
+	getLock(set).RUnlock()
+
 	if errors.Is(err, x.ErrNotFound) || keys != nil && len(keys.Keys) == 0 {
 		r.Logger().Warnf("JSON Web Key Set \"%s\" does not exist yet, generating new key pair...", set)
+
+		getLock(set).Lock()
+		defer getLock(set).Unlock()
+
 		keys, err = m.GenerateAndPersistKeySet(ctx, set, kid, alg, "sig")
 		if err != nil {
 			return nil, err
@@ -63,6 +67,9 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 		return privKey, nil
 	} else {
 		r.Logger().WithField("jwks", set).Warnf("JSON Web Key not found in JSON Web Key Set %s, generating new key pair...", set)
+
+		getLock(set).Lock()
+		defer getLock(set).Unlock()
 
 		keys, err = m.GenerateAndPersistKeySet(ctx, set, kid, alg, "sig")
 		if err != nil {

--- a/oauth2/.snapshots/TestHandlerWellKnown-hsm_enabled=false.json
+++ b/oauth2/.snapshots/TestHandlerWellKnown-hsm_enabled=false.json
@@ -63,7 +63,8 @@
   "require_request_uri_registration": true,
   "response_modes_supported": [
     "query",
-    "fragment"
+    "fragment",
+    "form_post"
   ],
   "response_types_supported": [
     "code",

--- a/oauth2/.snapshots/TestHandlerWellKnown-hsm_enabled=true.json
+++ b/oauth2/.snapshots/TestHandlerWellKnown-hsm_enabled=true.json
@@ -63,7 +63,8 @@
   "require_request_uri_registration": true,
   "response_modes_supported": [
     "query",
-    "fragment"
+    "fragment",
+    "form_post"
   ],
   "response_types_supported": [
     "code",


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Update the locking behavior of `jwk.GetOrGenerateKeys` to acquire a read lock to fetch keys  and only acquire the write lock when generating and persisting new keys.

## Related issue(s)

#3863

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

I can attempt to write up more unit tests if that is required, but since this is not a significant change I am wondering if the existing tests can cover it?

I am also not sure what would need to be written for documentation but I am happy to add it where it is preferred.

On the related issue there are some reproducible steps that can be used to demonstrate the benefit of this refactor, but I can specify steps or update here if needed.