### PR TITLE
chore: `Dockerfile` remove redundant directives

### DIFF
--- a/.docker/Dockerfile-alpine
+++ b/.docker/Dockerfile-alpine
@@ -5,6 +5,7 @@ RUN <<HEREDOC
     apk add --no-cache --upgrade ca-certificates
 
     # Add a user/group for Ory with a stable UID + GID:
+    # NOTE: This only appears relevant for supporting hydra as non-root, otherwise unnecessary.
     addgroup --system --gid 500 ory
     adduser --system --uid 500 \
       --gecos "Ory User" \
@@ -15,6 +16,9 @@ RUN <<HEREDOC
 
     # Create the sqlite directory with ownership to that user and group:
     # NOTE: This is required for read/write by SQLite.
+    # - Path may be a default value somewhere, or only explicitly provided via DSN?
+    # - Owner/Group is only relevant to permissions allowing the hydra process to read/write to the location.
+    # - Bind mount volumes will replace the ownership with that of the host directory, requiring correction.
     install --owner ory --group ory --directory /var/lib/sqlite
 HEREDOC
 

--- a/.docker/Dockerfile-alpine
+++ b/.docker/Dockerfile-alpine
@@ -1,16 +1,24 @@
 FROM alpine:3.20
 
-RUN addgroup -S ory; \
-    adduser -S ory -G ory -D -H -s /bin/nologin && \
-    apk upgrade --no-cache && \
+RUN <<HEREDOC
+    apk upgrade --no-cache
     apk add --no-cache --upgrade ca-certificates
 
-COPY hydra /usr/bin/hydra
+    # Add a user/group for Ory with a stable UID + GID:
+    addgroup --system --gid 500 ory
+    adduser --system --uid 500 \
+      --gecos "Ory User" \
+      --home /home/ory \
+      --ingroup ory \
+      --shell /sbin/nologin \
+      ory
 
-# By creating the sqlite folder as the ory user, the mounted volume will be owned by ory:ory, which
-# is required for read/write of SQLite.
-RUN mkdir -p /var/lib/sqlite && \
-    chown ory:ory /var/lib/sqlite
+    # Create the sqlite directory with ownership to that user and group:
+    # NOTE: This is required for read/write by SQLite.
+    install --owner ory --group ory --directory /var/lib/sqlite
+HEREDOC
+
+COPY hydra /usr/bin/hydra
 
 USER ory
 

--- a/.docker/Dockerfile-alpine
+++ b/.docker/Dockerfile-alpine
@@ -7,10 +7,6 @@ RUN addgroup -S ory; \
 
 COPY hydra /usr/bin/hydra
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
-RUN echo 'hosts: files dns' > /etc/nsswitch.conf
-
 # By creating the sqlite folder as the ory user, the mounted volume will be owned by ory:ory, which
 # is required for read/write of SQLite.
 RUN mkdir -p /var/lib/sqlite && \

--- a/.docker/Dockerfile-alpine
+++ b/.docker/Dockerfile-alpine
@@ -20,7 +20,6 @@ HEREDOC
 
 COPY hydra /usr/bin/hydra
 
-USER ory
-
 ENTRYPOINT ["hydra"]
 CMD ["serve", "all"]
+USER ory

--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -23,8 +23,6 @@ FROM gcr.io/distroless/static-debian12:nonroot AS runner
 COPY --from=builder --chown=nonroot:nonroot /var/lib/sqlite /var/lib/sqlite
 COPY --from=builder /usr/bin/hydra /usr/bin/hydra
 
-VOLUME /var/lib/sqlite
-
 # Declare the standard ports used by hydra (4444 for public service endpoint, 4445 for admin service endpoint)
 EXPOSE 4444 4445
 

--- a/.docker/Dockerfile-hsm
+++ b/.docker/Dockerfile-hsm
@@ -53,20 +53,32 @@ ENV HSM_LIBRARY=/usr/lib/softhsm/libsofthsm2.so
 ENV HSM_TOKEN_LABEL=hydra
 ENV HSM_PIN=1234
 
