### PR TITLE
feat: add handler for /.well-known/oauth-authorization-server.

### DIFF
--- a/oauth2/.snapshots/TestHandlerOauthAuthorizationServer-hsm_enabled=false.json
+++ b/oauth2/.snapshots/TestHandlerOauthAuthorizationServer-hsm_enabled=false.json
@@ -1,0 +1,104 @@
+{
+  "authorization_endpoint": "http://hydra.localhost/oauth2/auth",
+  "backchannel_logout_session_supported": true,
+  "backchannel_logout_supported": true,
+  "claims_parameter_supported": false,
+  "claims_supported": [
+    "sub"
+  ],
+  "code_challenge_methods_supported": [
+    "plain",
+    "S256"
+  ],
+  "credentials_endpoint_draft_00": "http://hydra.localhost/credentials",
+  "credentials_supported_draft_00": [
+    {
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "cryptographic_suites_supported": [
+        "PS256",
+        "RS256",
+        "ES256",
+        "PS384",
+        "RS384",
+        "ES384",
+        "PS512",
+        "RS512",
+        "ES512",
+        "EdDSA"
+      ],
+      "format": "jwt_vc_json",
+      "types": [
+        "VerifiableCredential",
+        "UserInfoCredential"
+      ]
+    }
+  ],
+  "device_authorization_endpoint": "http://hydra.localhost/oauth2/device/auth",
+  "end_session_endpoint": "http://hydra.localhost/oauth2/sessions/logout",
+  "frontchannel_logout_session_supported": true,
+  "frontchannel_logout_supported": true,
+  "grant_types_supported": [
+    "authorization_code",
+    "implicit",
+    "client_credentials",
+    "refresh_token",
+    "urn:ietf:params:oauth:grant-type:device_code"
+  ],
+  "id_token_signed_response_alg": [
+    "RS256"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "issuer": "http://hydra.localhost",
+  "jwks_uri": "http://hydra.localhost/.well-known/jwks.json",
+  "registration_endpoint": "http://client-register/registration",
+  "request_object_signing_alg_values_supported": [
+    "none",
+    "RS256",
+    "ES256"
+  ],
+  "request_parameter_supported": true,
+  "request_uri_parameter_supported": true,
+  "require_request_uri_registration": true,
+  "response_modes_supported": [
+    "query",
+    "fragment",
+    "form_post"
+  ],
+  "response_types_supported": [
+    "code",
+    "code id_token",
+    "id_token",
+    "token id_token",
+    "token",
+    "token id_token code"
+  ],
+  "revocation_endpoint": "http://hydra.localhost/oauth2/revoke",
+  "scopes_supported": [
+    "offline_access",
+    "offline",
+    "openid"
+  ],
+  "subject_types_supported": [
+    "pairwise",
+    "public"
+  ],
+  "token_endpoint": "http://hydra.localhost/oauth2/token",
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_post",
+    "client_secret_basic",
+    "private_key_jwt",
+    "none"
+  ],
+  "userinfo_endpoint": "/userinfo",
+  "userinfo_signed_response_alg": [
+    "RS256"
+  ],
+  "userinfo_signing_alg_values_supported": [
+    "none",
+    "RS256"
+  ]
+}

