### PR TITLE
perf: add index to optimize jwt query

### DIFF
--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.down.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key_2;

--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.down.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.down.sql
@@ -1,1 +1,1 @@
-DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_key_id;
+DROP INDEX IF EXISTS hydra_oauth2_trusted_jwt_bearer_issuer_key_id;

--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.down.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.down.sql
@@ -1,1 +1,1 @@
-DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key_2;
+DROP INDEX hydra_oauth2_trusted_jwt_bearer_issuer_key_id;

--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
@@ -1,2 +1,3 @@
 -- `key_id` is unique-ish per row so we place it first in the index to make queries including it very fast.
+-- Other fields have very few distinct values in the table so having them first in the index makes queries do a full table scan.
 CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_key_id ON hydra_oauth2_trusted_jwt_bearer_issuer (key_id ASC, issuer ASC, subject ASC, nid ASC);

--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
@@ -1,1 +1,2 @@
+-- `key_id` is unique-ish per row so we place it first in the index to make queries including it very fast.
 CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_key_id ON hydra_oauth2_trusted_jwt_bearer_issuer (key_id ASC, issuer ASC, subject ASC, nid ASC);

--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key_2 ON ory_hydra.public.hydra_oauth2_trusted_jwt_bearer_issuer USING btree (key_id ASC, issuer ASC, subject ASC, nid ASC);

--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
@@ -1,3 +1,3 @@
 -- `key_id` is unique-ish per row so we place it first in the index to make queries including it very fast.
 -- Other fields have very few distinct values in the table so having them first in the index makes queries do a full table scan.
-CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_key_id ON hydra_oauth2_trusted_jwt_bearer_issuer (key_id ASC, issuer ASC, subject ASC, nid ASC);
+CREATE UNIQUE INDEX IF NOT EXISTS hydra_oauth2_trusted_jwt_bearer_issuer_key_id ON hydra_oauth2_trusted_jwt_bearer_issuer (key_id ASC, issuer ASC, subject ASC, nid ASC);

--- a/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
+++ b/persistence/sql/migrations/20250520000001000000_add_oauth2_trusted_jwt_bearer_issuer_index.up.sql
@@ -1,1 +1,1 @@
-CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key_2 ON ory_hydra.public.hydra_oauth2_trusted_jwt_bearer_issuer USING btree (key_id ASC, issuer ASC, subject ASC, nid ASC);
+CREATE UNIQUE INDEX hydra_oauth2_trusted_jwt_bearer_issuer_key_id ON hydra_oauth2_trusted_jwt_bearer_issuer (key_id ASC, issuer ASC, subject ASC, nid ASC);


### PR DESCRIPTION
Analysis [here](https://github.com/ory-corp/cloud/issues/7479#issuecomment-2893908150).

Tests with a local Cockroach database with 1 million rows with a similar data distribution as in production:

Plan before:

```
 EXPLAIN                                                                                                           
 SELECT *
  FROM hydra_oauth2_trusted_jwt_bearer_issuer@hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key                                                                      
    WHERE ((issuer = '85d9280d-28ca-4fa0-8ac9-676e408f5efd'))                                                      
     AND ((subject = '') OR (allow_any_subject IS TRUE))                                                           
     AND (key_id = 'private:b178e4c5-7099-46ea-b2d1-fe4a96acd858')                                                                                          
     AND (nid = '9083676a-2b12-45f4-b663-d029ec43698d')                                                            
  LIMIT 1                                                                                                          
 ;                                                                                                                 

  • limit
  │ count: 1
  │
  └── • filter
      │ estimated row count: 0
      │ filter: (subject = '') OR (allow_any_subject IS true)
      │
      └── • index join
          │ estimated row count: 0
          │ table: hydra_oauth2_trusted_jwt_bearer_issuer@primary
          │
          └── • filter
              │ estimated row count: 0
              │ filter: (key_id = 'private:b178e4c5-7099-46ea-b2d1-fe4a96acd858') AND (nid = '9083676a-2b12-45f4-b663-d029ec43698d')
              │
              └── • scan
                    estimated row count: 334,945 (33% of the table; stats collected 7 minutes ago)
                    table: hydra_oauth2_trusted_jwt_bearer_issuer@hydra_oauth2_trusted_jwt_bearer_issuer_issuer_subject_key_id_key
                    spans: [/'85d9280d-28ca-4fa0-8ac9-676e408f5efd' - /'85d9280d-28ca-4fa0-8ac9-676e408f5efd']
(22 rows)

Time: 1ms total (execution 1ms / network 0ms)
```
 (a third of so of the table is effectively linearly scanned).

Plan after (same query):

```
 EXPLAIN                                                                                                           
 SELECT *
  FROM hydra_oauth2_trusted_jwt_bearer_issuer@hydra_oauth2_trusted_jwt_bearer_issuer_key_id                                                                    
    WHERE ((issuer = '85d9280d-28ca-4fa0-8ac9-676e408f5efd'))                                                      
     AND ((subject = '') OR (allow_any_subject IS TRUE))                                                           
     AND (key_id = 'private:b178e4c5-7099-46ea-b2d1-fe4a96acd858')                                                                                          
     AND (nid = '9083676a-2b12-45f4-b663-d029ec43698d')                                                            
  LIMIT 1                                                                                                          
 ;                                                                                                                 

  • limit
  │ count: 1
  │
  └── • filter
      │ estimated row count: 0
      │ filter: (subject = '') OR (allow_any_subject IS true)
      │
      └── • index join
          │ estimated row count: 0
          │ table: hydra_oauth2_trusted_jwt_bearer_issuer@primary
          │
          └── • filter
              │ estimated row count: 0
              │ filter: nid = '9083676a-2b12-45f4-b663-d029ec43698d'
              │
              └── • scan
                    estimated row count: 0 (<0.01% of the table; stats collected 9 minutes ago)
                    table: hydra_oauth2_trusted_jwt_bearer_issuer@hydra_oauth2_trusted_jwt_bearer_issuer_key_id
                    spans: [/'private:b178e4c5-7099-46ea-b2d1-fe4a96acd858'/'85d9280d-28ca-4fa0-8ac9-676e408f5efd' - /'private:b178e4c5-7099-46ea-b2d1-fe4a96acd858'/'85d9280d-28ca-4fa0-8ac9-676e408f5efd']
(22 rows)
```

**tl;dr**: query time for the same query (same row(s) returned): 

```
Before: Time: 140ms total (execution 140ms / network 0ms)
After: Time: 2ms total (execution 2ms / network 0ms)
```

## Related issue(s)

https://github.com/ory-corp/cloud/issues/7479

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

- The new index gets automatically picked up by the planner in my setup. We can think of removing the old index once the new index has proven to speed up things.
- I wanted to name the new index `<old_name>_2` but I bumped into the maximum length limit for an index in postgres