### PR TITLE
feat: optional access token strategy override for DCR

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -462,6 +462,18 @@
                 "type": "string"
               },
               "examples": [["openid", "offline", "offline_access"]]
+            },
+            "strategies": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Optional strategy overrides for clients created via OpenID Connect Dynamic Client Registration. When unset, dynamically registered clients inherit the global strategies (e.g. `strategies.access_token`).",
+              "properties": {
+                "access_token": {
+                  "type": "string",
+                  "enum": ["opaque", "jwt"],
+                  "description": "Access token strategy used for clients created via Dynamic Client Registration. When unset, the global `strategies.access_token` is used. Clients cannot override this value via the registration payload."
+                }
+              }
             }
           }
         }

--- a/client/validator.go
+++ b/client/validator.go
@@ -235,6 +235,13 @@ func (v *Validator) ValidateDynamicRegistration(ctx context.Context, c *Client) 
 		return errors.WithStack(ErrInvalidRequest.WithDescription(`"skip_logout_consent" cannot be set for dynamic client registration`))
 	}
 
+	// Apply the configured access-token strategy override for dynamically
+	// registered clients (if any). When unset, the client inherits the
+	// global `strategies.access_token` setting at token-issuance time.
+	if s := v.r.Config().OIDCDynamicClientRegistrationAccessTokenStrategy(ctx); s != "" {
+		c.AccessTokenStrategy = string(s)
+	}
+
 	return v.Validate(ctx, c)
 }
 

--- a/client/validator_test.go
+++ b/client/validator_test.go
@@ -404,3 +404,85 @@ func TestValidateDynamicRegistration(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateDynamicRegistrationAccessTokenStrategy covers the behaviour
+// matrix described in https://github.com/ory/hydra/issues/4060 for the
+// optional `oidc.dynamic_client_registration.strategies.access_token`
+// override.
+func TestValidateDynamicRegistrationAccessTokenStrategy(t *testing.T) {
+	ctx := t.Context()
+
+	baseConfig := func(extra map[string]any) map[string]any {
+		m := map[string]any{
+			config.KeySubjectTypesSupported: []string{"public"},
+			config.KeyDefaultClientScope:    []string{"openid"},
+		}
+		for k, v := range extra {
+			m[k] = v
+		}
+		return m
+	}
+
+	for _, tc := range []struct {
+		name           string
+		configValues   map[string]any
+		in             *Client
+		expectErr      bool
+		expectStrategy string
+	}{
+		{
+			name: "dcr-unset-global-opaque-client-inherits",
+			configValues: baseConfig(map[string]any{
+				config.KeyAccessTokenStrategy: "opaque",
+			}),
+			in:             &Client{RedirectURIs: []string{"https://foo/"}},
+			expectStrategy: "",
+		},
+		{
+			name: "dcr-unset-global-jwt-client-inherits",
+			configValues: baseConfig(map[string]any{
+				config.KeyAccessTokenStrategy: "jwt",
+			}),
+			in:             &Client{RedirectURIs: []string{"https://foo/"}},
+			expectStrategy: "",
+		},
+		{
+			name: "dcr-opaque-overrides-global-jwt",
+			configValues: baseConfig(map[string]any{
+				config.KeyAccessTokenStrategy:    "jwt",
+				config.KeyDCRAccessTokenStrategy: "opaque",
+			}),
+			in:             &Client{RedirectURIs: []string{"https://foo/"}},
+			expectStrategy: "opaque",
+		},
+		{
+			name: "dcr-jwt-overrides-global-opaque",
+			configValues: baseConfig(map[string]any{
+				config.KeyAccessTokenStrategy:    "opaque",
+				config.KeyDCRAccessTokenStrategy: "jwt",
+			}),
+			in:             &Client{RedirectURIs: []string{"https://foo/"}},
+			expectStrategy: "jwt",
+		},
+		{
+			name: "client-supplied-strategy-still-rejected-even-with-dcr-override",
+			configValues: baseConfig(map[string]any{
+				config.KeyDCRAccessTokenStrategy: "jwt",
+			}),
+			in:        &Client{RedirectURIs: []string{"https://foo/"}, AccessTokenStrategy: "jwt"},
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := testhelpers.NewRegistryMemory(t, driver.WithConfigOptions(configx.WithValues(tc.configValues)))
+			v := NewValidator(reg)
+			err := v.ValidateDynamicRegistration(ctx, tc.in)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectStrategy, tc.in.AccessTokenStrategy)
+		})
+	}
+}