--- a/oauth2/.snapshots/TestHandlerOauthAuthorizationServer-hsm_enabled=true.json
+++ b/oauth2/.snapshots/TestHandlerOauthAuthorizationServer-hsm_enabled=true.json
@@ -1,0 +1,104 @@
+{
+  "authorization_endpoint": "http://hydra.localhost/oauth2/auth",
+  "backchannel_logout_session_supported": true,
+  "backchannel_logout_supported": true,
+  "claims_parameter_supported": false,
+  "claims_supported": [
+    "sub"
+  ],
+  "code_challenge_methods_supported": [
+    "plain",
+    "S256"
+  ],
+  "credentials_endpoint_draft_00": "http://hydra.localhost/credentials",
+  "credentials_supported_draft_00": [
+    {
+      "cryptographic_binding_methods_supported": [
+        "jwk"
+      ],
+      "cryptographic_suites_supported": [
+        "PS256",
+        "RS256",
+        "ES256",
+        "PS384",
+        "RS384",
+        "ES384",
+        "PS512",
+        "RS512",
+        "ES512",
+        "EdDSA"
+      ],
+      "format": "jwt_vc_json",
+      "types": [
+        "VerifiableCredential",
+        "UserInfoCredential"
+      ]
+    }
+  ],
+  "device_authorization_endpoint": "http://hydra.localhost/oauth2/device/auth",
+  "end_session_endpoint": "http://hydra.localhost/oauth2/sessions/logout",
+  "frontchannel_logout_session_supported": true,
+  "frontchannel_logout_supported": true,
+  "grant_types_supported": [
+    "authorization_code",
+    "implicit",
+    "client_credentials",
+    "refresh_token",
+    "urn:ietf:params:oauth:grant-type:device_code"
+  ],
+  "id_token_signed_response_alg": [
+    "RS256"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "issuer": "http://hydra.localhost",
+  "jwks_uri": "http://hydra.localhost/.well-known/jwks.json",
+  "registration_endpoint": "http://client-register/registration",
+  "request_object_signing_alg_values_supported": [
+    "none",
+    "RS256",
+    "ES256"
+  ],
+  "request_parameter_supported": true,
+  "request_uri_parameter_supported": true,
+  "require_request_uri_registration": true,
+  "response_modes_supported": [
+    "query",
+    "fragment",
+    "form_post"
+  ],
+  "response_types_supported": [
+    "code",
+    "code id_token",
+    "id_token",
+    "token id_token",
+    "token",
+    "token id_token code"
+  ],
+  "revocation_endpoint": "http://hydra.localhost/oauth2/revoke",
+  "scopes_supported": [
+    "offline_access",
+    "offline",
+    "openid"
+  ],
+  "subject_types_supported": [
+    "pairwise",
+    "public"
+  ],
+  "token_endpoint": "http://hydra.localhost/oauth2/token",
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_post",
+    "client_secret_basic",
+    "private_key_jwt",
+    "none"
+  ],
+  "userinfo_endpoint": "/userinfo",
+  "userinfo_signed_response_alg": [
+    "RS256"
+  ],
+  "userinfo_signing_alg_values_supported": [
+    "none",
+    "RS256"
+  ]
+}

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -58,10 +58,11 @@ const (
 	AuthPath                      = "/oauth2/auth"
 	LogoutPath                    = "/oauth2/sessions/logout"
 
-	VerifiableCredentialsPath = "/credentials"
-	UserinfoPath              = "/userinfo"
-	WellKnownPath             = "/.well-known/openid-configuration"
-	JWKPath                   = "/.well-known/jwks.json"
+	VerifiableCredentialsPath    = "/credentials"
+	UserinfoPath                 = "/userinfo"
+	WellKnownPath                = "/.well-known/openid-configuration"
+	OauthAuthorizationServerPath = "/.well-known/oauth-authorization-server"
+	JWKPath                      = "/.well-known/jwks.json"
 
 	// IntrospectPath points to the OAuth2 introspection endpoint.
 	IntrospectPath   = "/oauth2/introspect"
@@ -125,6 +126,8 @@ func (h *Handler) SetRoutes(admin *httprouterx.RouterAdmin, public *httprouterx.
 	public.Handler("POST", RevocationPath, corsMiddleware(http.HandlerFunc(h.revokeOAuth2Token)))
 	public.Handler("OPTIONS", WellKnownPath, corsMiddleware(http.HandlerFunc(h.handleOptions)))
 	public.Handler("GET", WellKnownPath, corsMiddleware(http.HandlerFunc(h.discoverOidcConfiguration)))
+	public.Handler("OPTIONS", OauthAuthorizationServerPath, corsMiddleware(http.HandlerFunc(h.handleOptions)))
+	public.Handler("GET", OauthAuthorizationServerPath, corsMiddleware(http.HandlerFunc(h.discoverOidcConfiguration)))
 	public.Handler("OPTIONS", UserinfoPath, corsMiddleware(http.HandlerFunc(h.handleOptions)))
 	public.Handler("GET", UserinfoPath, corsMiddleware(http.HandlerFunc(h.getOidcUserInfo)))
 	public.Handler("POST", UserinfoPath, corsMiddleware(http.HandlerFunc(h.getOidcUserInfo)))


### PR DESCRIPTION
In order to support OAuth2.1 and some specific integrations that leverage the `/.well-known/oauth-authorization-server` endpoint, this PR adds a handler for the specific endpoint. The `/.well-known/openid-configuration` endpoint already supports all configuration items that conform to this endpoint as seen here: https://datatracker.ietf.org/doc/html/rfc8414