### PR TITLE
feat: graceful refresh count limit

### DIFF
--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -110,7 +110,8 @@ const (
 	KeyExcludeNotBeforeClaim                     = "oauth2.exclude_not_before_claim"
 	KeyAllowedTopLevelClaims                     = "oauth2.allowed_top_level_claims"
 	KeyMirrorTopLevelClaims                      = "oauth2.mirror_top_level_claims"
-	KeyRefreshTokenRotationGracePeriod           = "oauth2.grant.refresh_token.rotation_grace_period" // #nosec G101
+	KeyRefreshTokenRotationGracePeriod           = "oauth2.grant.refresh_token.rotation_grace_period"      // #nosec G101
+	KeyRefreshTokenRotationGraceReuseCount       = "oauth2.grant.refresh_token.rotation_grace_reuse_count" // #nosec G101
 	KeyOAuth2GrantJWTIDOptional                  = "oauth2.grant.jwt.jti_optional"
 	KeyOAuth2GrantJWTIssuedDateOptional          = "oauth2.grant.jwt.iat_optional"
 	KeyOAuth2GrantJWTMaxDuration                 = "oauth2.grant.jwt.max_ttl"
@@ -759,9 +760,15 @@ func (p *DefaultProvider) cookieSuffix(ctx context.Context, key string) string {
 }
 
 func (p *DefaultProvider) RefreshTokenRotationGracePeriod(ctx context.Context) time.Duration {
-	gracePeriod := p.getProvider(ctx).DurationF(KeyRefreshTokenRotationGracePeriod, 0)
-	if gracePeriod > time.Minute*5 {
-		return time.Minute * 5
+	return p.getProvider(ctx).DurationF(KeyRefreshTokenRotationGracePeriod, 0)
+}
+
+func (p *DefaultProvider) RefreshTokenRotationGraceReuseCount(ctx context.Context) int32 {
+	reuseCount := p.getProvider(ctx).IntF(KeyRefreshTokenRotationGraceReuseCount, 0)
+	if reuseCount > math.MaxInt32 {
+		return math.MaxInt32
+	} else if reuseCount < 0 {
+		return 0
 	}
-	return gracePeriod
+	return int32(reuseCount)
 }

--- a/driver/config/provider_test.go
+++ b/driver/config/provider_test.go
@@ -294,11 +294,13 @@ func TestViperProviderValidates(t *testing.T) {
 	assert.Equal(t, []string{"whatever"}, c.DefaultClientScope(ctx))
 
 	// refresh
-	assert.Equal(t, time.Duration(0), c.RefreshTokenRotationGracePeriod(ctx))
+	assert.Equal(t, GracefulRefreshTokenRotation{}, c.GracefulRefreshTokenRotation(ctx))
 	require.NoError(t, c.Set(ctx, KeyRefreshTokenRotationGracePeriod, "1s"))
-	assert.Equal(t, time.Second, c.RefreshTokenRotationGracePeriod(ctx))
+	assert.Equal(t, time.Second, c.GracefulRefreshTokenRotation(ctx).Period)
 	require.NoError(t, c.Set(ctx, KeyRefreshTokenRotationGracePeriod, "2h"))
-	assert.Equal(t, time.Minute*5, c.RefreshTokenRotationGracePeriod(ctx))
+	assert.Equal(t, 5*time.Minute, c.GracefulRefreshTokenRotation(ctx).Period)
+	require.NoError(t, c.Set(ctx, KeyRefreshTokenRotationGraceReuseCount, "2"))
+	assert.Equal(t, GracefulRefreshTokenRotation{Count: 2, Period: 2 * time.Hour}, c.GracefulRefreshTokenRotation(ctx))
 
 	// urls
 	assert.Equal(t, urlx.ParseOrPanic("https://issuer"), c.IssuerURL(ctx))

--- a/driver/registry_sql.go
+++ b/driver/registry_sql.go
@@ -714,7 +714,7 @@ func (m *RegistrySQL) Tracer(_ context.Context) *otelx.Tracer {
 			m.trc = t
 		}
 	}
-	if m.trc.Tracer() == nil {
+	if m.trc == nil || m.trc.Tracer() == nil {
 		m.trc = otelx.NewNoop(m.l, m.Config().Tracing())
 	}
 

--- a/driver/registry_sql_test.go
+++ b/driver/registry_sql_test.go
@@ -152,7 +152,7 @@ func TestDbUnknownTableColumns(t *testing.T) {
 	reg, err := NewRegistryFromDSN(ctx, c, l, false, true, &contextx.Default{})
 	require.NoError(t, err)
 
-	statement := "ALTER TABLE \"hydra_client\" ADD COLUMN \"temp_column\" VARCHAR(128) NOT NULL DEFAULT '';"
+	statement := `ALTER TABLE "hydra_client" ADD COLUMN IF NOT EXISTS "temp_column" VARCHAR(128) NOT NULL DEFAULT '';`
 	require.NoError(t, reg.Persister().Connection(ctx).RawQuery(statement).Exec())
 
 	cl := &client.Client{
@@ -161,7 +161,7 @@ func TestDbUnknownTableColumns(t *testing.T) {
 	require.NoError(t, reg.Persister().CreateClient(ctx, cl))
 	getClients := func(reg Registry) ([]client.Client, error) {
 		readClients := make([]client.Client, 0)
-		return readClients, reg.Persister().Connection(ctx).RawQuery("SELECT * FROM \"hydra_client\"").All(&readClients)
+		return readClients, reg.Persister().Connection(ctx).RawQuery(`SELECT * FROM "hydra_client"`).All(&readClients)
 	}
 
 	t.Run("with ignore disabled (default behavior)", func(t *testing.T) {

--- a/oauth2/oauth2_auth_code_test.go
+++ b/oauth2/oauth2_auth_code_test.go
@@ -844,7 +844,7 @@ func TestAuthCodeWithDefaultStrategy(t *testing.T) {
 					original := introspectAccessToken(t, conf, token, subject)
 
 					t.Run("followup=run the flow three more times", func(t *testing.T) {
-						for i := 0; i < 3; i++ {
+						for i := range 3 {
 							t.Run(fmt.Sprintf("run=%d", i), func(t *testing.T) {
 								code, _ := getAuthorizeCode(t, conf, oc,
 									oauth2.SetAuthURLParam("nonce", nonce),
@@ -1569,7 +1569,8 @@ func TestAuthCodeWithDefaultStrategy(t *testing.T) {
 						const nRefreshes = 5
 
 						reg.Config().MustSet(ctx, config.KeyRefreshTokenLifespan, "1m")
-						reg.Config().MustSet(ctx, config.KeyRefreshTokenRotationGracePeriod, "5s")
+						reg.Config().MustSet(ctx, config.KeyRefreshTokenRotationGracePeriod, "10s")
+						reg.Config().MustSet(ctx, config.KeyRefreshTokenRotationGraceReuseCount, 0)
 
 						token := issueTokens(t)
 						token.Expiry = time.Now().Add(-time.Hour * 24)

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0001.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0001.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0002.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0002.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0003.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0003.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0004.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0004.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0005.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0005.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0006.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0006.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0007.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0007.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0008.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0008.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0009.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0009.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0010.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0010.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0011.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-0011.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-20201110104000-01.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-20201110104000-01.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-20201110104000.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-20201110104000.json
@@ -24,5 +24,9 @@
   "AccessTokenSignature": {
     "String": "",
     "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 0,
+    "Valid": false
   }
 }

--- a/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-20250513132142.json
+++ b/persistence/sql/migratest/fixtures/hydra_oauth2_refresh/sig-20250513132142.json
@@ -1,0 +1,32 @@
+{
+  "ID": "sig-20250513132142",
+  "NID": "00000000-0000-0000-0000-000000000000",
+  "Request": "req-20250513132142",
+  "ConsentChallenge": {
+    "String": "challenge-0014",
+    "Valid": true
+  },
+  "RequestedAt": "0001-01-01T00:00:00Z",
+  "Client": "",
+  "Scopes": "scope",
+  "GrantedScope": "granted_scope",
+  "RequestedAudience": "requested_audience",
+  "GrantedAudience": "granted_audience",
+  "Form": "form_data",
+  "Subject": "subject-0014",
+  "Active": false,
+  "Session": "c2Vzc2lvbl9pZC0wMDE0",
+  "Table": "",
+  "FirstUsedAt": {
+    "Time": "0001-01-01T00:00:00Z",
+    "Valid": false
+  },
+  "AccessTokenSignature": {
+    "String": "",
+    "Valid": false
+  },
+  "UsedTimes": {
+    "Int32": 1,
+    "Valid": true
+  }
+}

--- a/persistence/sql/migratest/migration_test.go
+++ b/persistence/sql/migratest/migration_test.go
@@ -233,7 +233,7 @@ func TestMigrations(t *testing.T) {
 				t.Run("case=hydra_oauth2_refresh", func(t *testing.T) {
 					rs := []sql.OAuth2RefreshTable{}
 					require.NoError(t, c.All(&rs))
-					require.Len(t, rs, 13)
+					require.Len(t, rs, 14)
 
 					for _, r := range rs {
 						testhelpersuuid.AssertUUID(t, r.NID)

--- a/persistence/sql/migratest/testdata/20250513132142_testdata.sql
+++ b/persistence/sql/migratest/testdata/20250513132142_testdata.sql
@@ -1,0 +1,6 @@
+INSERT INTO hydra_oauth2_refresh (signature, request_id, requested_at, client_id, scope, granted_scope, form_data,
+                                  session_data, subject, active, requested_audience, granted_audience, challenge_id,
+                                  nid, used_times)
+VALUES ('sig-20250513132142', 'req-20250513132142', '2025-05-13 13:21:42', 'client-0014', 'scope',
+        'granted_scope', 'form_data', 'session_id-0014', 'subject-0014', false, 'requested_audience',
+        'granted_audience', 'challenge-0014', (SELECT id FROM networks LIMIT 1), 1);

--- a/persistence/sql/migrations/20250513132142000000_refresh_used_times.cockroach.up.sql
+++ b/persistence/sql/migrations/20250513132142000000_refresh_used_times.cockroach.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hydra_oauth2_refresh
+  ADD COLUMN used_times INT4 NULL;

--- a/persistence/sql/migrations/20250513132142000000_refresh_used_times.down.sql
+++ b/persistence/sql/migrations/20250513132142000000_refresh_used_times.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hydra_oauth2_refresh
+  DROP COLUMN used_times;

--- a/persistence/sql/migrations/20250513132142000000_refresh_used_times.up.sql
+++ b/persistence/sql/migrations/20250513132142000000_refresh_used_times.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hydra_oauth2_refresh
+  ADD COLUMN used_times INT NULL;

--- a/spec/config.json
+++ b/spec/config.json
@@ -1126,7 +1126,7 @@
               "properties": {
                 "rotation_grace_period": {
                   "title": "Refresh Token Rotation Grace Period",
-                  "description": "Configures how long a Refresh Token remains valid after it has been used. The maximum value is 5 minutes.",
+                  "description": "Configures how long a Refresh Token remains valid after it has been used. The maximum value is 5 minutes, unless also a reuse count is configured.",
                   "default": "0s",
                   "type": "string",
                   "allOf": [
@@ -1134,6 +1134,13 @@
                       "$ref": "#/definitions/duration"
                     }
                   ]
+                },
+                "rotation_grace_reuse_count": {
+                  "title": "Refresh Token Rotation Grace Period Reuse Count",
+                  "description": "Configures how many times a Refresh Token can be reused during the grace period. This is only effective if combined with a rotation grace period.",
+                  "default": 0,
+                  "type": "integer",
+                  "minimum": 0
                 }
               }
             },


### PR DESCRIPTION
This change adds a counter to the refresh, so that graceful refresh can be limited to a specific number of tries only.