--- a/driver/config/provider.go
+++ b/driver/config/provider.go
@@ -52,6 +52,7 @@ const (
 	KeyOAuth2DeviceAuthorisationURL              = "webfinger.oidc_discovery.device_authorization_url"
 	KeySubjectTypesSupported                     = "oidc.subject_identifiers.supported_types"
 	KeyDefaultClientScope                        = "oidc.dynamic_client_registration.default_scope"
+	KeyDCRAccessTokenStrategy                    = "oidc.dynamic_client_registration.strategies.access_token" // #nosec G101
 	KeyDSN                                       = "dsn"
 	KeyClientHTTPNoPrivateIPRanges               = "clients.http.disallow_private_ip_ranges"
 	KeyClientHTTPPrivateIPExceptionURLs          = "clients.http.private_ip_exception_urls"
@@ -595,6 +596,24 @@ func (p *DefaultProvider) AccessTokenStrategy(ctx context.Context, additionalSou
 		return AccessTokenDefaultStrategy
 	}
 
+	return s
+}
+
+// OIDCDynamicClientRegistrationAccessTokenStrategy returns the access token
+// strategy that should be applied to clients created via OpenID Connect
+// Dynamic Client Registration (RFC 7591). An empty string means the option
+// is not configured and DCR clients should fall back to the global
+// `strategies.access_token` setting.
+func (p *DefaultProvider) OIDCDynamicClientRegistrationAccessTokenStrategy(ctx context.Context) AccessTokenStrategyType {
+	raw := p.getProvider(ctx).String(KeyDCRAccessTokenStrategy)
+	if raw == "" {
+		return ""
+	}
+	s, err := ToAccessTokenStrategyType(raw)
+	if err != nil {
+		p.l.WithError(err).Warnf("Key `%s` contains an invalid value, falling back to the global access token strategy.", KeyDCRAccessTokenStrategy)
+		return ""
+	}
 	return s
 }
 

--- a/spec/config.json
+++ b/spec/config.json
@@ -462,6 +462,18 @@
                 "type": "string"
               },
               "examples": [["openid", "offline", "offline_access"]]
+            },
+            "strategies": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Optional strategy overrides for clients created via OpenID Connect Dynamic Client Registration. When unset, dynamically registered clients inherit the global strategies (e.g. `strategies.access_token`).",
+              "properties": {
+                "access_token": {
+                  "type": "string",
+                  "enum": ["opaque", "jwt"],
+                  "description": "Access token strategy used for clients created via Dynamic Client Registration. When unset, the global `strategies.access_token` is used. Clients cannot override this value via the registration payload."
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Adds an optional configuration path `oidc.dynamic_client_registration.strategies.access_token` (`jwt` or `opaque`) that, when set, overrides the global `strategies.access_token` for clients created through OpenID Connect Dynamic Client Registration (RFC 7591). When unset, behaviour is unchanged.

Closes #4060

## Behaviour

| DCR `strategies.access_token` | Global `strategies.access_token` | DCR client token strategy |
|-------------------------------|----------------------------------|---------------------------|
| not set                       | `opaque`                         | `opaque` (global default) |
| not set                       | `jwt`                            | `jwt` (global default)    |
| `opaque`                      | `jwt`                            | `opaque` (DCR override)   |
| `jwt`                         | `opaque`                         | `jwt` (DCR override)      |

Clients cannot set `access_token_strategy` themselves in the DCR payload — the existing 400 rejection is preserved. The Admin API is unaffected.

## Changes

- `spec/config.json` and `.schema/config.schema.json` — schema for the new optional key.
- `driver/config/provider.go` — `KeyDCRAccessTokenStrategy` constant and `OIDCDynamicClientRegistrationAccessTokenStrategy(ctx)` getter (returns empty when unset; defensively logs and falls back to empty for invalid values).
- `client/validator.go` — `ValidateDynamicRegistration` applies the configured override after the existing client-supplied rejection check; mirrors the existing `DefaultClientScope` server-side default pattern.
- `client/validator_test.go` — 5-case behaviour matrix (the 4 rows above plus the "client-supplied strategy still rejected even when override is active" guard).

## Backwards compatibility

- No DB migration; reuses existing `client.access_token_strategy` column.
- Configurations without the new key behave exactly as before.
- Admin API behaviour unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./client/... ./driver/config/...`
- [x] `go test ./client/... ./driver/config/...`
- [x] `go test -run TestValidateDynamicRegistrationAccessTokenStrategy -v ./client/...` — all 5 cases pass
- [ ] CI green on PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new configuration option to control the access token strategy for OIDC dynamically registered clients. Administrators can now specify opaque or JWT tokens. When unset, dynamically registered clients inherit the global strategy setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/hydra/pull/4105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->