### PR TITLE
feat: add subject query parameter to token deletion endpoint

### DIFF
--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -1265,15 +1265,25 @@ paths:
       - oAuth2
   /admin/oauth2/tokens:
     delete:
-      description: This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0
-        Client from the database.
+      description: |-
+        This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client or Subject from the database.
+
+        Note that you must specify either the `client_id` or the `subject` parameter.
       operationId: deleteOAuth2Token
       parameters:
       - description: OAuth 2.0 Client ID
         explode: true
         in: query
         name: client_id
-        required: true
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: OAuth 2.0 Subject
+        explode: true
+        in: query
+        name: subject
+        required: false
         schema:
           type: string
         style: form

--- a/internal/httpclient/api_o_auth2.go
+++ b/internal/httpclient/api_o_auth2.go
@@ -790,11 +790,18 @@ type ApiDeleteOAuth2TokenRequest struct {
 	ctx        context.Context
 	ApiService *OAuth2APIService
 	clientId   *string
+	subject    *string
 }
 
 // OAuth 2.0 Client ID
 func (r ApiDeleteOAuth2TokenRequest) ClientId(clientId string) ApiDeleteOAuth2TokenRequest {
 	r.clientId = &clientId
+	return r
+}
+
+// OAuth 2.0 Subject
+func (r ApiDeleteOAuth2TokenRequest) Subject(subject string) ApiDeleteOAuth2TokenRequest {
+	r.subject = &subject
 	return r
 }
 
@@ -805,7 +812,9 @@ func (r ApiDeleteOAuth2TokenRequest) Execute() (*http.Response, error) {
 /*
 DeleteOAuth2Token Delete OAuth 2.0 Access Tokens from specific OAuth 2.0 Client
 
-This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client from the database.
+This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client or Subject from the database.
+
+Note that you must specify either the `client_id` or the `subject` parameter.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@return ApiDeleteOAuth2TokenRequest
@@ -835,11 +844,13 @@ func (a *OAuth2APIService) DeleteOAuth2TokenExecute(r ApiDeleteOAuth2TokenReques
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.clientId == nil {
-		return nil, reportError("clientId is required and must be specified")
-	}
 
-	parameterAddToHeaderOrQuery(localVarQueryParams, "client_id", r.clientId, "")
+	if r.clientId != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "client_id", r.clientId, "")
+	}
+	if r.subject != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "subject", r.subject, "")
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/internal/httpclient/docs/OAuth2API.md
+++ b/internal/httpclient/docs/OAuth2API.md
@@ -444,7 +444,7 @@ No authorization required
 
 ## DeleteOAuth2Token
 
-> DeleteOAuth2Token(ctx).ClientId(clientId).Execute()
+> DeleteOAuth2Token(ctx).ClientId(clientId).Subject(subject).Execute()
 
 Delete OAuth 2.0 Access Tokens from specific OAuth 2.0 Client
 
@@ -463,11 +463,12 @@ import (
 )
 
 func main() {
-	clientId := "clientId_example" // string | OAuth 2.0 Client ID
+	clientId := "clientId_example" // string | OAuth 2.0 Client ID (optional)
+	subject := "subject_example" // string | OAuth 2.0 Subject (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	r, err := apiClient.OAuth2API.DeleteOAuth2Token(context.Background()).ClientId(clientId).Execute()
+	r, err := apiClient.OAuth2API.DeleteOAuth2Token(context.Background()).ClientId(clientId).Subject(subject).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `OAuth2API.DeleteOAuth2Token``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -487,6 +488,7 @@ Other parameters are passed through a pointer to a apiDeleteOAuth2TokenRequest s
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **clientId** | **string** | OAuth 2.0 Client ID | 
+ **subject** | **string** | OAuth 2.0 Subject | 
 
 ### Return type
 

--- a/persistence/sql/migrations/20250917050010000001_add_access_subject_idx.down.sql
+++ b/persistence/sql/migrations/20250917050010000001_add_access_subject_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX hydra_oauth2_access_client_id_subject_idx;

--- a/persistence/sql/migrations/20250917050010000001_add_access_subject_idx.up.sql
+++ b/persistence/sql/migrations/20250917050010000001_add_access_subject_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX hydra_oauth2_access_subject_idx on hydra_oauth2_access (subject);

--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -628,6 +628,17 @@ func (p *Persister) DeleteAccessTokens(ctx context.Context, clientID string) (er
 	)
 }
 
+func (p *Persister) DeleteSubjectAccessTokens(ctx context.Context, sub string) (err error) {
+	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.DeleteSubjectAccessTokens",
+		trace.WithAttributes(events.Subject(sub)),
+	)
+	defer otelx.End(span, &err)
+	/* #nosec G201 table is static */
+	return sqlcon.HandleError(
+		p.QueryWithNetwork(ctx).Where("subject = ?", sub).Delete(&OAuth2RequestSQL{Table: sqlTableAccess}),
+	)
+}
+
 func handleRetryError(err error) error {
 	if err == nil {
 		return nil

--- a/spec/api.json
+++ b/spec/api.json
@@ -3285,14 +3285,21 @@
     },
     "/admin/oauth2/tokens": {
       "delete": {
-        "description": "This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client from the database.",
+        "description": "This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client or Subject from the database.\n\nNote that you must specify either the `client_id` or the `subject` parameter.",
         "operationId": "deleteOAuth2Token",
         "parameters": [
           {
             "description": "OAuth 2.0 Client ID",
             "in": "query",
             "name": "client_id",
-            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "OAuth 2.0 Subject",
+            "in": "query",
+            "name": "subject",
             "schema": {
               "type": "string"
             }

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -1426,7 +1426,7 @@
     },
     "/admin/oauth2/tokens": {
       "delete": {
-        "description": "This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client from the database.",
+        "description": "This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client or Subject from the database.\n\nNote that you must specify either the `client_id` or the `subject` parameter.",
         "consumes": [
           "application/json"
         ],
@@ -1444,8 +1444,13 @@
             "type": "string",
             "description": "OAuth 2.0 Client ID",
             "name": "client_id",
-            "in": "query",
-            "required": true
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "OAuth 2.0 Subject",
+            "name": "subject",
+            "in": "query"
           }
         ],
         "responses": {

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -87,6 +87,10 @@ func ClientID(clientID string) otelattr.KeyValue {
 	return otelattr.String(attributeKeyOAuth2ClientID, clientID)
 }
 
+func Subject(subject string) otelattr.KeyValue {
+	return otelattr.String(attributeKeyOAuth2Subject, subject)
+}
+
 func RefreshTokenSignature(signature string) otelattr.KeyValue {
 	return otelattr.String(attributeKeyOAuth2RefreshTokenSignature, signature)
 }

--- a/x/fosite_storer.go
+++ b/x/fosite_storer.go
@@ -38,6 +38,8 @@ type FositeStorer interface {
 
 	DeleteAccessTokens(ctx context.Context, clientID string) error
 
+	DeleteSubjectAccessTokens(ctx context.Context, subject string) error
+
 	FlushInactiveRefreshTokens(ctx context.Context, notAfter time.Time, limit int, batchSize int) error
 
 	// DeleteOpenIDConnectSession deletes an OpenID Connect session.


### PR DESCRIPTION
## Related issue(s)

[#discussion 3284](https://github.com/ory/hydra/discussions/3284)

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

When using a token with introspection verification, I needed to be able to disable all access tokens for a specific user for immediate refresh. This doesn't apply to the user's Kratos session, as I only needed to prompt the client to refresh their current token without terminating the session or reauthenticating. I hope this contribution will help others resolve similar cases.