### PR TITLE
fix: avoid Client slice field be null

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -407,6 +407,26 @@ func (c *Client) BeforeSave(_ *pop.Connection) error {
 		c.AllowedCORSOrigins = sqlxx.StringSliceJSONFormat{}
 	}
 
+	if c.Contacts == nil {
+		c.Contacts = sqlxx.StringSliceJSONFormat{}
+	}
+
+	if c.PostLogoutRedirectURIs == nil {
+		c.PostLogoutRedirectURIs = sqlxx.StringSliceJSONFormat{}
+	}
+
+	if c.RequestURIs == nil {
+		c.RequestURIs = sqlxx.StringSliceJSONFormat{}
+	}
+
+	if c.GrantTypes == nil {
+		c.GrantTypes = sqlxx.StringSliceJSONFormat{}
+	}
+
+	if c.ResponseTypes == nil {
+		c.ResponseTypes = sqlxx.StringSliceJSONFormat{}
+	}
+
 	if c.CreatedAt.IsZero() {
 		c.CreatedAt = time.Now()
 	}


### PR DESCRIPTION
Avoid having the slice members in the Client structure returned by the handler for the `/oauth2/register` route be null, as this can cause significant issues for most clients that use the OpenID Dynamic Client Registration feature.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
