### PR TITLE
fix: client command example using v2 option

### DIFF
--- a/cmd/cmd_create_client.go
+++ b/cmd/cmd_create_client.go
@@ -57,7 +57,7 @@ func NewCreateClientsCommand() *cobra.Command {
 		Short:   "Create an OAuth 2.0 Client",
 		Aliases: []string{"client"},
 		Args:    cobra.NoArgs,
-		Example: `{{ .CommandPath }} -n "my app" -c http://localhost/cb -g authorization_code -r code -a core,foobar
+		Example: `{{ .CommandPath }} --name "my app" --redirect-uri http://localhost/cb --grant-type authorization_code --response-type code --scope core,foobar
 
 Use the tool jq (or any other JSON tool) to get the OAuth2 Client ID and Secret:
 
@@ -74,7 +74,7 @@ the Authorize Code, Implicit, Refresh flow. This command allows settings all fie
 
 To encrypt an auto-generated OAuth2 Client Secret, use flags ` + "`--pgp-key`" + `, ` + "`--pgp-key-url`" + ` or ` + "`--keybase`" + ` flag, for example:
 
-  {{ .CommandPath }} -n "my app" -g client_credentials -r token -a core,foobar --keybase keybase_username
+  {{ .CommandPath }} --name "my app" --grant-type client_credentials --response-type token --scope core,foobar --keybase keybase_username
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			m, _, err := cliclient.NewClient(cmd)

--- a/cmd/cmd_import_client.go
+++ b/cmd/cmd_import_client.go
@@ -47,7 +47,7 @@ Alternatively:
 
 To encrypt an auto-generated OAuth2 Client Secret, use flags ` + "`--pgp-key`" + `, ` + "`--pgp-key-url`" + ` or ` + "`--keybase`" + ` flag, for example:
 
-  {{ .CommandPath }} -n "my app" -g client_credentials -r token -a core,foobar --keybase keybase_username
+  hydra create client --name "my app" --grant-types client_credentials --response-type token --scope core,foobar --keybase keybase_username
 `,
 		Long: `This command reads in each listed JSON file and imports their contents as a list of OAuth 2.0 Clients.
 

--- a/cmd/cmd_import_client.go
+++ b/cmd/cmd_import_client.go
@@ -47,7 +47,7 @@ Alternatively:
 
 To encrypt an auto-generated OAuth2 Client Secret, use flags ` + "`--pgp-key`" + `, ` + "`--pgp-key-url`" + ` or ` + "`--keybase`" + ` flag, for example:
 
-  hydra create client --name "my app" --grant-types client_credentials --response-type token --scope core,foobar --keybase keybase_username
+  {{ .CommandPath }} --name "my app" --grant-type client_credentials --response-type token --scope core,foobar --keybase keybase_username
 `,
 		Long: `This command reads in each listed JSON file and imports their contents as a list of OAuth 2.0 Clients.
 

--- a/cmd/cmd_update_client.go
+++ b/cmd/cmd_update_client.go
@@ -22,11 +22,11 @@ func NewUpdateClientCmd() *cobra.Command {
 		Aliases: []string{"client"},
 		Short:   "Update an OAuth 2.0 Client",
 		Args:    cobra.ExactArgs(1),
-		Example: `{{ .CommandPath }} <client-id-here> -c http://localhost/cb -g authorization_code -r code -a core,foobar
+		Example: `{{ .CommandPath }} <client-id-here> --redirect-uri http://localhost/cb --grant-type authorization_code --response-type code --scope core,foobar
 
 To encrypt an auto-generated OAuth2 Client Secret, use flags ` + "`--pgp-key`" + `, ` + "`--pgp-key-url`" + ` or ` + "`--keybase`" + ` flag, for example:
 
-  {{ .CommandPath }} e6e96aa5-9cd2-4a70-bf56-ad6434c8aaa2 -n "my app" -g client_credentials -r token -a core,foobar --keybase keybase_username
+  {{ .CommandPath }} e6e96aa5-9cd2-4a70-bf56-ad6434c8aaa2 --name "my app" --grant-type client_credentials --response-type token --scope core,foobar --keybase keybase_username
 `,
 		Long: `This command replaces an OAuth 2.0 Client by its ID. Please be aware that this command replaces the entire client. If only the name flag (-n "my updated app") is provided, the all other fields are updated to their default values.`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
The examples of these three commands are based on hydra v1 cli option.
* `hydra create client`
* `hydra import client`
* `hydra update client`

When I follow the examples using hydra v2 cli, it didn't work. I got the message like `unknown shorthand flag: 'n' in -n`.
I updated these three commands example using v2 option.

<!--
Describe the big picture of your achanges here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

```console
# The examples and usage section are using v1 options.
$ docker run --rm -it oryd/hydra:v2.3.0 create client --help
...
  hydra create oauth2-client -n "my app" -g client_credentials -r token -a core,foobar --keybase keybase_username
...
Examples:
hydra create oauth2-client -n "my app" -c http://localhost/cb -g authorization_code -r code -a core,foobar


# follows the example
$ docker run --rm -it oryd/hydra:v2.3.0 create oauth2-client -n "my app" -c http://localhost/cb -g authorization_code -r code -a core,foobar
Error: unknown shorthand flag: 'n' in -n
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
   - The page like https://www.ory.sh/docs/hydra/cli/hydra-create-client will be generated automatically, I guess.  Also written here https://github.com/ory/docs?tab=readme-ov-file#cli-and-api-reference---auto-generated-content. So I didn't edit docs.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

Since this is my first time to submit pr to this repo, please tell me if I missed anything.
