### PR TITLE
fix: avoid config watchers in static config tests

### DIFF
--- a/driver/config/provider_test.go
+++ b/driver/config/provider_test.go
@@ -205,7 +205,10 @@ func TestProviderCookieSameSiteMode(t *testing.T) {
 
 func TestProviderValidates(t *testing.T) {
 	ctx := t.Context()
-	c := newProvider(t, configx.WithConfigFiles("../../internal/.hydra.yaml"))
+	c := newProvider(t,
+		configx.WithConfigFiles("../../internal/.hydra.yaml"),
+		configx.DisableFileWatching(),
+	)
 
 	// log
 	assert.Equal(t, "debug", c.Source(ctx).String(KeyLogLevel))

--- a/oryx/configx/options.go
+++ b/oryx/configx/options.go
@@ -74,6 +74,13 @@ func DisableEnvLoading() OptionModifier {
 	}
 }
 
+// DisableFileWatching loads configured files once without watching them for changes.
+func DisableFileWatching() OptionModifier {
+	return func(p *Provider) {
+		p.disableFileWatching = true
+	}
+}
+
 func WithValue(key string, value interface{}) OptionModifier {
 	return func(p *Provider) {
 		p.forcedValues = append(p.forcedValues, tuple{Key: key, Value: value})

--- a/oryx/configx/provider.go
+++ b/oryx/configx/provider.go
@@ -49,8 +49,9 @@ type Provider struct {
 	baseValues   []tuple
 	files        []string
 
-	skipValidation    bool
-	disableEnvLoading bool
+	skipValidation      bool
+	disableEnvLoading   bool
+	disableFileWatching bool
 
 	logger *logrusx.Logger
 
@@ -142,7 +143,7 @@ func (p *Provider) createProviders(ctx context.Context) (providers []koanf.Provi
 	c := make(watcherx.EventChannel)
 
 	defer func() {
-		if err == nil && len(paths) > 0 {
+		if err == nil && len(paths) > 0 && !p.disableFileWatching {
 			go p.watchForFileChanges(ctx, c)
 		}
 	}()
@@ -152,8 +153,10 @@ func (p *Provider) createProviders(ctx context.Context) (providers []koanf.Provi
 			return nil, err
 		}
 
-		if _, err := fp.WatchChannel(ctx, c); err != nil {
-			return nil, err
+		if !p.disableFileWatching {
+			if _, err := fp.WatchChannel(ctx, c); err != nil {
+				return nil, err
+			}
 		}
 
 		providers = append(providers, fp)


### PR DESCRIPTION
## Related issue(s)

No direct issue found. Closest hits were #47 and #2850, but different root causes.

## What changed

`TestProviderValidates` only reads `internal/.hydra.yaml` as a static fixture, but `configx` still spins up an fsnotify watcher for it. On machines already near `fs.inotify.max_user_instances`, that goes boom with `too many open files`.

Repro:

```bash
sysctl fs.inotify.max_user_instances
go test ./driver/config -run TestProviderValidates -count=1 -v
```

This adds `configx.DisableFileWatching()` and uses it for that static config test. Prod defaults stay the same; file watching is still on unless callers opt out. Tiny deflake, no big machinery.

Checks:

```bash
go test ./driver/config -run TestProviderValidates -count=1 -v
go test ./driver/config -count=1
(cd oryx && go test ./configx -count=1)
git diff --check
```

## Checklist

- [x] I have read the contributing guidelines.
- [x] I am following the contributing code guidelines.
- [x] I have read the security policy.
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed the documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to disable file watching, allowing configuration files to be loaded once without automatic change monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->