### PR TITLE
fix: return access_denied to device token poll when consent is denied

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -636,7 +636,13 @@ func (s *defaultStrategy) verifyConsent(ctx context.Context, _ http.ResponseWrit
 
 	if f.ConsentError.IsError() {
 		f.ConsentError.SetDefaults(flow.ConsentRequestDeniedErrorName)
-		return nil, errors.WithStack(f.ConsentError.ToRFCError())
+		// Return the flow alongside the error so device-flow callers can read
+		// DeviceCodeRequestID and mark the device-code session as rejected. This
+		// lets the polling client receive access_denied (RFC 8628 section 3.5)
+		// instead of waiting for the device code to expire. The authorization
+		// code flow caller (HandleOAuth2AuthorizationRequest) discards the flow
+		// on error, so returning it here is safe for that path.
+		return f, errors.WithStack(f.ConsentError.ToRFCError())
 	}
 
 	if err := s.r.ConsentManager().CreateConsentSession(ctx, f); errors.Is(err, sqlcon.ErrUniqueViolation()) {

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -765,6 +765,17 @@ func (h *Handler) performOAuth2DeviceVerificationFlow(w http.ResponseWriter, r *
 	if errors.Is(err, consent.ErrUserRedirected) {
 		return
 	} else if err != nil {
+		// If the user denied the consent request, mark the associated
+		// device-code session as rejected so the polling client receives
+		// access_denied (RFC 8628 section 3.5) on its next poll instead of
+		// continuing to receive authorization_pending until the device code
+		// expires. f is non-nil here only when consent was denied (see
+		// DefaultStrategy.verifyConsent); other errors return a nil flow.
+		if f != nil && f.DeviceCodeRequestID.String() != "" && f.ConsentError.IsError() {
+			if rejectErr := h.markDeviceUserCodeRejected(ctx, f.DeviceCodeRequestID.String()); rejectErr != nil {
+				x.LogError(r, rejectErr, h.r.Logger())
+			}
+		}
 		x.LogError(r, err, h.r.Logger())
 		h.r.Writer().WriteError(w, r, err)
 		return
@@ -813,6 +824,24 @@ func (h *Handler) performOAuth2DeviceVerificationFlow(w http.ResponseWriter, r *
 
 	redirectURL := urlx.SetQuery(h.c.DeviceDoneURL(ctx), url.Values{"client_id": {f.Client.GetID()}}).String()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// markDeviceUserCodeRejected transitions the device-code session identified by
+// deviceCodeRequestID into the UserCodeRejected state. It is called when the
+// user denies the device authorization request during the verification flow so
+// that the device's token poll returns access_denied (RFC 8628 section 3.5)
+// rather than continuing to return authorization_pending until the device code
+// expires. This mirrors the UserCodeAccepted transition performed on the
+// accept path above.
+func (h *Handler) markDeviceUserCodeRejected(ctx context.Context, deviceCodeRequestID string) error {
+	req, signature, err := h.r.OAuth2Storage().GetDeviceCodeSessionByRequestID(ctx, deviceCodeRequestID, &Session{})
+	if err != nil {
+		return err
+	}
+
+	req.SetUserCodeState(fosite.UserCodeRejected)
+
+	return h.r.OAuth2Storage().UpdateDeviceCodeSessionBySignature(ctx, signature, req)
 }
 
 // OAuth2 Device Flow

--- a/oauth2/oauth2_device_code_test.go
+++ b/oauth2/oauth2_device_code_test.go
@@ -5,7 +5,9 @@ package oauth2_test
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -451,6 +453,56 @@ func TestDeviceCodeWithDefaultStrategy(t *testing.T) {
 		assert.Empty(t, token.Extra("id_token"))
 		assert.Empty(t, token.RefreshToken)
 	})
+	t.Run("case=polling client receives access_denied when consent is denied", func(t *testing.T) {
+		c, conf := newDeviceClient(t, reg)
+		conf.Scopes = []string{"hydra"}
+
+		rejectConsentHandler := func(w http.ResponseWriter, r *http.Request) {
+			vr, _, err := adminClient.OAuth2API.RejectOAuth2ConsentRequest(context.Background()).
+				ConsentChallenge(r.URL.Query().Get("consent_challenge")).
+				RejectOAuth2Request(hydra.RejectOAuth2Request{
+					Error:            new(fosite.ErrAccessDenied.ErrorField),
+					ErrorDescription: new("user denied the device authorization request"),
+					StatusCode:       new(int64(fosite.ErrAccessDenied.CodeField)),
+				}).
+				Execute()
+			require.NoError(t, err)
+			require.NotEmpty(t, vr.RedirectTo)
+			http.Redirect(w, r, vr.RedirectTo, http.StatusFound)
+		}
+
+		testhelpers.NewDeviceLoginConsentUI(t, reg.Config(),
+			acceptDeviceHandler(t, c),
+			acceptLoginHandler(t, c, subject, conf.Scopes, nil),
+			rejectConsentHandler,
+		)
+
+		resp, err := getDeviceCode(t, conf, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.DeviceCode)
+		require.NotEmpty(t, resp.UserCode)
+
+		// Drive the browser through device accept -> login -> consent denial.
+		// The user agent ends at an error page rather than the device-done URL.
+		hc := testhelpers.NewEmptyJarClient(t)
+		browserResp, err := hc.Get(resp.VerificationURIComplete)
+		require.NoError(t, err)
+		require.NoError(t, browserResp.Body.Close())
+
+		// The polling client must now receive access_denied on its next poll,
+		// instead of continuing to receive authorization_pending until the
+		// device code expires.
+		tokenResp := pollDeviceToken(t, conf, resp.DeviceCode)
+		body, err := io.ReadAll(tokenResp.Body)
+		require.NoError(t, err)
+		require.NoError(t, tokenResp.Body.Close())
+
+		// The key assertion: the polling client receives the access_denied error
+		// code (RFC 8628 section 3.5) rather than authorization_pending. fosite
+		// serialises ErrAccessDenied with HTTP 403.
+		assert.Equal(t, http.StatusForbidden, tokenResp.StatusCode, "body: %s", body)
+		assert.Equal(t, "access_denied", gjson.GetBytes(body, "error").String(), "body: %s", body)
+	})
 	t.Run("case=perform device flow with ID token", func(t *testing.T) {
 		c, conf := newDeviceClient(t, reg)
 		conf.Scopes = []string{"openid", "hydra"}
@@ -872,4 +924,24 @@ func newDeviceClient(
 		},
 		Scopes: strings.Split(c.Scope, " "),
 	}
+}
+
+// pollDeviceToken performs a single device-code token poll (RFC 8628 section 3.4)
+// against the token endpoint and returns the raw response. It deliberately does
+// not loop on authorization_pending, so callers can assert on the exact response
+// to a single poll (e.g. access_denied after the user denied consent) without
+// risking a hang until the device code expires.
+func pollDeviceToken(t *testing.T, conf *oauth2.Config, deviceCode string) *http.Response {
+	form := url.Values{}
+	form.Set("grant_type", string(fosite.GrantTypeDeviceCode))
+	form.Set("device_code", deviceCode)
+	form.Set("client_id", conf.ClientID)
+
+	req, err := http.NewRequest(http.MethodPost, conf.Endpoint.TokenURL, strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
 }


### PR DESCRIPTION
## Related issue(s)

Closes #4110

## Summary

When a user **denies** the consent prompt during the OAuth 2.0 Device Authorization Grant (RFC 8628) flow, the device-code token poll keeps returning `authorization_pending` until the `device_code` expires, instead of returning `access_denied`. The polling client (e.g. a CLI) therefore appears to hang for the full device-code lifetime even though the user already denied the request in the browser.

## Root cause

fosite already returns `access_denied` when the device session is in the `UserCodeRejected` state (`handler/rfc8628/token_handler.go`):

```go
if state == fosite.UserCodeRejected {
    return nil, fosite.ErrAccessDenied
}
```

But Hydra never transitions a device session into `UserCodeRejected`. The only writer of the state is the accept path (`req.SetUserCodeState(fosite.UserCodeAccepted)`). On consent denial, `DefaultStrategy.verifyConsent` returns the `access_denied` RFC error and discards the flow, and `performOAuth2DeviceVerificationFlow` writes that error to the browser and returns **before** reaching any `SetUserCodeState` call. The device session is left at `UserCodeUnused`, so the poll keeps returning `authorization_pending`.

## Change

- `consent/strategy_default.go`: `verifyConsent` now returns the flow alongside the error on the consent-denied path. The authorization code caller (`HandleOAuth2AuthorizationRequest`) discards the flow on error, so this is safe; the device caller uses it to identify the device-code session.
- `oauth2/handler.go`: when `performOAuth2DeviceVerificationFlow` sees a denied device flow, it marks the associated device-code session as `UserCodeRejected` (via a new `markDeviceUserCodeRejected` helper that mirrors the existing accept-path transition). The polling client then receives `access_denied` on its next poll.

The change is gated on `f != nil && f.DeviceCodeRequestID != "" && f.ConsentError.IsError()`, so it only affects the device flow on an actual consent denial; the authorization code flow is unchanged.

## Test

Added an end-to-end regression test in `oauth2/oauth2_device_code_test.go` (`case=polling client receives access_denied when consent is denied`): it runs the full device flow, denies consent, and asserts the token poll returns `access_denied`. Verified that the test fails without the fix (the poll returns `authorization_pending`) and passes with it. The existing device-flow and consent suites continue to pass.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ory/hydra/blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security vulnerability, I confirm that I got the approval (please contact security@ory.sh) from the maintainers to push the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device code flow error handling: when a user denies consent, polling clients now receive an immediate `access_denied` response instead of waiting for the request to expire.

* **Tests**
  * Added test coverage for device flow consent rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->