### PR TITLE
fix: add code_verifier to token exchange OpenAPI spec

### DIFF
--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -5001,6 +5001,9 @@ components:
         code:
           type: string
           x-formData-name: code
+        code_verifier:
+          type: string
+          x-formData-name: code_verifier
         grant_type:
           required:
           - grant_type

--- a/internal/httpclient/api_o_auth2.go
+++ b/internal/httpclient/api_o_auth2.go
@@ -2438,6 +2438,7 @@ type ApiOauth2TokenExchangeRequest struct {
 	grantType    *string
 	clientId     *string
 	code         *string
+	codeVerifier *string
 	redirectUri  *string
 	refreshToken *string
 }
@@ -2454,6 +2455,11 @@ func (r ApiOauth2TokenExchangeRequest) ClientId(clientId string) ApiOauth2TokenE
 
 func (r ApiOauth2TokenExchangeRequest) Code(code string) ApiOauth2TokenExchangeRequest {
 	r.code = &code
+	return r
+}
+
+func (r ApiOauth2TokenExchangeRequest) CodeVerifier(codeVerifier string) ApiOauth2TokenExchangeRequest {
+	r.codeVerifier = &codeVerifier
 	return r
 }
 
@@ -2537,6 +2543,9 @@ func (a *OAuth2APIService) Oauth2TokenExchangeExecute(r ApiOauth2TokenExchangeRe
 	}
 	if r.code != nil {
 		parameterAddToHeaderOrQuery(localVarFormParams, "code", r.code, "", "")
+	}
+	if r.codeVerifier != nil {
+		parameterAddToHeaderOrQuery(localVarFormParams, "code_verifier", r.codeVerifier, "", "")
 	}
 	parameterAddToHeaderOrQuery(localVarFormParams, "grant_type", r.grantType, "", "")
 	if r.redirectUri != nil {

--- a/internal/httpclient/docs/OAuth2API.md
+++ b/internal/httpclient/docs/OAuth2API.md
@@ -1318,7 +1318,7 @@ No authorization required
 
 ## Oauth2TokenExchange
 
-> OAuth2TokenExchange Oauth2TokenExchange(ctx).GrantType(grantType).ClientId(clientId).Code(code).RedirectUri(redirectUri).RefreshToken(refreshToken).Execute()
+> OAuth2TokenExchange Oauth2TokenExchange(ctx).GrantType(grantType).ClientId(clientId).Code(code).CodeVerifier(codeVerifier).RedirectUri(redirectUri).RefreshToken(refreshToken).Execute()
 
 The OAuth 2.0 Token Endpoint
 
@@ -1340,12 +1340,13 @@ func main() {
 	grantType := "grantType_example" // string | 
 	clientId := "clientId_example" // string |  (optional)
 	code := "code_example" // string |  (optional)
+	codeVerifier := "codeVerifier_example" // string |  (optional)
 	redirectUri := "redirectUri_example" // string |  (optional)
 	refreshToken := "refreshToken_example" // string |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.OAuth2API.Oauth2TokenExchange(context.Background()).GrantType(grantType).ClientId(clientId).Code(code).RedirectUri(redirectUri).RefreshToken(refreshToken).Execute()
+	resp, r, err := apiClient.OAuth2API.Oauth2TokenExchange(context.Background()).GrantType(grantType).ClientId(clientId).Code(code).CodeVerifier(codeVerifier).RedirectUri(redirectUri).RefreshToken(refreshToken).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `OAuth2API.Oauth2TokenExchange``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -1369,6 +1370,7 @@ Name | Type | Description  | Notes
  **grantType** | **string** |  | 
  **clientId** | **string** |  | 
  **code** | **string** |  | 
+ **codeVerifier** | **string** |  | 
  **redirectUri** | **string** |  | 
  **refreshToken** | **string** |  | 
 

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -1109,6 +1109,9 @@ type _ struct {
 
 	// in: formData
 	ClientID string `json:"client_id"`
+
+	// in: formData
+	CodeVerifier string `json:"code_verifier"`
 }
 
 // OAuth2 Token Exchange Result

--- a/oryx/pagination/keysetpagination_v2/page_token.go
+++ b/oryx/pagination/keysetpagination_v2/page_token.go
@@ -12,9 +12,10 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/ory/herodot"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/nacl/secretbox"
+
+	"github.com/ory/herodot"
 )
 
 var fallbackEncryptionKey = &[32]byte{}

--- a/spec/api.json
+++ b/spec/api.json
@@ -4088,6 +4088,10 @@
                     "type": "string",
                     "x-formData-name": "code"
                   },
+                  "code_verifier": {
+                    "type": "string",
+                    "x-formData-name": "code_verifier"
+                  },
                   "grant_type": {
                     "required": [
                       "grant_type"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -2173,6 +2173,11 @@
             "type": "string",
             "name": "client_id",
             "in": "formData"
+          },
+          {
+            "type": "string",
+            "name": "code_verifier",
+            "in": "formData"
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR fixes a mismatch between the OAuth2 token endpoint implementation and the OpenAPI (Swagger) specification by adding the missing `code_verifier` parameter to the token exchange request.

Hydra already supports PKCE, but the `code_verifier` field was not included in the `swagger:parameters oauth2TokenExchange` definition. This caused generated SDKs and API documentation to be incomplete.

## Related issue(s)
[oauth2: Missing code_verifier parameter in token exchange OpenAPI spec](https://github.com/ory/hydra/issues/4099)

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- ~~[ ] I have referenced an issue containing the design document if my change
      introduces a new feature.~~ N/A - updating existing feature
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- ~~[ ] I have added or changed [the documentation](https://github.com/ory/docs).~~ N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Optional OAuth2 PKCE support: allow sending a code_verifier with token exchange requests.

* **Documentation**
  * Updated OAuth2 token exchange docs and examples to show the optional code_verifier parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->