### PR TITLE
refactor: use trylock

### DIFF
--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -8,14 +8,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"math/big"
 	"sync"
-	"time"
 
 	hydra "github.com/ory/hydra-client-go/v2"
 
@@ -31,13 +28,6 @@ import (
 
 var mapLock sync.RWMutex
 var locks = map[string]*sync.RWMutex{}
-
-func lockDelay() (duration time.Duration) {
-	if n, err := rand.Int(rand.Reader, big.NewInt(3)); err == nil {
-		duration = time.Duration(n.Int64()) * time.Millisecond
-	}
-	return
-}
 
 func getLock(set string) *sync.RWMutex {
 	mapLock.Lock()
@@ -64,7 +54,6 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 				return nil, err
 			}
 		} else {
-			time.Sleep(lockDelay())
 			return GetOrGenerateKeys(ctx, r, m, set, kid, alg)
 		}
 	} else if err != nil {
@@ -92,7 +81,6 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 		return privKey, nil
 	}
 
-	time.Sleep(lockDelay())
 	return GetOrGenerateKeys(ctx, r, m, set, kid, alg)
 }
 

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"sync"
+	"time"
 
 	hydra "github.com/ory/hydra-client-go/v2"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+var waitDelay = 3 * time.Millisecond
 var mapLock sync.RWMutex
 var locks = map[string]*sync.RWMutex{}
 
@@ -54,6 +56,7 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 				return nil, err
 			}
 		} else {
+			time.Sleep(waitDelay)
 			return GetOrGenerateKeys(ctx, r, m, set, kid, alg)
 		}
 	} else if err != nil {
@@ -80,7 +83,7 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 		}
 		return privKey, nil
 	}
-
+	time.Sleep(waitDelay)
 	return GetOrGenerateKeys(ctx, r, m, set, kid, alg)
 }
 

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"sync"
+	"time"
 
 	hydra "github.com/ory/hydra-client-go/v2"
 
@@ -28,6 +29,7 @@ import (
 
 var mapLock sync.RWMutex
 var locks = map[string]*sync.RWMutex{}
+var lockDelay = 3 * time.Millisecond
 
 func getLock(set string) *sync.RWMutex {
 	mapLock.Lock()
@@ -54,6 +56,7 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 				return nil, err
 			}
 		} else {
+			time.Sleep(lockDelay)
 			return GetOrGenerateKeys(ctx, r, m, set, kid, alg)
 		}
 	} else if err != nil {
@@ -80,6 +83,8 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 		}
 		return privKey, nil
 	}
+
+	time.Sleep(lockDelay)
 	return GetOrGenerateKeys(ctx, r, m, set, kid, alg)
 }
 

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -72,7 +72,7 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 		return nil, err
 	}
 
-	privKey, err := FindPrivateKey(keys)
+	privKey, err = FindPrivateKey(keys)
 	if err != nil {
 		return nil, err
 	}

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -45,10 +45,6 @@ func EnsureAsymmetricKeypairExists(ctx context.Context, r InternalRegistry, alg,
 
 func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, kid, alg string) (private *jose.JSONWebKey, err error) {
 	keys, err := m.GetKeySet(ctx, set)
-	if err == nil && keys != nil && len(keys.Keys) > 0 {
-		return FindPrivateKey(keys)
-	}
-
 	if errors.Is(err, x.ErrNotFound) || keys != nil && len(keys.Keys) == 0 {
 		r.Logger().Warnf("JSON Web Key Set \"%s\" does not exist yet, generating new key pair...", set)
 		getLock(set).Lock()

--- a/jwk/helper.go
+++ b/jwk/helper.go
@@ -61,22 +61,22 @@ func GetOrGenerateKeys(ctx context.Context, r InternalRegistry, m Manager, set, 
 	privKey, privKeyErr := FindPrivateKey(keys)
 	if privKeyErr == nil {
 		return privKey, nil
-	} else {
-		r.Logger().WithField("jwks", set).Warnf("JSON Web Key not found in JSON Web Key Set %s, generating new key pair...", set)
-
-		getLock(set).Lock()
-		keys, err = m.GenerateAndPersistKeySet(ctx, set, kid, alg, "sig")
-		getLock(set).Unlock()
-		if err != nil {
-			return nil, err
-		}
-
-		privKey, err := FindPrivateKey(keys)
-		if err != nil {
-			return nil, err
-		}
-		return privKey, nil
 	}
+
+	r.Logger().WithField("jwks", set).Warnf("JSON Web Key not found in JSON Web Key Set %s, generating new key pair...", set)
+
+	getLock(set).Lock()
+	keys, err = m.GenerateAndPersistKeySet(ctx, set, kid, alg, "sig")
+	getLock(set).Unlock()
+	if err != nil {
+		return nil, err
+	}
+
+	privKey, err := FindPrivateKey(keys)
+	if err != nil {
+		return nil, err
+	}
+	return privKey, nil
 }
 
 func First(keys []jose.JSONWebKey) *jose.JSONWebKey {


### PR DESCRIPTION
This attempts to deal with write contention by using `TryLock` of the `RWMutex` and recurse if the lock cannot be obtained which will check for the key again.

## Related issue(s)

#3866

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

The idea is that when the lock is not obtained for writing we can leverage the implicit latency of the database statement to get the key after recursing.