### PR TITLE
Update claims instead of overwrite from webhook response

### DIFF
--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -14,7 +14,8 @@
         "amr": null,
         "c_hash": "",
         "ext": {
-          "hooked": "legacy"
+          "hooked": "legacy",
+          "sid": ""
         }
       },
       "headers": {

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -14,7 +14,8 @@
         "amr": null,
         "c_hash": "",
         "ext": {
-          "hooked": "legacy"
+          "hooked": "legacy",
+          "sid": ""
         }
       },
       "headers": {

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -14,7 +14,8 @@
         "amr": null,
         "c_hash": "",
         "ext": {
-          "hooked": "legacy"
+          "hooked": "legacy",
+          "sid": ""
         }
       },
       "headers": {

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -14,7 +14,8 @@
         "amr": null,
         "c_hash": "",
         "ext": {
-          "hooked": "legacy"
+          "hooked": "legacy",
+          "sid": ""
         }
       },
       "headers": {

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -14,7 +14,8 @@
         "amr": null,
         "c_hash": "",
         "ext": {
-          "hooked": "legacy"
+          "hooked": "legacy",
+          "sid": ""
         }
       },
       "headers": {

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -14,7 +14,8 @@
         "amr": null,
         "c_hash": "",
         "ext": {
-          "hooked": "legacy"
+          "hooked": "legacy",
+          "sid": ""
         }
       },
       "headers": {

--- a/oauth2/token_hook.go
+++ b/oauth2/token_hook.go
@@ -143,11 +143,23 @@ func executeHookAndUpdateSession(ctx context.Context, reg x.HTTPClientProvider, 
 		)
 	}
 
-	// Overwrite existing session data (extra claims).
-	session.Extra = respBody.Session.AccessToken
+	// Update existing session data (extra claims).
+	session.Extra = updateExtraClaims(session.Extra, respBody.Session.AccessToken)
 	idTokenClaims := session.IDTokenClaims()
-	idTokenClaims.Extra = respBody.Session.IDToken
+	idTokenClaims.Extra = updateExtraClaims(idTokenClaims.Extra, respBody.Session.IDToken)
 	return nil
+}
+
+func updateExtraClaims(priorExtraClaims, webhookExtraClaims map[string]interface{}) map[string]interface{} {
+	updatedClaims := make(map[string]interface{})
+	for key, value := range priorExtraClaims {
+		updatedClaims[key] = value
+	}
+	for key, value := range webhookExtraClaims {
+		updatedClaims[key] = value
+	}
+
+	return updatedClaims
 }
 
 // TokenHook is an AccessRequestHook called for all grant types.

--- a/oauth2/token_hook.go
+++ b/oauth2/token_hook.go
@@ -144,22 +144,16 @@ func executeHookAndUpdateSession(ctx context.Context, reg x.HTTPClientProvider, 
 	}
 
 	// Update existing session data (extra claims).
-	session.Extra = updateExtraClaims(session.Extra, respBody.Session.AccessToken)
+	updateExtraClaims(session.Extra, respBody.Session.AccessToken)
 	idTokenClaims := session.IDTokenClaims()
-	idTokenClaims.Extra = updateExtraClaims(idTokenClaims.Extra, respBody.Session.IDToken)
+	updateExtraClaims(idTokenClaims.Extra, respBody.Session.IDToken)
 	return nil
 }
 
-func updateExtraClaims(priorExtraClaims, webhookExtraClaims map[string]interface{}) map[string]interface{} {
-	updatedClaims := make(map[string]interface{})
-	for key, value := range priorExtraClaims {
-		updatedClaims[key] = value
-	}
+func updateExtraClaims(claimsToUpdate, webhookExtraClaims map[string]interface{}) {
 	for key, value := range webhookExtraClaims {
-		updatedClaims[key] = value
+		claimsToUpdate[key] = value
 	}
-
-	return updatedClaims
 }
 
 // TokenHook is an AccessRequestHook called for all grant types.

--- a/oauth2/token_hook.go
+++ b/oauth2/token_hook.go
@@ -144,16 +144,23 @@ func executeHookAndUpdateSession(ctx context.Context, reg x.HTTPClientProvider, 
 	}
 
 	// Update existing session data (extra claims).
-	updateExtraClaims(session.Extra, respBody.Session.AccessToken)
+	session.Extra = updateExtraClaims(session.Extra, respBody.Session.AccessToken)
 	idTokenClaims := session.IDTokenClaims()
-	updateExtraClaims(idTokenClaims.Extra, respBody.Session.IDToken)
+	idTokenClaims.Extra = updateExtraClaims(idTokenClaims.Extra, respBody.Session.IDToken)
 	return nil
 }
 
