### PR TITLE
fix: cgroups auto-tune before driver configuration

### DIFF
--- a/cmd/server/handler.go
+++ b/cmd/server/handler.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rs/cors"
 	"github.com/spf13/cobra"
 	"github.com/urfave/negroni"
-	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/ory/graceful"
 	"github.com/ory/x/healthx"
@@ -190,14 +189,6 @@ func RunServeAll(slOpts []servicelocatorx.Option, dOpts []driver.OptionsModifier
 
 func setup(ctx context.Context, d driver.Registry, cmd *cobra.Command) (admin *httprouterx.RouterAdmin, public *httprouterx.RouterPublic, adminmw, publicmw *negroni.Negroni) {
 	fmt.Println(banner(config.Version))
-
-	if d.Config().CGroupsV1AutoMaxProcsEnabled() {
-		_, err := maxprocs.Set(maxprocs.Logger(d.Logger().Infof))
-
-		if err != nil {
-			d.Logger().WithError(err).Fatal("Couldn't set GOMAXPROCS")
-		}
-	}
 
 	adminmw = negroni.New()
 	publicmw = negroni.New()

--- a/driver/factory.go
+++ b/driver/factory.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 
 	"github.com/pkg/errors"
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/ory/hydra/v2/driver/config"
 	"github.com/ory/hydra/v2/fositex"
@@ -138,6 +139,14 @@ func New(ctx context.Context, sl *servicelocatorx.Options, opts []OptionsModifie
 	if o.validate {
 		if err := config.Validate(ctx, l, c); err != nil {
 			return nil, err
+		}
+	}
+
+	if c.CGroupsV1AutoMaxProcsEnabled() {
+		_, err := maxprocs.Set(maxprocs.Logger(l.Infof))
+
+		if err != nil {
+			l.WithError(err).Fatal("Couldn't set GOMAXPROCS")
 		}
 	}
 


### PR DESCRIPTION
Move the cgroups auto-tuning into the driver factory so that its effect is automatically applied to the database connection pool defaults.

BREAKING CHANGE: Automatic GOMAXPROCS tuning based on cgroups influences the default database connection limits. Set connection limits explicitly based on the number of CPUs in the deployment to keep previous behavior.

## Related issue(s)

There is no issue filed because the behavior is not clearly documented one way or another. The database documentation states that the default connection limit is twice the number of CPUs, but it is undocumented that GOMAXPROCS changes this default.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).