+# NOTE: This is broken already. Even though this image provides a shell, you'd need to configure it with
+# `SHELL ["/busybox/sh", "-c"]`, however `apt-get` does not exist either in a distroless image.
+# This was original an Alpine image, the refactoring was not verified properly in this commit:
+# https://github.com/ory/hydra/commit/c1e1a569621d88365dceee7372ca49ecd119f939#diff-ae54bef08e3587b28ad8e93eb253a9a5cd9ea6f4251977e35b88dc6b42329e25L31
 RUN apt-get -y install softhsm opensc &&\
     pkcs11-tool --module "$HSM_LIBRARY" --slot 0 --init-token --so-pin 0000 --init-pin --pin "$HSM_PIN" --label "$HSM_TOKEN_LABEL"
 
-RUN addgroup -S ory; \
-    adduser -S ory -G ory -D  -h /home/ory -s /bin/nologin; \
-    chown -R ory:ory /home/ory; \
+RUN <<HEREDOC
+    # Add a user/group for Ory with a stable UID + GID:
+    addgroup --system --gid 500 ory
+    adduser --system --uid 500 \
+        --gecos "Ory User" \
+        --home /home/ory \
+        --ingroup ory \
+        --shell /sbin/nologin \
+        ory
+
+    # Create the sqlite directory with ownership to that user and group:
+    # NOTE: This is required for read/write by SQLite.
+    install --owner ory --group ory --directory /var/lib/sqlite
+
+    # NOTE: Presumably this was already created by the prior RUN directive
     chown -R ory:ory /var/lib/softhsm/tokens
+HEREDOC
 
 COPY --from=build-hydra /usr/bin/hydra /usr/bin/hydra
-
-# By creating the sqlite folder as the ory user, the mounted volume will be owned by ory:ory, which
-# is required for read/write of SQLite.
-RUN mkdir -p /var/lib/sqlite && \
-    chown ory:ory /var/lib/sqlite
 
 VOLUME /var/lib/sqlite
 
@@ -76,7 +88,6 @@ VOLUME /home/ory
 # Declare the standard ports used by hydra (4444 for public service endpoint, 4445 for admin service endpoint)
 EXPOSE 4444 4445
 
-USER ory
-
 ENTRYPOINT ["hydra"]
 CMD ["serve"]
+USER ory

--- a/.docker/Dockerfile-hsm
+++ b/.docker/Dockerfile-hsm
@@ -80,11 +80,6 @@ HEREDOC
 
 COPY --from=build-hydra /usr/bin/hydra /usr/bin/hydra
 
-VOLUME /var/lib/sqlite
-
-# Exposing the ory home directory
-VOLUME /home/ory
-
 # Declare the standard ports used by hydra (4444 for public service endpoint, 4445 for admin service endpoint)
 EXPOSE 4444 4445
 

--- a/.docker/Dockerfile-scratch
+++ b/.docker/Dockerfile-scratch
@@ -1,20 +1,28 @@
-FROM alpine:3.20
+FROM alpine:3.20 AS base-files
 
-RUN apk upgrade --no-cache && \
+RUN <<HEREDOC
+    apk upgrade --no-cache
     apk add --no-cache --upgrade ca-certificates
 
-RUN addgroup -S ory; \
-    adduser -S ory -G ory -D  -h /home/ory -s /bin/nologin;
+    # Add a user/group for Ory with a stable UID + GID:
+    addgroup --system --gid 500 ory
+    adduser --system --uid 500 \
+      --gecos "Ory User" \
+      --home /home/ory \
+      --ingroup ory \
+      --shell /sbin/nologin \
+      ory
 
-RUN mkdir -p /var/lib/sqlite && \
-    chown -R ory:ory /var/lib/sqlite
+    # Create the sqlite directory with ownership to that user and group:
+    install --owner ory --group ory --directory /var/lib/sqlite
+HEREDOC
 
 FROM scratch
-
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=0 /etc/nsswitch.conf /etc/nsswitch.conf
-COPY --from=0 /etc/passwd /etc/passwd
-COPY --from=0 /var/lib/sqlite /var/lib/sqlite
+COPY --from=base-files /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base-files /etc/nsswitch.conf /etc/nsswitch.conf
+# NOTE: /etc/group and /etc/shadow were not copied over, only user lookup is valid for `USER`:
+COPY --from=base-files /etc/passwd /etc/passwd
+COPY --from=base-files /var/lib/sqlite /var/lib/sqlite
 
 COPY hydra /usr/bin/hydra
 

