### PR TITLE
fix(oidc): return registration_client_uri in PUT and GET dynamic client responses

### DIFF
--- a/client/handler.go
+++ b/client/handler.go
@@ -384,6 +384,8 @@ func (h *Handler) setOidcDynamicClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	c.RegistrationClientURI = urlx.AppendPaths(h.r.Config().PublicURL(r.Context()), DynClientsHandlerPath, url.PathEscape(c.GetID())).String()
+
 	h.r.Writer().Write(w, r, &c)
 }
 
@@ -666,6 +668,7 @@ func (h *Handler) getOidcDynamicClient(w http.ResponseWriter, r *http.Request) {
 
 	c.Secret = ""
 	c.Metadata = nil
+	c.RegistrationClientURI = urlx.AppendPaths(h.r.Config().PublicURL(r.Context()), DynClientsHandlerPath, url.PathEscape(c.GetID())).String()
 	h.r.Writer().Write(w, r, c)
 }
 


### PR DESCRIPTION
Fixes #4084

## Problem

The OIDC Dynamic Client Registration `PUT` and `GET` endpoints do not include `registration_client_uri` in their responses, violating the [OpenID Connect Dynamic Client Registration 1.0](https://openid.net/specs/openid-connect-registration-1_0.html) specification.

The `POST` (create) endpoint correctly sets it (handler.go:199), but `PUT` (update) and `GET` (read) omit it.

## Fix

Set `RegistrationClientURI` before writing the response in both `setOidcDynamicClient` and `getOidcDynamicClient`, matching the create handler.