### PR TITLE
fix: add optional exp claim to back-channel logout token

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -713,14 +713,20 @@ func (s *defaultStrategy) executeBackChannelLogout(ctx context.Context, r *http.
 		// s.r.ConsentManager().GetForcedObfuscatedLoginSession(context.Background(), subject, <missing>)
 		// sub := s.obfuscateSubjectIdentifier(c, subject, )
 
-		t, _, err := s.r.OpenIDJWTSigner().Generate(ctx, jwt.MapClaims{
+		now := time.Now().UTC()
+		claims := jwt.MapClaims{
 			"iss":    s.r.Config().IssuerURL(ctx).String(),
 			"aud":    []string{c.ID},
-			"iat":    time.Now().UTC().Unix(),
+			"iat":    now.Unix(),
 			"jti":    uuid.New(),
 			"events": map[string]struct{}{"http://schemas.openid.net/event/backchannel-logout": {}},
 			"sid":    sid,
-		}, &jwt.Headers{
+		}
+		if logoutTokenLifespan := s.r.Config().GetLogoutTokenLifespan(ctx); logoutTokenLifespan > 0 {
+			claims["exp"] = now.Add(logoutTokenLifespan).Unix()
+		}
+
+		t, _, err := s.r.OpenIDJWTSigner().Generate(ctx, claims, &jwt.Headers{
 			Extra: map[string]interface{}{"kid": openIDKeyID},
 		})
 		if err != nil {

--- a/consent/strategy_logout_test.go
+++ b/consent/strategy_logout_test.go
@@ -332,6 +332,7 @@ func TestLogoutFlows(t *testing.T) {
 			assert.EqualValues(t, <-sid, logoutToken.Get("sid").String(), logoutToken.Raw)
 			assert.Empty(t, logoutToken.Get("sub").String(), logoutToken.Raw) // The sub claim should be empty because it doesn't work with forced obfuscation and thus we can't easily recover it.
 			assert.Empty(t, logoutToken.Get("nonce").String(), logoutToken.Raw)
+			assert.False(t, logoutToken.Get("exp").Exists(), "exp claim should not be present when ttl.logout_token is not set")
 		})
 
 		t.Run("method=get", testExpectPostLogoutPage(createBrowserWithSession(t, c), http.MethodGet, url.Values{}, defaultRedirectedMessage))
@@ -340,6 +341,36 @@ func TestLogoutFlows(t *testing.T) {
 
 		logoutWg.Wait()      // we want to ensure that logout ui was called!
 		backChannelWG.Wait() // we want to ensure that all back channels have been called!
+	})
+
+	t.Run("case=should include exp claim in logout token when ttl.logout_token is set", func(t *testing.T) {
+		require.NoError(t, reg.Config().Source(ctx).Set(config.KeyLogoutTokenLifespan, "2m"))
+		t.Cleanup(func() {
+			require.NoError(t, reg.Config().Source(ctx).Set(config.KeyLogoutTokenLifespan, "0s"))
+		})
+
+		sid := acceptLoginAsAndWatchSid(t, subject)
+
+		logoutWg := newWg(2)
+		setupCheckAndAcceptLogoutHandler(t, logoutWg, nil)
+
+		backChannelWG := newWg(2)
+		c := createClientWithBackchannelLogout(t, backChannelWG, func(t *testing.T, logoutToken gjson.Result) {
+			assert.EqualValues(t, <-sid, logoutToken.Get("sid").String(), logoutToken.Raw)
+			assert.True(t, logoutToken.Get("exp").Exists(), "exp claim should be present when ttl.logout_token is set")
+
+			iat := logoutToken.Get("iat").Int()
+			exp := logoutToken.Get("exp").Int()
+			diff := exp - iat
+			assert.InDelta(t, 120, diff, 2, "exp should be approximately iat + 120 seconds")
+		})
+
+		t.Run("method=get", testExpectPostLogoutPage(createBrowserWithSession(t, c), http.MethodGet, url.Values{}, defaultRedirectedMessage))
+
+		t.Run("method=post", testExpectPostLogoutPage(createBrowserWithSession(t, c), http.MethodPost, url.Values{}, defaultRedirectedMessage))
+
+		logoutWg.Wait()
+		backChannelWG.Wait()
 	})
 
 	// Only do GET requests from here on out, POST should be tested enough to ensure that it is working fine already.

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -75,6 +75,7 @@ const (
 	KeyIDTokenLifespan                           = "ttl.id_token"      // #nosec G101
 	KeyAuthCodeLifespan                          = "ttl.auth_code"
 	KeyDeviceAndUserCodeLifespan                 = "ttl.device_user_code"
+	KeyLogoutTokenLifespan                       = "ttl.logout_token" // #nosec G101
 	KeyAuthenticationSessionLifespan             = "ttl.authentication_session"
 	KeyScopeStrategy                             = "strategies.scope"
 	KeyGetCookieSecrets                          = "secrets.cookie"
@@ -427,6 +428,11 @@ func (p *DefaultProvider) fallbackURL(ctx context.Context, path string, serve *c
 // GetDeviceAndUserCodeLifespan returns the device_code and user_code lifespan. Defaults to 15 minutes.
 func (p *DefaultProvider) GetDeviceAndUserCodeLifespan(ctx context.Context) time.Duration {
 	return p.p.DurationF(KeyDeviceAndUserCodeLifespan, time.Minute*15)
+}
+
+// GetLogoutTokenLifespan returns the logout_token lifespan. Defaults to 0 (no exp claim).
+func (p *DefaultProvider) GetLogoutTokenLifespan(ctx context.Context) time.Duration {
+	return p.p.DurationF(KeyLogoutTokenLifespan, 0)
 }
 
 // GetAuthenticationSessionLifespan returns the authentication_session lifespan.

--- a/oryx/httpx/ssrf.go
+++ b/oryx/httpx/ssrf.go
@@ -11,9 +11,10 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/ory/x/ipx"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/ory/x/ipx"
 )
 
 var _ http.RoundTripper = (*noInternalIPRoundTripper)(nil)

--- a/oryx/otelx/middleware.go
+++ b/oryx/otelx/middleware.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ory/x/httprouterx"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/ory/x/httprouterx"
 )
 
 var withDefaultFilters = otelhttp.WithFilter(func(r *http.Request) bool {

--- a/oryx/prometheusx/metrics.go
+++ b/oryx/prometheusx/metrics.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/ory/x/httprouterx"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/negroni"
+
+	"github.com/ory/x/httprouterx"
 )
 
 type HTTPMetrics struct {

--- a/oryx/region/region.go
+++ b/oryx/region/region.go
@@ -5,8 +5,9 @@ package region
 import (
 	"database/sql/driver"
 
-	"github.com/ory/herodot"
 	"github.com/pkg/errors"
+
+	"github.com/ory/herodot"
 )
 
 // Region is an Ory Network region. Specific regions map to a single CRDB

--- a/oryx/watcherx/directory.go
+++ b/oryx/watcherx/directory.go
@@ -53,7 +53,7 @@ type directoryWatcher struct {
 	// potentially by external callers (e.g. tests) concurrently.
 	subDirsMtx sync.RWMutex
 	subDirs    map[string]struct{}
-	w       *fsnotify.Watcher
+	w          *fsnotify.Watcher
 }
 
 func (w *directoryWatcher) handleEvent(ctx context.Context, e fsnotify.Event) {

--- a/spec/config.json
+++ b/spec/config.json
@@ -726,6 +726,15 @@
               "$ref": "#/definitions/duration"
             }
           ]
+        },
+        "logout_token": {
+          "description": "Configures how long logout tokens are valid. If set to \"0s\" (zero seconds) or left unset, no exp claim will be added to the logout token (preserving backward compatibility). The value must use the duration string format. The OpenID Connect Back-Channel Logout specification recommends a value of at most two minutes (e.g. \"2m\").",
+          "type": "string",
+          "allOf": [
+            {
+              "$ref": "#/definitions/duration"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

[The OpenID Connect Back-Channel Logout 1.0 specification](https://openid.net/specs/openid-connect-backchannel-1_0.html) requires the `exp` claim in logout tokens, but Hydra currently omits it.

This adds a new `ttl.logout_token` configuration option. When set (e.g. `2m`), the `exp` claim is included in the logout token. 

When unset or 0, the current behavior is preserved for backward compatibility.

## Related issue(s)

https://github.com/ory/hydra/issues/4035

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.com/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logout tokens can optionally include an expiration (exp) claim controlled by the ttl.logout_token configuration; when unset or zero, tokens remain backward-compatible (no exp).

* **Tests**
  * Added tests verifying both unset and configured logout token lifespans, asserting presence/absence of exp and correct iat/exp timing.

* **Style**
  * Minor import/formatting housekeeping across utility packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/hydra/pull/4073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->