### PR TITLE
fix: use up-to-date `kid` in JWT header when refreshing

### DIFF
--- a/cypress/helpers/index.js
+++ b/cypress/helpers/index.js
@@ -98,3 +98,20 @@ const deleteGrant = (id) =>
     "DELETE",
     Cypress.env("admin_url") + "/trust/grants/jwt-bearer/issuers/" + id,
   )
+
+export const validateJwt = (jwt) =>
+  cy
+    .request({
+      method: "POST",
+      url: `${Cypress.env("client_url")}/oauth2/validate-jwt`,
+      form: true,
+      body: { jwt },
+    })
+    .then(({ body }) => body)
+
+export const rotateJwks = (set) =>
+  cy
+    .request("POST", `${Cypress.env("admin_url")}/keys/${set}`, {
+      alg: "RS256",
+    })
+    .then(({ body }) => body)

--- a/cypress/integration/oauth2/jwt.js
+++ b/cypress/integration/oauth2/jwt.js
@@ -1,7 +1,7 @@
 // Copyright © 2022 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-import { createClient, prng } from "../../helpers"
+import { createClient, prng, validateJwt } from "../../helpers"
 
 const accessTokenStrategies = ["opaque", "jwt"]
 
@@ -44,15 +44,12 @@ describe("OAuth 2.0 JSON Web Token Access Tokens", () => {
               expect(token.refresh_token).to.not.be.empty
               expect(token.access_token.split(".").length).to.equal(3)
               expect(token.refresh_token.split(".").length).to.equal(2)
-            })
 
-          cy.request(`${Cypress.env("client_url")}/oauth2/validate-jwt`)
-            .its("body")
-            .then((body) => {
-              console.log(body)
-              expect(body.sub).to.eq("foo@bar.com")
-              expect(body.client_id).to.eq(client.client_id)
-              expect(body.jti).to.not.be.empty
+              validateJwt(token.access_token).then(({ payload }) => {
+                expect(payload.sub).to.eq("foo@bar.com")
+                expect(payload.client_id).to.eq(client.client_id)
+                expect(payload.jti).to.not.be.empty
+              })
             })
         })
       })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -196,10 +196,9 @@ Cypress.Commands.add(
       })
     }
     if (doCreateClient) {
-      createClient(client).then(run)
-      return
+      return createClient(client).then(run)
     }
-    run(client)
+    return run(client)
   },
 )
 

--- a/test/e2e/oauth2-client/src/index.js
+++ b/test/e2e/oauth2-client/src/index.js
@@ -179,23 +179,24 @@ app.get("/oauth2/revoke", (req, res) => {
     })
 })
 
-app.get("/oauth2/validate-jwt", (req, res) => {
+app.post("/oauth2/validate-jwt", (req, res) => {
   const client = jwksClient({
     jwksUri: new URL("/.well-known/jwks.json", config.public).toString(),
   })
 
   jwt.verify(
-    req.session.oauth2_flow.token.access_token,
+    req.body.jwt,
     (header, callback) => {
       client.getSigningKey(header.kid, function (err, key) {
         const signingKey = key.publicKey || key.rsaPublicKey
         callback(null, signingKey)
       })
     },
+    { complete: true },
     (err, decoded) => {
       if (err) {
         console.error(err)
-        res.send(400)
+        res.status(400).send(JSON.stringify({ error: err.toString() }))
         return
       }
 


### PR DESCRIPTION
When you rotate any of the JWT signing keys (`hydra.jwt.access-token`/`hydra.openid.id-token`, Hydra will (as expected) sign all new JWTs with the new key - including any JWTs from a refresh token grant flow. However, for any refresh token chain that existed before the key rotation Hydra will incorrectly use the `kid` of the old key in the JWT header. This effectively breaks/poisons all issued refresh tokens on key rotation since all future access/id tokens they provide will be invalid. See the new test for a reproducible example.

I consider this to be a _critical_ bug.

## Related issue(s)

#3573, #3719

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] (Not relevant) I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

The underlying problem is that the JWT signing mechanism doesn't control the `kid` in the JWT header - it's picked separately and stored in `Session`. So ideally, we would  either instruct Fosite which key to use or respect the key that Fosite chooses. As pointed out in #3573, if we do not set the KIDs Fosite will use the correct `kid`. However, because we include the KIDs in the token hook upfront before we sign the JWTs it would be a breaking change to omit it. It seems non-trivial (for me at least) to refactor the codebase so the KIDs used in the actual JWT signing code is the source of truth for the KIDs provided in the token hook - mostly because the hook must run before the signing.

Therefore, I've opted for being consistent with how it's done for the initial authorization/token exchange. On the start of every refresh token grant we set the KIDs in the `Session` to correspond to the newest keys. This is not a perfect solution, but is a huge improvement over the current situation without making big changes. It goes from "guaranteed" breaking of all JWTs from existing refresh tokens to "very unlikely". Given the severity of this bug, I think it makes sense to first make a smaller fix and then follow up later with larger structural improvements.

What do you think?