--- a/.docker/Dockerfile-scratch
+++ b/.docker/Dockerfile-scratch
@@ -14,6 +14,7 @@ RUN <<HEREDOC
       ory
 
     # Create the sqlite directory with ownership to that user and group:
+    # NOTE: This is required for read/write by SQLite.
     install --owner ory --group ory --directory /var/lib/sqlite
 HEREDOC
 
@@ -22,11 +23,11 @@ COPY --from=base-files /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=base-files /etc/nsswitch.conf /etc/nsswitch.conf
 # NOTE: /etc/group and /etc/shadow were not copied over, only user lookup is valid for `USER`:
 COPY --from=base-files /etc/passwd /etc/passwd
+# NOTE: This COPY defaults to 0:0 for ownership, voiding the requirement conveyed above
 COPY --from=base-files /var/lib/sqlite /var/lib/sqlite
 
 COPY hydra /usr/bin/hydra
 
-USER ory
-
 ENTRYPOINT ["hydra"]
 CMD ["serve", "all"]
+USER ory

--- a/.docker/Dockerfile-scratch
+++ b/.docker/Dockerfile-scratch
@@ -1,3 +1,8 @@
+# TODO: Remove this file in favor of distroless-static variant:
+# https://github.com/ory/hydra/blob/master/.docker/Dockerfile-distroless-static
+# However if published to any registry, continue to publish the variant tag but as an alias to `-distroless` tags:
+# https://github.com/ory/hydra/pull/3914#pullrequestreview-2527315326
+
 FROM alpine:3.20 AS base-files
 
 RUN <<HEREDOC
@@ -5,6 +10,7 @@ RUN <<HEREDOC
     apk add --no-cache --upgrade ca-certificates
 
     # Add a user/group for Ory with a stable UID + GID:
+    # NOTE: This only appears relevant for supporting hydra as non-root, otherwise unnecessary.
     addgroup --system --gid 500 ory
     adduser --system --uid 500 \
       --gecos "Ory User" \
@@ -15,6 +21,8 @@ RUN <<HEREDOC
 
     # Create the sqlite directory with ownership to that user and group:
     # NOTE: This is required for read/write by SQLite.
+    # - Path may be a default value somewhere, or only explicitly provided via DSN?
+    # - Owner/Group is only relevant to permissions allowing the hydra process to read/write to the location.
     install --owner ory --group ory --directory /var/lib/sqlite
 HEREDOC
 

--- a/.docker/Dockerfile-scratch
+++ b/.docker/Dockerfile-scratch
@@ -3,10 +3,6 @@ FROM alpine:3.20
 RUN apk upgrade --no-cache && \
     apk add --no-cache --upgrade ca-certificates
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-
 RUN addgroup -S ory; \
     adduser -S ory -G ory -D  -h /home/ory -s /bin/nologin;
 

--- a/.docker/Dockerfile-sqlite
+++ b/.docker/Dockerfile-sqlite
@@ -7,20 +7,27 @@ FROM alpine:3.20
 #
 #   /home/ory/sqlite/some-file.
 
-RUN addgroup -S ory; \
-    adduser -S ory -G ory -D  -h /home/ory -s /bin/nologin; \
-    chown -R ory:ory /home/ory && \
-    apk upgrade --no-cache && \
+RUN <<HEREDOC
+    apk upgrade --no-cache
     apk add --no-cache --upgrade --latest ca-certificates sqlite
+
+    # Add a user/group for Ory with a stable UID + GID:
+    addgroup --system --gid 500 ory
+    adduser --system --uid 500 \
+      --gecos "Ory User" \
+      --home /home/ory \
+      --ingroup ory \
+      --shell /sbin/nologin \
+      ory
+
+    # Create the sqlite directory with ownership to that user and group:
+    # NOTE: This is required for read/write by SQLite.
+    install --owner ory --group ory --directory /var/lib/sqlite
+HEREDOC
 
 WORKDIR /home/ory
 
 COPY hydra /usr/bin/hydra
