### PR TITLE
Include Requested Scopes in Webhook Requests

### DIFF
--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -35,6 +35,11 @@
   },
   "request": {
     "client_id": "app-client",
+    "requested_scopes": [
+      "hydra.*",
+      "offline",
+      "openid"
+    ],
     "granted_scopes": [
       "offline",
       "openid",

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -35,6 +35,11 @@
   },
   "request": {
     "client_id": "app-client",
+    "requested_scopes": [
+      "hydra.*",
+      "offline",
+      "openid"
+    ],
     "granted_scopes": [
       "offline",
       "openid",

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=jwt-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -35,6 +35,11 @@
   },
   "request": {
     "client_id": "app-client",
+    "requested_scopes": [
+      "hydra.*",
+      "offline",
+      "openid"
+    ],
     "granted_scopes": [
       "offline",
       "openid",

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=0-description=should_pass_request_if_strategy_passes-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -35,6 +35,11 @@
   },
   "request": {
     "client_id": "app-client",
+    "requested_scopes": [
+      "hydra.*",
+      "offline",
+      "openid"
+    ],
     "granted_scopes": [
       "offline",
       "openid",

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=2-description=should_pass_because_prompt=none_and_max_age_is_less_than_auth_time-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -35,6 +35,11 @@
   },
   "request": {
     "client_id": "app-client",
+    "requested_scopes": [
+      "hydra.*",
+      "offline",
+      "openid"
+    ],
     "granted_scopes": [
       "offline",
       "openid",

--- a/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
+++ b/oauth2/.snapshots/TestAuthCodeWithMockStrategy-strategy=opaque-case=5-description=should_pass_with_prompt=login_when_authentication_time_is_recent-should_call_refresh_token_hook_if_configured-hook=new.json
@@ -35,6 +35,11 @@
   },
   "request": {
     "client_id": "app-client",
+    "requested_scopes": [
+      "hydra.*",
+      "offline",
+      "openid"
+    ],
     "granted_scopes": [
       "offline",
       "openid",

--- a/oauth2/token_hook.go
+++ b/oauth2/token_hook.go
@@ -30,6 +30,8 @@ type AccessRequestHook func(ctx context.Context, requester fosite.AccessRequeste
 type Request struct {
 	// ClientID is the identifier of the OAuth 2.0 client.
 	ClientID string `json:"client_id"`
+	// RequestedScopes is the list of scopes requested to the OAuth 2.0 client.
+	RequestedScopes []string `json:"requested_scopes"`
 	// GrantedScopes is the list of scopes granted to the OAuth 2.0 client.
 	GrantedScopes []string `json:"granted_scopes"`
 	// GrantedAudience is the list of audiences granted to the OAuth 2.0 client.
@@ -168,6 +170,7 @@ func TokenHook(reg interface {
 
 		request := Request{
 			ClientID:        requester.GetClient().GetID(),
+			RequestedScopes: requester.GetRequestedScopes(),
 			GrantedScopes:   requester.GetGrantedScopes(),
 			GrantedAudience: requester.GetGrantedAudience(),
 			GrantTypes:      requester.GetGrantTypes(),


### PR DESCRIPTION
Add requested scopes to the webhook request, allowing the webhook to condition access based on the scopes requested by the user.


## Related issue(s)

Fixes https://github.com/ory/hydra/issues/3620, particularly implementing the idea proposed in this comment: https://github.com/ory/hydra/issues/3620#issuecomment-1745442682.

If this PR is accepted, I can provide an update to the documentation.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
