### PR TITLE
refactor: moved the `prompt=none` check to a more appropriate place 

### DIFF
--- a/consent/strategy_oauth_test.go
+++ b/consent/strategy_oauth_test.go
@@ -811,7 +811,7 @@ func TestStrategyLoginConsentNext(t *testing.T) {
 			acceptConsentHandler(t, &hydra.AcceptOAuth2ConsentRequest{Remember: pointerx.Bool(true)}))
 
 		makeRequestAndExpectError(t, nil, c, url.Values{"prompt": {"none"}},
-			"Prompt 'none' was requested, but no existing login session was found")
+			"prompt is set to 'none' and no existing login session was found")
 	})
 
 	t.Run("case=should fail because prompt is none and consent is missing a permission which requires re-authorization of the app", func(t *testing.T) {


### PR DESCRIPTION
This pull request centralizes the logic for handling `prompt=none` into a single location.
Previously, this check was scattered across multiple places in the codebase, leading to duplicated logic and making the flow harder to follow.
By moving the `prompt=none` check to a more appropriate layer, this change improves maintainability, readability, and ensures consistent behavior throughout the login process.

No breaking changes are introduced.

## Related issue(s)

This PR addresses internal maintainability concerns and does not correspond to a specific GitHub issue.
The duplication and fragmentation of `prompt=none` logic was identified during code review and refactoring efforts.

## Checklist

* [x] I have read the [[contributing guidelines](https://chatgpt.com/blob/master/CONTRIBUTING.md)](../blob/master/CONTRIBUTING.md).
* [ ] I have referenced an issue containing the design document if my change introduces a new feature.
* [x] I am following the [[contributing code guidelines](https://chatgpt.com/blob/master/CONTRIBUTING.md#contributing-code)](../blob/master/CONTRIBUTING.md#contributing-code).
* [x] I have read the [[security policy](https://chatgpt.com/security/policy)](../security/policy).
* [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security vulnerability, I confirm that I got the approval (please contact [[security@ory.sh](mailto:security@ory.sh)](mailto:security@ory.sh)) from the maintainers to push the changes.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [ ] I have added or changed [[the documentation](https://github.com/ory/docs)](https://github.com/ory/docs).

## Further Comments