-
-# By creating the sqlite folder as the ory user, the mounted volume will be owned by ory:ory, which
-# is required for read/write of SQLite.
-RUN mkdir -p /var/lib/sqlite && \
-    chown ory:ory /var/lib/sqlite
 
 VOLUME /var/lib/sqlite
 
@@ -30,7 +37,6 @@ VOLUME /home/ory
 # Declare the standard ports used by Hydra (4444 for public service endpoint, 4445 for admin service endpoint)
 EXPOSE 4444 4445
 
-USER ory
-
 ENTRYPOINT ["hydra"]
 CMD ["serve"]
+USER ory

--- a/.docker/Dockerfile-sqlite
+++ b/.docker/Dockerfile-sqlite
@@ -25,14 +25,7 @@ RUN <<HEREDOC
     install --owner ory --group ory --directory /var/lib/sqlite
 HEREDOC
 
-WORKDIR /home/ory
-
 COPY hydra /usr/bin/hydra
-
-VOLUME /var/lib/sqlite
-
-# Exposing the ory home directory
-VOLUME /home/ory
 
 # Declare the standard ports used by Hydra (4444 for public service endpoint, 4445 for admin service endpoint)
 EXPOSE 4444 4445

--- a/.docker/Dockerfile-sqlite
+++ b/.docker/Dockerfile-sqlite
@@ -1,17 +1,16 @@
+# TODO: Remove this file in favor of the main/default Alpine image. The sqlite package is no longer required:
+# https://github.com/ory/hydra/blob/master/.docker/Dockerfile-alpine
+# However if published to any registry, continue to publish the variant tag but as an alias to standard Alpine image tags:
+# https://github.com/ory/hydra/pull/3914#pullrequestreview-2527315326
+
 FROM alpine:3.20
-
-# Because this image is built for SQLite, we create /home/ory and /home/ory/sqlite which is owned by the ory user
-# and declare /home/ory/sqlite a volume.
-#
-# To get SQLite and Docker Volumes working with this image, mount the volume where SQLite should be written to at:
-#
-#   /home/ory/sqlite/some-file.
-
 RUN <<HEREDOC
+    # NOTE: The sqlite package is not required when the later copied hydra binary is built with statically linked sqlite?
     apk upgrade --no-cache
     apk add --no-cache --upgrade --latest ca-certificates sqlite
 
     # Add a user/group for Ory with a stable UID + GID:
+    # NOTE: This only appears relevant for supporting hydra as non-root, otherwise unnecessary.
     addgroup --system --gid 500 ory
     adduser --system --uid 500 \
       --gecos "Ory User" \
@@ -22,6 +21,8 @@ RUN <<HEREDOC
 
     # Create the sqlite directory with ownership to that user and group:
     # NOTE: This is required for read/write by SQLite.
+    # - Path may be a default value somewhere, or only explicitly provided via DSN?
+    # - Owner/Group is only relevant to permissions allowing the hydra process to read/write to the location.
     install --owner ory --group ory --directory /var/lib/sqlite
 HEREDOC
 


### PR DESCRIPTION
- Removes the `/etc/nsswitch.conf` workaround.
- Removes the redundant usage of `VOLUME` directives.

## Related issue(s)

The associated issues have been ignored for over a year. They've now been marked as stale, this PR attempts to address them for this repo.

- https://github.com/ory/hydra/issues/3685
- https://github.com/ory/hydra/issues/3683

See the issues for detailed justification of the summarized changes.

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

These changes should be rather straight-forward. The bulk of the changeset is just noise repeating the same lines across several Dockerfiles, but I did notice inconsistencies which hint that these files may need to be revisited by someone more familiar with them.

Especially with the HSM image which appears to have had the `runner` stage broken since [this June 2023 PR](https://github.com/ory/hydra/pull/3539). though only earlier stages are built with the Makefile:

https://github.com/ory/hydra/blob/8e71f9178d9a21dead8a260bae60b8406710cf5b/Makefile#L89-L96

The HSM quickstart compose example should attempt to build the `runner` stage and fail:

https://github.com/ory/hydra/blob/8e71f9178d9a21dead8a260bae60b8406710cf5b/quickstart-hsm.yml#L16
