### PR TITLE
fix: override oauth2.HTTPClient w/ ctx correctly

### DIFF
--- a/cmd/cmd_perform_authorization_code.go
+++ b/cmd/cmd_perform_authorization_code.go
@@ -598,7 +598,7 @@ func (rt *router) callback(w http.ResponseWriter, r *http.Request, _ httprouter.
 	}
 
 	code := r.URL.Query().Get("code")
-	ctx := context.WithValue(rt.cmd.Context(), oauth2.HTTPClient, rt.cl)
+	ctx := context.WithValue(rt.cmd.Context(), oauth2.HTTPClient, rt.cl.GetConfig().HTTPClient)
 	token, err := rt.conf.Exchange(ctx, code)
 	if err != nil {
 		_, _ = fmt.Fprintf(rt.cmd.ErrOrStderr(), "Unable to exchange code for token: %s\n", err)

--- a/cmd/cmd_perform_client_credentials.go
+++ b/cmd/cmd_perform_client_credentials.go
@@ -35,7 +35,7 @@ using the CLI.`,
 				return err
 			}
 
-			ctx := context.WithValue(cmd.Context(), oauth2.HTTPClient, hc)
+			ctx := context.WithValue(cmd.Context(), oauth2.HTTPClient, hc.GetConfig().HTTPClient)
 
 			scopes := flagx.MustGetStringSlice(cmd, "scope")
 			audience := flagx.MustGetStringSlice(cmd, "audience")


### PR DESCRIPTION
Previously, the various commands that exist to help you do the OAuth2 flow locally were not overriding the `oauth2.HTTPClient` via the context correctly. This meant that if you were e.g. running Hydra locally and using a self-signed/test TLS certificate, the flows would fail with TLS errors _even in the presence of_ the `--skip-tls-verify` flag.

**Steps to reproduce bug:**

1. Set `SERVE_TLS_CERT_BASE64` and `SERVE_TLS_KEY_BASE64` to something self-signed/PEM that will otherwise not be considered valid.
2. Enable TLS serving in Hydra's config:
    ```diff
    serve:
    +  tls:
    +    enabled: true
    ```
3. Create a test client:

    ```
    $ hydra create client --skip-tls-verify \
        --name demo-client \
        --secret password123 \
        --grant-type authorization_code,refresh_token \
        --response-type token,code,id_token \
        --scope openid,offline,example.scope \
        --redirect-uri http://127.0.0.1:9010/callback
    ```

4. Use `perform` to try and do an `authorization-code`:
    ```bash
    $ hydra perform --skip-tls-verify authorization-code --port 9010 --client-id 387069d9-9a01-4e53-b72c-507a59f0f4df --client-secret password123 --scope openid,offline,example.scope --skip-tls-verify --auth-url https://127.0.0.1:4444/oauth2/auth
    ```

5. Observe failure, as if `--skip-tls-verify` had not been set at all:
    ![image](https://github.com/user-attachments/assets/2cb0b98b-7bcb-43c9-a088-1913db5fa9aa)


6. Apply diff in this PR.

7. It works as you'd expect:
    ![image](https://github.com/user-attachments/assets/5f2e19e0-48d5-4e3c-9136-c66a6a865136)



## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] ~~I have added or changed [the documentation](https://github.com/ory/docs).~~ Not applicable, docs already contained information about this flag; it just didn't work.

## Further Comments

Minor change.