### PR TITLE
fix: allow updating when JWKS URI is set (#3935)

### DIFF
--- a/client/sdk_test.go
+++ b/client/sdk_test.go
@@ -230,4 +230,20 @@ func TestClientSDK(t *testing.T) {
 		// secret hashes shouldn't change between these PUT calls
 		require.Equal(t, result1.ClientSecret, result2.ClientSecret)
 	})
+
+	t.Run("case=patch client that has JSONWebKeysURI", func(t *testing.T) {
+		op := "replace"
+		path := "/client_name"
+		value := "test"
+
+		client := createTestClient("")
+		client.SetJwksUri("https://example.org/.well-known/jwks.json")
+		created, _, err := c.OAuth2API.CreateOAuth2Client(context.Background()).OAuth2Client(client).Execute()
+		require.NoError(t, err)
+		client.ClientId = created.ClientId
+
+		result, _, err := c.OAuth2API.PatchOAuth2Client(context.Background(), *client.ClientId).JsonPatch([]hydra.JsonPatch{{Op: op, Path: path, Value: value}}).Execute()
+		require.NoError(t, err)
+		require.Equal(t, value, pointerx.Deref(result.ClientName))
+	})
 }

--- a/client/validator.go
+++ b/client/validator.go
@@ -54,7 +54,7 @@ func (v *Validator) Validate(ctx context.Context, c *Client) error {
 	if c.TokenEndpointAuthMethod == "" {
 		c.TokenEndpointAuthMethod = "client_secret_basic"
 	} else if c.TokenEndpointAuthMethod == "private_key_jwt" {
-		if len(c.JSONWebKeysURI) == 0 && c.JSONWebKeys == nil {
+		if len(c.JSONWebKeysURI) == 0 && c.GetJSONWebKeys() == nil {
 			return errorsx.WithStack(ErrInvalidClientMetadata.WithHint("When token_endpoint_auth_method is 'private_key_jwt', either jwks or jwks_uri must be set."))
 		}
 		if c.TokenEndpointAuthSigningAlgorithm != "" && !isSupportedAuthTokenSigningAlg(c.TokenEndpointAuthSigningAlgorithm) {
@@ -62,12 +62,12 @@ func (v *Validator) Validate(ctx context.Context, c *Client) error {
 		}
 	}
 
-	if len(c.JSONWebKeysURI) > 0 && c.JSONWebKeys != nil {
+	if len(c.JSONWebKeysURI) > 0 && c.GetJSONWebKeys() != nil {
 		return errorsx.WithStack(ErrInvalidClientMetadata.WithHint("Fields jwks and jwks_uri can not both be set, you must choose one."))
 	}
 
-	if c.JSONWebKeys != nil && c.JSONWebKeys.JSONWebKeySet != nil {
-		for _, k := range c.JSONWebKeys.Keys {
+	if jsonWebKeys := c.GetJSONWebKeys(); jsonWebKeys != nil {
+		for _, k := range jsonWebKeys.Keys {
 			if !k.Valid() {
 				return errorsx.WithStack(ErrInvalidClientMetadata.WithHint("Invalid JSON web key in set."))
 			}

--- a/client/validator_test.go
+++ b/client/validator_test.go
@@ -113,6 +113,12 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			in: &Client{ID: "foo", JSONWebKeys: new(x.JoseJSONWebKeySet), JSONWebKeysURI: "https://example.org/jwks.json"},
+			check: func(t *testing.T, c *Client) {
+				assert.Nil(t, c.GetJSONWebKeys())
+			},
+		},
+		{
 			in:        &Client{ID: "foo", PostLogoutRedirectURIs: []string{"https://bar/"}, RedirectURIs: []string{"https://foo/"}},
 			assertErr: assert.Error,
 		},


### PR DESCRIPTION
The validator rejects updates when `JSONWebKeysURI` is non-empty and `JSONWebKeys` is not nil, but this field is set to `new(x.JoseJSONWebKeySet)` in Client's `BeforeSave`.

## Related issue(s)

#3935 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
