### PR TITLE
fix: remove stale reference to closed PR #3851

### DIFF
--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -758,8 +758,7 @@ func (h *Handler) performOAuth2DeviceVerificationFlow(w http.ResponseWriter, r *
 	// - The device auth session is updated (user_code is marked as accepted)
 	// - The OpenID session is created
 	// If there were multiple flows created for the same user_code then we may end up with multiple flow objects
-	// persisted to the database, while only one of them was actually used to validate the user_code
-	// (see https://github.com/ory/hydra/pull/3851#discussion_r1843678761)
+	// persisted to the database, while only one of them was actually used to validate the user_code.
 	f, err := h.r.ConsentStrategy().HandleOAuth2DeviceAuthorizationRequest(ctx, w, r)
 	if errors.Is(err, consent.ErrAbortOAuth2Request) {
 		x.LogError(r, err, h.r.Logger())


### PR DESCRIPTION
## Summary

Removes dead link to closed PR #3851 discussion from `oauth2/handler.go`. The Device Authorization Grant (RFC 8628) feature was later merged via PR #3912, making the reference to #3851 stale. The explanatory comment about the race condition is preserved.

Closes #3953

## Note on #3996

Issue #3996 reports stale references to `ory/x#509` in 146 SQL migration files. However, PR #509 in ory/x was merged (not abandoned) on 2022-05-17. The Closed Reference Notifier bot filed #3996 as a false positive since GitHub treats merged PRs as "closed". Additionally, the migration files are auto-generated and marked `DO NOT EDIT`. I recommend closing #3996 as not actionable.

## Test plan

- No behavioral changes, comment-only fix
- Verified no other references to PR #3851 remain in the codebase