### PR TITLE
chore: update dependencies, authenticate docker hub

### DIFF
--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -1,5 +1,6 @@
 name: Docker Image Scanners
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"
@@ -9,30 +10,51 @@ on:
     branches:
       - "master"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   scanners:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Env
         id: vars
         shell: bash
         run: |
           echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=oryd/hydra:$(git rev-parse --short HEAD)-sqlite" >> "${GITHUB_ENV}"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build images
         shell: bash
         run: |
           IMAGE_TAG="${{ env.SHA_SHORT }}" make docker
+
+      # Add GitHub authentication for Trivy
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Configure Trivy
+      - name: Configure Trivy
+        run: |
+          mkdir -p $HOME/.cache/trivy
+          echo "TRIVY_USERNAME=${{ github.actor }}" >> $GITHUB_ENV
+          echo "TRIVY_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+
       - name: Anchore Scanner
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v5
         id: grype-scan
         with:
-          image: oryd/hydra:${{ env.SHA_SHORT }}-sqlite
+          image: ${{ env.IMAGE_NAME }}
           fail-build: true
           severity-cutoff: high
           add-cpes-if-none: true
@@ -45,14 +67,14 @@ jobs:
           echo "::endgroup::"
       - name: Anchore upload scan SARIF report
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}
       - name: Kubescape scanner
         uses: kubescape/github-action@main
         id: kubescape
         with:
-          image: oryd/hydra:${{ env.SHA_SHORT }}-sqlite
+          image: ${{ env.IMAGE_NAME }}
           verbose: true
           format: pretty-printer
           # can't whitelist CVE yet: https://github.com/kubescape/kubescape/pull/1568
@@ -61,18 +83,22 @@ jobs:
         uses: aquasecurity/trivy-action@master
         if: ${{ always() }}
         with:
-          image-ref: oryd/hydra:${{ env.SHA_SHORT }}-sqlite
+          image-ref: ${{ env.IMAGE_NAME }}
           format: "table"
           exit-code: "42"
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
-          scanners: "vuln,secret,config"
+          scanners: "vuln,secret,misconfig"
+        env:
+          TRIVY_SKIP_JAVA_DB_UPDATE: "true"
+          TRIVY_DISABLE_VEX_NOTICE: "true"
+
       - name: Dockle Linter
-        uses: erzz/dockle-action@v1.3.2
+        uses: erzz/dockle-action@v1
         if: ${{ always() }}
         with:
-          image: oryd/hydra:${{ env.SHA_SHORT }}-sqlite
+          image: ${{ env.IMAGE_NAME }}
           exit-code: 42
           failure-threshold: high
       - name: Hadolint


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/cve-scan.yaml` file to enhance the security scanning process and update dependencies.

### Workflow Enhancements:
* Added `workflow_dispatch` to allow manual triggering of the workflow.
* Added `permissions` to specify read access to contents and write access to security events.

### Dependency Updates:
* Updated `actions/checkout` from v3 to v4.
* Updated `docker/setup-qemu-action` from v2 to v3.
* Updated `docker/setup-buildx-action` from v2 to v3.
* Updated `anchore/scan-action` from v3 to v5.
* Updated `github/codeql-action/upload-sarif` from v2 to v3.
* Updated `erzz/dockle-action` from v1.3.2 to v1.

### Configuration Changes:
* Added steps to login to GitHub Container Registry and configure Trivy for enhanced security scanning.
* Unified the image name definition to use `IMAGE_NAME` environment variable across all steps. [[1]](diffhunk://#diff-aa6fda5edbd4fbdbcb708b81d7835f730889e01a18ebaa3582c0f09e039a0409R13-R57) [[2]](diffhunk://#diff-aa6fda5edbd4fbdbcb708b81d7835f730889e01a18ebaa3582c0f09e039a0409L48-R77) [[3]](diffhunk://#diff-aa6fda5edbd4fbdbcb708b81d7835f730889e01a18ebaa3582c0f09e039a0409L64-R101)
* Added environment variables to Trivy configuration to skip Java DB updates and disable VEX notices.