### PR TITLE
fix: revoke by consent request ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ quicktest-hsm:
 
 .PHONY: test-refresh
 test-refresh:
-	UPDATE_SNAPSHOTS=true go test -failfast -short -tags sqlite,sqlite_omit_load_extension ./...
+	UPDATE_SNAPSHOTS=true go test -short -tags sqlite,sqlite_omit_load_extension ./...
 	DOCKER_CONTENT_TRUST=1 docker build --progress=plain -f .docker/Dockerfile-test-hsm  --target test-refresh-hsm -t oryd/hydra:${IMAGE_TAG} --target test-refresh-hsm .
 
 authors:  # updates the AUTHORS file

--- a/consent/handler_test.go
+++ b/consent/handler_test.go
@@ -187,18 +187,18 @@ func TestGetConsentRequest(t *testing.T) {
 				challenge, err = f.ToConsentChallenge(ctx, reg)
 				require.NoError(t, err)
 				require.NoError(t, reg.ConsentManager().CreateConsentRequest(ctx, f, &flow.OAuth2ConsentRequest{
-					Client:         cl,
-					ID:             challenge,
-					Verifier:       challenge,
-					CSRF:           challenge,
-					LoginChallenge: sqlxx.NullString(lr.ID),
+					Client:           cl,
+					ConsentRequestID: challenge,
+					Verifier:         challenge,
+					CSRF:             challenge,
+					LoginChallenge:   sqlxx.NullString(lr.ID),
 				}))
 
 				if tc.handled {
 					_, err := reg.ConsentManager().HandleConsentRequest(ctx, f, &flow.AcceptOAuth2ConsentRequest{
-						ID:         challenge,
-						WasHandled: true,
-						HandledAt:  sqlxx.NullTime(time.Now()),
+						ConsentRequestID: challenge,
+						WasHandled:       true,
+						HandledAt:        sqlxx.NullTime(time.Now()),
 					})
 					require.NoError(t, err)
 					challenge, err = f.ToConsentChallenge(ctx, reg)

--- a/consent/helper_test.go
+++ b/consent/helper_test.go
@@ -39,52 +39,52 @@ func TestSanitizeClient(t *testing.T) {
 
 func TestMatchScopes(t *testing.T) {
 	for k, tc := range []struct {
-		granted         []flow.AcceptOAuth2ConsentRequest
-		requested       []string
-		expectChallenge string
+		granted    []flow.AcceptOAuth2ConsentRequest
+		requested  []string
+		expectedID string
 	}{
 		{
-			granted:         []flow.AcceptOAuth2ConsentRequest{{ID: "1", GrantedScope: []string{"foo", "bar"}}},
-			requested:       []string{"foo", "bar"},
-			expectChallenge: "1",
+			granted:    []flow.AcceptOAuth2ConsentRequest{{ConsentRequestID: "1", GrantedScope: []string{"foo", "bar"}}},
+			requested:  []string{"foo", "bar"},
+			expectedID: "1",
 		},
 		{
-			granted:         []flow.AcceptOAuth2ConsentRequest{{ID: "1", GrantedScope: []string{"foo", "bar"}}},
-			requested:       []string{"foo", "bar", "baz"},
-			expectChallenge: "",
-		},
-		{
-			granted: []flow.AcceptOAuth2ConsentRequest{
-				{ID: "1", GrantedScope: []string{"foo", "bar"}},
-				{ID: "2", GrantedScope: []string{"foo", "bar"}},
-			},
-			requested:       []string{"foo", "bar"},
-			expectChallenge: "1",
+			granted:    []flow.AcceptOAuth2ConsentRequest{{ConsentRequestID: "1", GrantedScope: []string{"foo", "bar"}}},
+			requested:  []string{"foo", "bar", "baz"},
+			expectedID: "",
 		},
 		{
 			granted: []flow.AcceptOAuth2ConsentRequest{
-				{ID: "1", GrantedScope: []string{"foo", "bar"}},
-				{ID: "2", GrantedScope: []string{"foo", "bar", "baz"}},
+				{ConsentRequestID: "1", GrantedScope: []string{"foo", "bar"}},
+				{ConsentRequestID: "2", GrantedScope: []string{"foo", "bar"}},
 			},
-			requested:       []string{"foo", "bar", "baz"},
-			expectChallenge: "2",
+			requested:  []string{"foo", "bar"},
+			expectedID: "1",
 		},
 		{
 			granted: []flow.AcceptOAuth2ConsentRequest{
-				{ID: "1", GrantedScope: []string{"foo", "bar"}},
-				{ID: "2", GrantedScope: []string{"foo", "bar", "baz"}},
+				{ConsentRequestID: "1", GrantedScope: []string{"foo", "bar"}},
+				{ConsentRequestID: "2", GrantedScope: []string{"foo", "bar", "baz"}},
 			},
-			requested:       []string{"zab"},
-			expectChallenge: "",
+			requested:  []string{"foo", "bar", "baz"},
+			expectedID: "2",
+		},
+		{
+			granted: []flow.AcceptOAuth2ConsentRequest{
+				{ConsentRequestID: "1", GrantedScope: []string{"foo", "bar"}},
+				{ConsentRequestID: "2", GrantedScope: []string{"foo", "bar", "baz"}},
+			},
+			requested:  []string{"zab"},
+			expectedID: "",
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
 			got := matchScopes(fosite.ExactScopeStrategy, tc.granted, tc.requested)
-			if tc.expectChallenge == "" {
+			if tc.expectedID == "" {
 				assert.Nil(t, got)
 				return
 			}
-			assert.Equal(t, tc.expectChallenge, got.ID)
+			assert.Equal(t, tc.expectedID, got.ConsentRequestID)
 		})
 	}
 }

--- a/consent/janitor_consent_test_helper.go
+++ b/consent/janitor_consent_test_helper.go
@@ -32,7 +32,7 @@ func NewHandledLoginRequest(challenge string, hasError bool, requestedAt time.Ti
 	}
 }
 
-func NewHandledConsentRequest(challenge string, hasError bool, requestedAt time.Time, authenticatedAt sqlxx.NullTime) *flow.AcceptOAuth2ConsentRequest {
+func NewHandledConsentRequest(consentRequestID string, hasError bool, requestedAt time.Time, authenticatedAt sqlxx.NullTime) *flow.AcceptOAuth2ConsentRequest {
 	var deniedErr *flow.RequestDeniedError
 	if hasError {
 		deniedErr = &flow.RequestDeniedError{
@@ -46,11 +46,11 @@ func NewHandledConsentRequest(challenge string, hasError bool, requestedAt time.
 	}
 
 	return &flow.AcceptOAuth2ConsentRequest{
-		ID:              challenge,
-		HandledAt:       sqlxx.NullTime(time.Now().Round(time.Second)),
-		Error:           deniedErr,
-		RequestedAt:     requestedAt,
-		AuthenticatedAt: authenticatedAt,
-		WasHandled:      true,
+		ConsentRequestID: consentRequestID,
+		HandledAt:        sqlxx.NullTime(time.Now().Round(time.Second)),
+		Error:            deniedErr,
+		RequestedAt:      requestedAt,
+		AuthenticatedAt:  authenticatedAt,
+		WasHandled:       true,
 	}
 }

--- a/consent/manager.go
+++ b/consent/manager.go
@@ -30,7 +30,7 @@ type (
 		HandleConsentRequest(ctx context.Context, f *flow.Flow, r *flow.AcceptOAuth2ConsentRequest) (*flow.OAuth2ConsentRequest, error)
 		RevokeSubjectConsentSession(ctx context.Context, user string) error
 		RevokeSubjectClientConsentSession(ctx context.Context, user, client string) error
-		RevokeConsentSessionByID(ctx context.Context, consentChallengeID string) error
+		RevokeConsentSessionByID(ctx context.Context, consentRequestID string) error
 
 		VerifyAndInvalidateConsentRequest(ctx context.Context, verifier string) (*flow.AcceptOAuth2ConsentRequest, error)
 		FindGrantedAndRememberedConsentRequests(ctx context.Context, client, user string) ([]flow.AcceptOAuth2ConsentRequest, error)

--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -585,13 +585,13 @@ func (s *DefaultStrategy) forwardConsentRequest(
 
 	// Set up csrf/challenge/verifier values
 	verifier := strings.Replace(uuid.New(), "-", "", -1)
-	consentChallengeID := strings.Replace(uuid.New(), "-", "", -1)
+	consentRequestID := strings.Replace(uuid.New(), "-", "", -1)
 	csrf := strings.Replace(uuid.New(), "-", "", -1)
 
 	cl := sanitizeClientFromRequest(ar)
 
 	consentRequest := &flow.OAuth2ConsentRequest{
-		ID:                     consentChallengeID,
+		ConsentRequestID:       consentRequestID,
 		ACR:                    as.ACR,
 		AMR:                    as.AMR,
 		Verifier:               verifier,

--- a/consent/strategy_default_test.go
+++ b/consent/strategy_default_test.go
@@ -47,7 +47,7 @@ func checkAndAcceptConsentHandler(t *testing.T, apiClient *hydra.APIClient, cb f
 		payload := cb(t, res, err)
 
 		v, _, err := apiClient.OAuth2API.AcceptOAuth2ConsentRequest(context.Background()).
-			ConsentChallenge(r.URL.Query().Get("consent_challenge")).
+			ConsentChallenge(res.Challenge).
 			AcceptOAuth2ConsentRequest(payload).
 			Execute()
 		require.NoError(t, err)

--- a/consent/strategy_oauth_test.go
+++ b/consent/strategy_oauth_test.go
@@ -207,11 +207,12 @@ func TestStrategyLoginConsentNext(t *testing.T) {
 
 		testhelpers.NewLoginConsentUI(t, reg.Config(),
 			func(w http.ResponseWriter, r *http.Request) {
+				loginChallenge = r.URL.Query().Get("login_challenge")
 				res, _, err := adminClient.OAuth2API.GetOAuth2LoginRequest(ctx).
-					LoginChallenge(r.URL.Query().Get("login_challenge")).
+					LoginChallenge(loginChallenge).
 					Execute()
 				require.NoError(t, err)
-				loginChallenge = res.Challenge
+				require.Equal(t, loginChallenge, res.Challenge)
 
 				v, _, err := adminClient.OAuth2API.AcceptOAuth2LoginRequest(ctx).
 					LoginChallenge(loginChallenge).
@@ -223,10 +224,11 @@ func TestStrategyLoginConsentNext(t *testing.T) {
 			},
 			func(w http.ResponseWriter, r *http.Request) {
 				consentChallenge = r.URL.Query().Get("consent_challenge")
-				_, _, err := adminClient.OAuth2API.GetOAuth2ConsentRequest(ctx).
+				res, _, err := adminClient.OAuth2API.GetOAuth2ConsentRequest(ctx).
 					ConsentChallenge(consentChallenge).
 					Execute()
 				require.NoError(t, err)
+				require.Equal(t, consentChallenge, res.Challenge)
 
 				v, _, err := adminClient.OAuth2API.AcceptOAuth2ConsentRequest(ctx).
 					ConsentChallenge(consentChallenge).

--- a/flow/.snapshots/TestOAuth2ConsentRequest_MarshalJSON.json
+++ b/flow/.snapshots/TestOAuth2ConsentRequest_MarshalJSON.json
@@ -1,1 +1,1 @@
-"{\"challenge\":\"\",\"requested_scope\":[],\"requested_access_token_audience\":[],\"skip\":false,\"subject\":\"\",\"oidc_context\":null,\"client\":null,\"request_url\":\"\",\"login_challenge\":\"\",\"login_session_id\":\"\",\"acr\":\"\",\"amr\":[]}"
+"{\"challenge\":\"\",\"consent_request_id\":\"\",\"requested_scope\":[],\"requested_access_token_audience\":[],\"skip\":false,\"subject\":\"\",\"oidc_context\":null,\"client\":null,\"request_url\":\"\",\"login_challenge\":\"\",\"login_session_id\":\"\",\"acr\":\"\",\"amr\":[]}"

--- a/flow/.snapshots/TestOAuth2ConsentSession_MarshalJSON.json
+++ b/flow/.snapshots/TestOAuth2ConsentSession_MarshalJSON.json
@@ -1,1 +1,1 @@
-"{\"grant_scope\":[],\"grant_access_token_audience\":[],\"session\":null,\"remember\":false,\"remember_for\":0,\"handled_at\":null,\"context\":{},\"consent_request\":null}"
+"{\"consent_request_id\":\"\",\"grant_scope\":[],\"grant_access_token_audience\":[],\"session\":null,\"remember\":false,\"remember_for\":0,\"handled_at\":null,\"context\":{},\"consent_request\":null}"

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -52,7 +52,7 @@ func (f *Flow) setHandledLoginRequest(r *HandledLoginRequest) {
 }
 
 func (f *Flow) setConsentRequest(r OAuth2ConsentRequest) {
-	f.ConsentChallengeID = sqlxx.NullString(r.ID)
+	f.ConsentRequestID = sqlxx.NullString(r.ConsentRequestID)
 	f.RequestedScope = r.RequestedScope
 	f.RequestedAudience = r.RequestedAudience
 	f.ConsentSkip = r.Skip
@@ -75,7 +75,7 @@ func (f *Flow) setConsentRequest(r OAuth2ConsentRequest) {
 }
 
 func (f *Flow) setHandledConsentRequest(r AcceptOAuth2ConsentRequest) {
-	f.ConsentChallengeID = sqlxx.NullString(r.ID)
+	f.ConsentRequestID = sqlxx.NullString(r.ConsentRequestID)
 	f.GrantedScope = r.GrantedScope
 	f.GrantedAudience = r.GrantedAudience
 	f.ConsentRemember = r.Remember
@@ -191,7 +191,7 @@ func TestFlow_GetConsentRequest(t *testing.T) {
 		expected := OAuth2ConsentRequest{}
 		assert.NoError(t, faker.FakeData(&expected))
 		f.setConsentRequest(expected)
-		actual := f.GetConsentRequest()
+		actual := f.GetConsentRequest(expected.Challenge)
 		assert.Equal(t, expected, *actual)
 	})
 }
@@ -203,7 +203,7 @@ func TestFlow_HandleConsentRequest(t *testing.T) {
 	expected := AcceptOAuth2ConsentRequest{}
 	require.NoError(t, faker.FakeData(&expected))
 
-	expected.ID = string(f.ConsentChallengeID)
+	expected.ConsentRequestID = string(f.ConsentRequestID)
 	expected.HandledAt = sqlxx.NullTime(time.Now())
 	expected.RequestedAt = f.RequestedAt
 	expected.Session = &AcceptOAuth2ConsentRequestSession{

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/ory/hydra-client-go/v2 v2.2.1
 	github.com/ory/jsonschema/v3 v3.0.8
 	github.com/ory/kratos-client-go v1.2.1
-	github.com/ory/x v0.0.675
+	github.com/ory/x v0.0.695
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/ory/kratos-client-go v1.2.1 h1:Q3T/adfAfAkHFcV1LGLnwz4QkY6ghBdX9zde5T
 github.com/ory/kratos-client-go v1.2.1/go.mod h1:WiQYlrqW4Atj6Js7oDN5ArbZxo0nTO2u/e1XaDv2yMI=
 github.com/ory/pop/v6 v6.2.1-0.20241121111754-e5dfc0f3344b h1:BIzoOe2/wynZBQak1po0tzgvARseIKsR2bF6b+SZoKE=
 github.com/ory/pop/v6 v6.2.1-0.20241121111754-e5dfc0f3344b/go.mod h1:okVAYKGtgunD/wbW3NGhZTndJCS+6FqO+cA89rQ4doc=
-github.com/ory/x v0.0.675 h1:K6GpVo99BXBFv2UiwMjySNNNqCFKGswynrt7vWQJFU8=
-github.com/ory/x v0.0.675/go.mod h1:zJmnDtKje2FCP4EeFvRsKk94XXiqKCSGJMZcirAfhUs=
+github.com/ory/x v0.0.695 h1:cUOQPtKO0MChwwXBB0sycrT/c5MU3la8fz3I45tR/VU=
+github.com/ory/x v0.0.695/go.mod h1:CLnDxtKBkO2MoOYRbQe9HASUlqTBl7AP9r7YcmyD1CY=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -1048,12 +1048,12 @@ paths:
           type: string
         style: form
       - description: |-
-          Consent Challenge ID
+          Consent Request ID
 
           If set, revoke all token chains derived from this particular consent request ID.
         explode: true
         in: query
-        name: consent_challenge_id
+        name: consent_request_id
         required: false
         schema:
           type: string
@@ -3032,6 +3032,7 @@ components:
       type: object
     oAuth2ConsentRequest:
       example:
+        consent_request_id: consent_request_id
         requested_access_token_audience:
         - requested_access_token_audience
         - requested_access_token_audience
@@ -3138,10 +3139,13 @@ components:
             \ JSON for SQL storage."
           type: array
         challenge:
-          description: ID is the identifier of the consent authorization request.
+          description: Challenge is used to retrieve/accept/deny the consent request.
           type: string
         client:
           $ref: '#/components/schemas/oAuth2Client'
+        consent_request_id:
+          description: ConsentRequestID is the ID of the consent request.
+          type: string
         context:
           title: "JSONRawMessage represents a json.RawMessage that works well with\
             \ JSON, SQL, and Swagger."
@@ -3258,8 +3262,10 @@ components:
     oAuth2ConsentSession:
       description: A completed OAuth 2.0 Consent Session.
       example:
+        consent_request_id: consent_request_id
         remember: true
         consent_request:
+          consent_request_id: consent_request_id
           requested_access_token_audience:
           - requested_access_token_audience
           - requested_access_token_audience
@@ -3374,6 +3380,10 @@ components:
       properties:
         consent_request:
           $ref: '#/components/schemas/oAuth2ConsentRequest'
+        consent_request_id:
+          description: ConsentRequestID is the identifier of the consent request that
+            initiated this consent session.
+          type: string
         context:
           title: "JSONRawMessage represents a json.RawMessage that works well with\
             \ JSON, SQL, and Swagger."

--- a/internal/httpclient/api_o_auth2.go
+++ b/internal/httpclient/api_o_auth2.go
@@ -2881,12 +2881,12 @@ func (a *OAuth2APIService) RejectOAuth2LogoutRequestExecute(r ApiRejectOAuth2Log
 }
 
 type ApiRevokeOAuth2ConsentSessionsRequest struct {
-	ctx                context.Context
-	ApiService         *OAuth2APIService
-	subject            *string
-	client             *string
-	consentChallengeId *string
-	all                *bool
+	ctx              context.Context
+	ApiService       *OAuth2APIService
+	subject          *string
+	client           *string
+	consentRequestId *string
+	all              *bool
 }
 
 // OAuth 2.0 Consent Subject  The subject whose consent sessions should be deleted.
@@ -2901,9 +2901,9 @@ func (r ApiRevokeOAuth2ConsentSessionsRequest) Client(client string) ApiRevokeOA
 	return r
 }
 
-// Consent Challenge ID  If set, revoke all token chains derived from this particular consent request ID.
-func (r ApiRevokeOAuth2ConsentSessionsRequest) ConsentChallengeId(consentChallengeId string) ApiRevokeOAuth2ConsentSessionsRequest {
-	r.consentChallengeId = &consentChallengeId
+// Consent Request ID  If set, revoke all token chains derived from this particular consent request ID.
+func (r ApiRevokeOAuth2ConsentSessionsRequest) ConsentRequestId(consentRequestId string) ApiRevokeOAuth2ConsentSessionsRequest {
+	r.consentRequestId = &consentRequestId
 	return r
 }
 
@@ -2958,8 +2958,8 @@ func (a *OAuth2APIService) RevokeOAuth2ConsentSessionsExecute(r ApiRevokeOAuth2C
 	if r.client != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "client", r.client, "")
 	}
-	if r.consentChallengeId != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "consent_challenge_id", r.consentChallengeId, "")
+	if r.consentRequestId != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "consent_request_id", r.consentRequestId, "")
 	}
 	if r.all != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "all", r.all, "")

--- a/internal/httpclient/docs/OAuth2API.md
+++ b/internal/httpclient/docs/OAuth2API.md
@@ -1532,7 +1532,7 @@ No authorization required
 
 ## RevokeOAuth2ConsentSessions
 
-> RevokeOAuth2ConsentSessions(ctx).Subject(subject).Client(client).ConsentChallengeId(consentChallengeId).All(all).Execute()
+> RevokeOAuth2ConsentSessions(ctx).Subject(subject).Client(client).ConsentRequestId(consentRequestId).All(all).Execute()
 
 Revoke OAuth 2.0 Consent Sessions of a Subject
 
@@ -1553,12 +1553,12 @@ import (
 func main() {
 	subject := "subject_example" // string | OAuth 2.0 Consent Subject  The subject whose consent sessions should be deleted. (optional)
 	client := "client_example" // string | OAuth 2.0 Client ID  If set, deletes only those consent sessions that have been granted to the specified OAuth 2.0 Client ID. (optional)
-	consentChallengeId := "consentChallengeId_example" // string | Consent Challenge ID  If set, revoke all token chains derived from this particular consent request ID. (optional)
+	consentRequestId := "consentRequestId_example" // string | Consent Request ID  If set, revoke all token chains derived from this particular consent request ID. (optional)
 	all := true // bool | Revoke All Consent Sessions  If set to `true` deletes all consent sessions by the Subject that have been granted. (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	r, err := apiClient.OAuth2API.RevokeOAuth2ConsentSessions(context.Background()).Subject(subject).Client(client).ConsentChallengeId(consentChallengeId).All(all).Execute()
+	r, err := apiClient.OAuth2API.RevokeOAuth2ConsentSessions(context.Background()).Subject(subject).Client(client).ConsentRequestId(consentRequestId).All(all).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `OAuth2API.RevokeOAuth2ConsentSessions``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -1579,7 +1579,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **subject** | **string** | OAuth 2.0 Consent Subject  The subject whose consent sessions should be deleted. | 
  **client** | **string** | OAuth 2.0 Client ID  If set, deletes only those consent sessions that have been granted to the specified OAuth 2.0 Client ID. | 
- **consentChallengeId** | **string** | Consent Challenge ID  If set, revoke all token chains derived from this particular consent request ID. | 
+ **consentRequestId** | **string** | Consent Request ID  If set, revoke all token chains derived from this particular consent request ID. | 
  **all** | **bool** | Revoke All Consent Sessions  If set to &#x60;true&#x60; deletes all consent sessions by the Subject that have been granted. | 
 
 ### Return type

--- a/internal/httpclient/docs/OAuth2ConsentRequest.md
+++ b/internal/httpclient/docs/OAuth2ConsentRequest.md
@@ -6,8 +6,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Acr** | Pointer to **string** | ACR represents the Authentication AuthorizationContext Class Reference value for this authentication session. You can use it to express that, for example, a user authenticated using two factor authentication. | [optional] 
 **Amr** | Pointer to **[]string** |  | [optional] 
-**Challenge** | **string** | ID is the identifier of the consent authorization request. | 
+**Challenge** | **string** | Challenge is used to retrieve/accept/deny the consent request. | 
 **Client** | Pointer to [**OAuth2Client**](OAuth2Client.md) |  | [optional] 
+**ConsentRequestId** | Pointer to **string** | ConsentRequestID is the ID of the consent request. | [optional] 
 **Context** | Pointer to **interface{}** |  | [optional] 
 **LoginChallenge** | Pointer to **string** | LoginChallenge is the login challenge this consent challenge belongs to. It can be used to associate a login and consent request in the login &amp; consent app. | [optional] 
 **LoginSessionId** | Pointer to **string** | LoginSessionID is the login session ID. If the user-agent reuses a login session (via cookie / remember flag) this ID will remain the same. If the user-agent did not have an existing authentication session (e.g. remember is false) this will be a new random value. This value is used as the \&quot;sid\&quot; parameter in the ID Token and in OIDC Front-/Back- channel logout. It&#39;s value can generally be used to associate consecutive login requests by a certain user. | [optional] 
@@ -131,6 +132,31 @@ SetClient sets Client field to given value.
 `func (o *OAuth2ConsentRequest) HasClient() bool`
 
 HasClient returns a boolean if a field has been set.
+
+### GetConsentRequestId
+
+`func (o *OAuth2ConsentRequest) GetConsentRequestId() string`
+
+GetConsentRequestId returns the ConsentRequestId field if non-nil, zero value otherwise.
+
+### GetConsentRequestIdOk
+
+`func (o *OAuth2ConsentRequest) GetConsentRequestIdOk() (*string, bool)`
+
+GetConsentRequestIdOk returns a tuple with the ConsentRequestId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetConsentRequestId
+
+`func (o *OAuth2ConsentRequest) SetConsentRequestId(v string)`
+
+SetConsentRequestId sets ConsentRequestId field to given value.
+
+### HasConsentRequestId
+
+`func (o *OAuth2ConsentRequest) HasConsentRequestId() bool`
+
+HasConsentRequestId returns a boolean if a field has been set.
 
 ### GetContext
 

--- a/internal/httpclient/docs/OAuth2ConsentSession.md
+++ b/internal/httpclient/docs/OAuth2ConsentSession.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ConsentRequest** | Pointer to [**OAuth2ConsentRequest**](OAuth2ConsentRequest.md) |  | [optional] 
+**ConsentRequestId** | Pointer to **string** | ConsentRequestID is the identifier of the consent request that initiated this consent session. | [optional] 
 **Context** | Pointer to **interface{}** |  | [optional] 
 **ExpiresAt** | Pointer to [**OAuth2ConsentSessionExpiresAt**](OAuth2ConsentSessionExpiresAt.md) |  | [optional] 
 **GrantAccessTokenAudience** | Pointer to **[]string** |  | [optional] 
@@ -57,6 +58,31 @@ SetConsentRequest sets ConsentRequest field to given value.
 `func (o *OAuth2ConsentSession) HasConsentRequest() bool`
 
 HasConsentRequest returns a boolean if a field has been set.
+
+### GetConsentRequestId
+
+`func (o *OAuth2ConsentSession) GetConsentRequestId() string`
+
+GetConsentRequestId returns the ConsentRequestId field if non-nil, zero value otherwise.
+
+### GetConsentRequestIdOk
+
+`func (o *OAuth2ConsentSession) GetConsentRequestIdOk() (*string, bool)`
+
+GetConsentRequestIdOk returns a tuple with the ConsentRequestId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetConsentRequestId
+
+`func (o *OAuth2ConsentSession) SetConsentRequestId(v string)`
+
+SetConsentRequestId sets ConsentRequestId field to given value.
+
+### HasConsentRequestId
+
+`func (o *OAuth2ConsentSession) HasConsentRequestId() bool`
+
+HasConsentRequestId returns a boolean if a field has been set.
 
 ### GetContext
 

--- a/internal/httpclient/model_o_auth2_consent_request.go
+++ b/internal/httpclient/model_o_auth2_consent_request.go
@@ -25,10 +25,12 @@ type OAuth2ConsentRequest struct {
 	// ACR represents the Authentication AuthorizationContext Class Reference value for this authentication session. You can use it to express that, for example, a user authenticated using two factor authentication.
 	Acr *string  `json:"acr,omitempty"`
 	Amr []string `json:"amr,omitempty"`
-	// ID is the identifier of the consent authorization request.
+	// Challenge is used to retrieve/accept/deny the consent request.
 	Challenge string        `json:"challenge"`
 	Client    *OAuth2Client `json:"client,omitempty"`
-	Context   interface{}   `json:"context,omitempty"`
+	// ConsentRequestID is the ID of the consent request.
+	ConsentRequestId *string     `json:"consent_request_id,omitempty"`
+	Context          interface{} `json:"context,omitempty"`
 	// LoginChallenge is the login challenge this consent challenge belongs to. It can be used to associate a login and consent request in the login & consent app.
 	LoginChallenge *string `json:"login_challenge,omitempty"`
 	// LoginSessionID is the login session ID. If the user-agent reuses a login session (via cookie / remember flag) this ID will remain the same. If the user-agent did not have an existing authentication session (e.g. remember is false) this will be a new random value. This value is used as the \"sid\" parameter in the ID Token and in OIDC Front-/Back- channel logout. It's value can generally be used to associate consecutive login requests by a certain user.
@@ -182,6 +184,38 @@ func (o *OAuth2ConsentRequest) HasClient() bool {
 // SetClient gets a reference to the given OAuth2Client and assigns it to the Client field.
 func (o *OAuth2ConsentRequest) SetClient(v OAuth2Client) {
 	o.Client = &v
+}
+
+// GetConsentRequestId returns the ConsentRequestId field value if set, zero value otherwise.
+func (o *OAuth2ConsentRequest) GetConsentRequestId() string {
+	if o == nil || IsNil(o.ConsentRequestId) {
+		var ret string
+		return ret
+	}
+	return *o.ConsentRequestId
+}
+
+// GetConsentRequestIdOk returns a tuple with the ConsentRequestId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *OAuth2ConsentRequest) GetConsentRequestIdOk() (*string, bool) {
+	if o == nil || IsNil(o.ConsentRequestId) {
+		return nil, false
+	}
+	return o.ConsentRequestId, true
+}
+
+// HasConsentRequestId returns a boolean if a field has been set.
+func (o *OAuth2ConsentRequest) HasConsentRequestId() bool {
+	if o != nil && !IsNil(o.ConsentRequestId) {
+		return true
+	}
+
+	return false
+}
+
+// SetConsentRequestId gets a reference to the given string and assigns it to the ConsentRequestId field.
+func (o *OAuth2ConsentRequest) SetConsentRequestId(v string) {
+	o.ConsentRequestId = &v
 }
 
 // GetContext returns the Context field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -492,6 +526,9 @@ func (o OAuth2ConsentRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["challenge"] = o.Challenge
 	if !IsNil(o.Client) {
 		toSerialize["client"] = o.Client
+	}
+	if !IsNil(o.ConsentRequestId) {
+		toSerialize["consent_request_id"] = o.ConsentRequestId
 	}
 	if o.Context != nil {
 		toSerialize["context"] = o.Context

--- a/internal/httpclient/model_o_auth2_consent_session.go
+++ b/internal/httpclient/model_o_auth2_consent_session.go
@@ -21,7 +21,9 @@ var _ MappedNullable = &OAuth2ConsentSession{}
 
 // OAuth2ConsentSession A completed OAuth 2.0 Consent Session.
 type OAuth2ConsentSession struct {
-	ConsentRequest           *OAuth2ConsentRequest          `json:"consent_request,omitempty"`
+	ConsentRequest *OAuth2ConsentRequest `json:"consent_request,omitempty"`
+	// ConsentRequestID is the identifier of the consent request that initiated this consent session.
+	ConsentRequestId         *string                        `json:"consent_request_id,omitempty"`
 	Context                  interface{}                    `json:"context,omitempty"`
 	ExpiresAt                *OAuth2ConsentSessionExpiresAt `json:"expires_at,omitempty"`
 	GrantAccessTokenAudience []string                       `json:"grant_access_token_audience,omitempty"`
@@ -81,6 +83,38 @@ func (o *OAuth2ConsentSession) HasConsentRequest() bool {
 // SetConsentRequest gets a reference to the given OAuth2ConsentRequest and assigns it to the ConsentRequest field.
 func (o *OAuth2ConsentSession) SetConsentRequest(v OAuth2ConsentRequest) {
 	o.ConsentRequest = &v
+}
+
+// GetConsentRequestId returns the ConsentRequestId field value if set, zero value otherwise.
+func (o *OAuth2ConsentSession) GetConsentRequestId() string {
+	if o == nil || IsNil(o.ConsentRequestId) {
+		var ret string
+		return ret
+	}
+	return *o.ConsentRequestId
+}
+
+// GetConsentRequestIdOk returns a tuple with the ConsentRequestId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *OAuth2ConsentSession) GetConsentRequestIdOk() (*string, bool) {
+	if o == nil || IsNil(o.ConsentRequestId) {
+		return nil, false
+	}
+	return o.ConsentRequestId, true
+}
+
+// HasConsentRequestId returns a boolean if a field has been set.
+func (o *OAuth2ConsentSession) HasConsentRequestId() bool {
+	if o != nil && !IsNil(o.ConsentRequestId) {
+		return true
+	}
+
+	return false
+}
+
+// SetConsentRequestId gets a reference to the given string and assigns it to the ConsentRequestId field.
+func (o *OAuth2ConsentSession) SetConsentRequestId(v string) {
+	o.ConsentRequestId = &v
 }
 
 // GetContext returns the Context field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -352,6 +386,9 @@ func (o OAuth2ConsentSession) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.ConsentRequest) {
 		toSerialize["consent_request"] = o.ConsentRequest
+	}
+	if !IsNil(o.ConsentRequestId) {
+		toSerialize["consent_request_id"] = o.ConsentRequestId
 	}
 	if o.Context != nil {
 		toSerialize["context"] = o.Context

--- a/internal/testhelpers/janitor_test_helper.go
+++ b/internal/testhelpers/janitor_test_helper.go
@@ -302,15 +302,15 @@ func (j *JanitorConsentTestHelper) ConsentRejectionSetup(ctx context.Context, re
 			f.LoginAuthenticatedAt = consentRequest.AuthenticatedAt
 
 			// Reject the consents
-			if consentRequest.ID == j.flushConsentRequests[0].ID {
+			if consentRequest.ConsentRequestID == j.flushConsentRequests[0].ConsentRequestID {
 				// accept this one
 				_, err = cm.HandleConsentRequest(ctx, f, consent.NewHandledConsentRequest(
-					consentRequest.ID, false, consentRequest.RequestedAt, consentRequest.AuthenticatedAt))
+					consentRequest.ConsentRequestID, false, consentRequest.RequestedAt, consentRequest.AuthenticatedAt))
 				require.NoError(t, err)
 				continue
 			}
 			_, err = cm.HandleConsentRequest(ctx, f, consent.NewHandledConsentRequest(
-				consentRequest.ID, true, consentRequest.RequestedAt, consentRequest.AuthenticatedAt))
+				consentRequest.ConsentRequestID, true, consentRequest.RequestedAt, consentRequest.AuthenticatedAt))
 			require.NoError(t, err)
 		}
 	}
@@ -320,8 +320,7 @@ func (j *JanitorConsentTestHelper) ConsentRejectionValidate(ctx context.Context,
 	return func(t *testing.T) {
 		var err error
 		for _, r := range j.flushConsentRequests {
-			t.Logf("check consent: %s", r.ID)
-			_, err = cm.GetConsentRequest(ctx, r.ID)
+			_, err = cm.GetConsentRequest(ctx, r.Challenge)
 			// Consent requests should never be persisted.
 			require.Error(t, err)
 		}
@@ -406,11 +405,11 @@ func (j *JanitorConsentTestHelper) ConsentTimeoutSetup(ctx context.Context, reg 
 			if i == 0 {
 				// Create at least 1 consent request that has been accepted
 				_, err = cm.HandleConsentRequest(ctx, f, &flow.AcceptOAuth2ConsentRequest{
-					ID:              consentRequest.ID,
-					WasHandled:      true,
-					HandledAt:       sqlxx.NullTime(time.Now()),
-					RequestedAt:     consentRequest.RequestedAt,
-					AuthenticatedAt: consentRequest.AuthenticatedAt,
+					ConsentRequestID: consentRequest.ConsentRequestID,
+					WasHandled:       true,
+					HandledAt:        sqlxx.NullTime(time.Now()),
+					RequestedAt:      consentRequest.RequestedAt,
+					AuthenticatedAt:  consentRequest.AuthenticatedAt,
 				})
 				require.NoError(t, err)
 			}
@@ -424,7 +423,7 @@ func (j *JanitorConsentTestHelper) ConsentTimeoutValidate(ctx context.Context, c
 		var err error
 
 		for _, r := range j.flushConsentRequests {
-			_, err = cm.GetConsentRequest(ctx, r.ID)
+			_, err = cm.GetConsentRequest(ctx, r.Challenge)
 			require.Error(t, err, "Unverified consent requests are never pesisted")
 		}
 	}
@@ -809,7 +808,7 @@ func genLoginRequests(uniqueName string, lifespan time.Duration) []*flow.LoginRe
 func genConsentRequests(uniqueName string, lifespan time.Duration) []*flow.OAuth2ConsentRequest {
 	return []*flow.OAuth2ConsentRequest{
 		{
-			ID:                   fmt.Sprintf("%s_flush-consent-1", uniqueName),
+			ConsentRequestID:     fmt.Sprintf("%s_flush-consent-1", uniqueName),
 			RequestedScope:       []string{"foo", "bar"},
 			Subject:              fmt.Sprintf("%s_flush-consent-1", uniqueName),
 			OpenIDConnectContext: nil,
@@ -821,7 +820,7 @@ func genConsentRequests(uniqueName string, lifespan time.Duration) []*flow.OAuth
 			CSRF:                 fmt.Sprintf("%s_flush-consent-1", uniqueName),
 		},
 		{
-			ID:                   fmt.Sprintf("%s_flush-consent-2", uniqueName),
+			ConsentRequestID:     fmt.Sprintf("%s_flush-consent-2", uniqueName),
 			RequestedScope:       []string{"foo", "bar"},
 			Subject:              fmt.Sprintf("%s_flush-consent-2", uniqueName),
 			OpenIDConnectContext: nil,
@@ -833,7 +832,7 @@ func genConsentRequests(uniqueName string, lifespan time.Duration) []*flow.OAuth
 			CSRF:                 fmt.Sprintf("%s_flush-consent-2", uniqueName),
 		},
 		{
-			ID:                   fmt.Sprintf("%s_flush-consent-3", uniqueName),
+			ConsentRequestID:     fmt.Sprintf("%s_flush-consent-3", uniqueName),
 			RequestedScope:       []string{"foo", "bar"},
 			Subject:              fmt.Sprintf("%s_flush-consent-3", uniqueName),
 			OpenIDConnectContext: nil,

--- a/oauth2/fosite_store_helpers_test.go
+++ b/oauth2/fosite_store_helpers_test.go
@@ -113,7 +113,7 @@ func mockRequestForeignKey(t *testing.T, id string, x oauth2.InternalRegistry) {
 		Client:               cl,
 		OpenIDConnectContext: new(flow.OAuth2ConsentRequestOpenIDConnectContext),
 		LoginChallenge:       sqlxx.NullString(id),
-		ID:                   id,
+		ConsentRequestID:     id,
 		Verifier:             id,
 		CSRF:                 id,
 		AuthenticatedAt:      sqlxx.NullTime(time.Now()),
@@ -138,16 +138,16 @@ func mockRequestForeignKey(t *testing.T, id string, x oauth2.InternalRegistry) {
 	err = x.ConsentManager().CreateConsentRequest(ctx, f, cr)
 	require.NoError(t, err)
 
-	encodedFlow, err := f.ToConsentVerifier(ctx, x)
+	_, err = f.ToConsentVerifier(ctx, x)
 	require.NoError(t, err)
 
 	_, err = x.ConsentManager().HandleConsentRequest(ctx, f, &flow.AcceptOAuth2ConsentRequest{
-		ConsentRequest:  cr,
-		Session:         new(flow.AcceptOAuth2ConsentRequestSession),
-		AuthenticatedAt: sqlxx.NullTime(time.Now()),
-		ID:              encodedFlow,
-		RequestedAt:     time.Now(),
-		HandledAt:       sqlxx.NullTime(time.Now()),
+		ConsentRequest:   cr,
+		Session:          new(flow.AcceptOAuth2ConsentRequestSession),
+		AuthenticatedAt:  sqlxx.NullTime(time.Now()),
+		ConsentRequestID: cr.ConsentRequestID,
+		RequestedAt:      time.Now(),
+		HandledAt:        sqlxx.NullTime(time.Now()),
 	})
 
 	require.NoError(t, err)

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -1125,7 +1125,7 @@ func (h *Handler) oAuth2Authorize(w http.ResponseWriter, r *http.Request, _ http
 		return
 	}
 
-	authorizeRequest.SetID(session.ID)
+	authorizeRequest.SetID(session.ConsentRequestID)
 	claims := &jwt.IDTokenClaims{
 		Subject:                             obfuscatedSubject,
 		Issuer:                              h.c.IssuerURL(ctx).String(),
@@ -1160,7 +1160,7 @@ func (h *Handler) oAuth2Authorize(w http.ResponseWriter, r *http.Request, _ http
 			Extra:                 session.Session.AccessToken,
 			KID:                   accessTokenKeyID,
 			ClientID:              authorizeRequest.GetClient().GetID(),
-			ConsentChallenge:      session.ID,
+			ConsentChallenge:      session.ConsentRequestID,
 			ExcludeNotBeforeClaim: h.c.ExcludeNotBeforeClaim(ctx),
 			AllowedTopLevelClaims: h.c.AllowedTopLevelClaims(ctx),
 			MirrorTopLevelClaims:  h.c.MirrorTopLevelClaims(ctx),

--- a/spec/api.json
+++ b/spec/api.json
@@ -839,11 +839,15 @@
             "$ref": "#/components/schemas/StringSliceJSONFormat"
           },
           "challenge": {
-            "description": "ID is the identifier of the consent authorization request.",
+            "description": "Challenge is used to retrieve/accept/deny the consent request.",
             "type": "string"
           },
           "client": {
             "$ref": "#/components/schemas/oAuth2Client"
+          },
+          "consent_request_id": {
+            "description": "ConsentRequestID is the ID of the consent request.",
+            "type": "string"
           },
           "context": {
             "$ref": "#/components/schemas/JSONRawMessage"
@@ -922,6 +926,10 @@
         "properties": {
           "consent_request": {
             "$ref": "#/components/schemas/oAuth2ConsentRequest"
+          },
+          "consent_request_id": {
+            "description": "ConsentRequestID is the identifier of the consent request that initiated this consent session.",
+            "type": "string"
           },
           "context": {
             "$ref": "#/components/schemas/JSONRawMessage"
@@ -2908,9 +2916,9 @@
             }
           },
           {
-            "description": "Consent Challenge ID\n\nIf set, revoke all token chains derived from this particular consent request ID.",
+            "description": "Consent Request ID\n\nIf set, revoke all token chains derived from this particular consent request ID.",
             "in": "query",
-            "name": "consent_challenge_id",
+            "name": "consent_request_id",
             "schema": {
               "type": "string"
             }

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -1259,8 +1259,8 @@
           },
           {
             "type": "string",
-            "description": "Consent Challenge ID\n\nIf set, revoke all token chains derived from this particular consent request ID.",
-            "name": "consent_challenge_id",
+            "description": "Consent Request ID\n\nIf set, revoke all token chains derived from this particular consent request ID.",
+            "name": "consent_request_id",
             "in": "query"
           },
           {
@@ -2867,11 +2867,15 @@
           "$ref": "#/definitions/StringSliceJSONFormat"
         },
         "challenge": {
-          "description": "ID is the identifier of the consent authorization request.",
+          "description": "Challenge is used to retrieve/accept/deny the consent request.",
           "type": "string"
         },
         "client": {
           "$ref": "#/definitions/oAuth2Client"
+        },
+        "consent_request_id": {
+          "description": "ConsentRequestID is the ID of the consent request.",
+          "type": "string"
         },
         "context": {
           "$ref": "#/definitions/JSONRawMessage"
@@ -2947,6 +2951,10 @@
       "properties": {
         "consent_request": {
           "$ref": "#/definitions/oAuth2ConsentRequest"
+        },
+        "consent_request_id": {
+          "description": "ConsentRequestID is the identifier of the consent request that initiated this consent session.",
+          "type": "string"
         },
         "context": {
           "$ref": "#/definitions/JSONRawMessage"

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -109,6 +109,11 @@ func WithSubject(subject string) trace.EventOption {
 	return trace.WithAttributes(otelattr.String(attributeKeyOAuth2Subject, subject))
 }
 
+// WithSubject emits the consent request ID as part of the event.
+func WithConsentRequestID(id string) trace.EventOption {
+	return trace.WithAttributes(ConsentRequestID(id))
+}
+
 // WithRequest emits the subject and client ID from the fosite request as part of the event.
 func WithRequest(request fosite.Requester) trace.EventOption {
 	var attributes []otelattr.KeyValue


### PR DESCRIPTION
This is a follow-up to #3932.

This makes several improvements, chiefly restoring backwards compatibility to Hydra before #3932. We now return both the `challenge` as well as the `consent_request_id` from our APIs and distinguish between them clearly.

Closes #3941 