-func updateExtraClaims(claimsToUpdate, webhookExtraClaims map[string]interface{}) {
+func updateExtraClaims(claimsToUpdate, webhookExtraClaims map[string]interface{}) map[string]interface{} {
+	if webhookExtraClaims == nil {
+		return claimsToUpdate
+	}
+	if claimsToUpdate == nil {
+		claimsToUpdate = make(map[string]interface{})
+	}
 	for key, value := range webhookExtraClaims {
 		claimsToUpdate[key] = value
 	}
+	return claimsToUpdate
 }
 
 // TokenHook is an AccessRequestHook called for all grant types.

--- a/oauth2/token_hook_test.go
+++ b/oauth2/token_hook_test.go
@@ -1,0 +1,84 @@
+package oauth2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUpdateExtraClaims(t *testing.T) {
+	tests := []struct {
+		name               string
+		priorExtraClaims   map[string]interface{}
+		webhookExtraClaims map[string]interface{}
+		expected           map[string]interface{}
+	}{
+		{
+			name: "Merge with no updates",
+			priorExtraClaims: map[string]interface{}{
+				"claim1": "value1",
+				"claim2": "value2",
+			},
+			webhookExtraClaims: map[string]interface{}{
+				"claim3": "value3",
+				"claim4": "value4",
+			},
+			expected: map[string]interface{}{
+				"claim1": "value1",
+				"claim2": "value2",
+				"claim3": "value3",
+				"claim4": "value4",
+			},
+		},
+		{
+			name: "Merge with updates",
+			priorExtraClaims: map[string]interface{}{
+				"claim1": "value1",
+				"claim2": "value2",
+			},
+			webhookExtraClaims: map[string]interface{}{
+				"claim2": "newValue2", // Overwrites prior claim2
+				"claim3": "value3",
+			},
+			expected: map[string]interface{}{
+				"claim1": "value1",
+				"claim2": "newValue2",
+				"claim3": "value3",
+			},
+		},
+		{
+			name: "Empty webhook claims",
+			priorExtraClaims: map[string]interface{}{
+				"claim1": "value1",
+			},
+			webhookExtraClaims: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"claim1": "value1",
+			},
+		},
+		{
+			name:             "Empty prior claims",
+			priorExtraClaims: map[string]interface{}{},
+			webhookExtraClaims: map[string]interface{}{
+				"claim1": "value1",
+			},
+			expected: map[string]interface{}{
+				"claim1": "value1",
+			},
+		},
+		{
+			name:               "Both maps empty",
+			priorExtraClaims:   map[string]interface{}{},
+			webhookExtraClaims: map[string]interface{}{},
+			expected:           map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := updateExtraClaims(tt.priorExtraClaims, tt.webhookExtraClaims)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("updateExtraClaims() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/oauth2/token_hook_test.go
+++ b/oauth2/token_hook_test.go
@@ -74,15 +74,36 @@ func TestUpdateExtraClaims(t *testing.T) {
 			webhookExtraClaims: map[string]interface{}{},
 			expected:           map[string]interface{}{},
 		},
+		{
+			name:               "Nil webhook claims",
+			priorExtraClaims:   map[string]interface{}{"claim1": "value1"},
+			webhookExtraClaims: nil,
+			expected:           map[string]interface{}{"claim1": "value1"},
+		},
+		{
+			name:               "Nil prior claims",
+			priorExtraClaims:   nil,
+			webhookExtraClaims: map[string]interface{}{"claim1": "value1"},
+			expected:           map[string]interface{}{"claim1": "value1"},
+		},
+		{
+			name:               "Both maps nil",
+			priorExtraClaims:   nil,
+			webhookExtraClaims: nil,
+			expected:           nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Act
-			updateExtraClaims(tt.priorExtraClaims, tt.webhookExtraClaims)
+			if tt.priorExtraClaims == nil {
+				tt.priorExtraClaims = nil // Explicitly ensure nil for this test case
+			}
+			actual := updateExtraClaims(tt.priorExtraClaims, tt.webhookExtraClaims)
 
 			// Assert
-			if !reflect.DeepEqual(tt.priorExtraClaims, tt.expected) {
+			if !reflect.DeepEqual(actual, tt.expected) {
 				t.Errorf("claimsToUpdate = %v, want %v", tt.priorExtraClaims, tt.expected)
 			}
 		})

--- a/oauth2/token_hook_test.go
+++ b/oauth2/token_hook_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
 package oauth2
 
 import (
@@ -75,9 +78,12 @@ func TestUpdateExtraClaims(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updateExtraClaims(tt.priorExtraClaims, tt.webhookExtraClaims)
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("updateExtraClaims() = %v, want %v", result, tt.expected)
+			// Act
+			updateExtraClaims(tt.priorExtraClaims, tt.webhookExtraClaims)
+
+			// Assert
+			if !reflect.DeepEqual(tt.priorExtraClaims, tt.expected) {
+				t.Errorf("claimsToUpdate = %v, want %v", tt.priorExtraClaims, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
According to the [webhook documentation](https://www.ory.sh/docs/hydra/guides/claims-at-refresh#responding-to-the-webhook):

> To accept the token exchange without modification, return a 204 or 200 HTTP status code without a response body.


However, this behavior is currently not functioning as expected. When an empty response is returned, it overwrites the additional claims sent to the webhook, effectively erasing them.

## Related issue(s)

https://github.com/ory/hydra/issues/3879

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
