### PR TITLE
fix(consent): use GetLoginSession in logout handlers to handle remember=false sessions

### DIFF
--- a/consent/manager.go
+++ b/consent/manager.go
@@ -52,6 +52,7 @@ type (
 	}
 	LoginManager interface {
 		GetRememberedLoginSession(ctx context.Context, id string) (*flow.LoginSession, error)
+		GetLoginSession(ctx context.Context, id string) (*flow.LoginSession, error)
 		DeleteLoginSession(ctx context.Context, id string) (deletedSession *flow.LoginSession, err error)
 		RevokeSubjectLoginSession(ctx context.Context, subject string) error
 		ConfirmLoginSession(ctx context.Context, loginSession *flow.LoginSession) error

--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -939,7 +939,7 @@ func (s *defaultStrategy) issueLogoutVerifier(ctx context.Context, w http.Respon
 
 	// We do not really want to verify if the user (from id token hint) has a session here because it doesn't really matter.
 	// Instead, we'll check this when we're actually revoking the cookie!
-	session, err := s.r.LoginManager().GetRememberedLoginSession(ctx, hintSid)
+	session, err := s.r.LoginManager().GetLoginSession(ctx, hintSid)
 	if errors.Is(err, x.ErrNotFound) {
 		// Such a session does not exist - maybe it has already been revoked? In any case, we can't do much except
 		// leaning back and redirecting back.
@@ -1096,7 +1096,7 @@ func (s *defaultStrategy) HandleOpenIDConnectLogout(ctx context.Context, w http.
 }
 
 func (s *defaultStrategy) HandleHeadlessLogout(ctx context.Context, _ http.ResponseWriter, r *http.Request, sid string) error {
-	loginSession, lsErr := s.r.LoginManager().GetRememberedLoginSession(ctx, sid)
+	loginSession, lsErr := s.r.LoginManager().GetLoginSession(ctx, sid)
 
 	if errors.Is(lsErr, x.ErrNotFound) {
 		// This is ok (session probably already revoked), do nothing!

--- a/persistence/sql/persister_consent.go
+++ b/persistence/sql/persister_consent.go
@@ -240,6 +240,20 @@ func (p *Persister) GetRememberedLoginSession(ctx context.Context, id string) (_
 	return &s, nil
 }
 
+func (p *Persister) GetLoginSession(ctx context.Context, id string) (_ *flow.LoginSession, err error) {
+	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.GetLoginSession")
+	defer otelx.End(span, &err)
+
+	var s flow.LoginSession
+	if err := p.QueryWithNetwork(ctx).Find(&s, id); errors.Is(err, sql.ErrNoRows) {
+		return nil, errors.WithStack(x.ErrNotFound)
+	} else if err != nil {
+		return nil, sqlcon.HandleError(err)
+	}
+
+	return &s, nil
+}
+
 // ConfirmLoginSession creates or updates the login session. The NID will be set to the network ID of the context.
 func (p *Persister) ConfirmLoginSession(ctx context.Context, loginSession *flow.LoginSession) (err error) {
 	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.ConfirmLoginSession")


### PR DESCRIPTION
Fixes #3132

## Problem

When a user logs in with `remember: false`, the login session **is** persisted in `hydra_oauth2_authentication_session` (with `remember = FALSE`), but the logout handler uses `GetRememberedLoginSession` which has a `WHERE remember = TRUE` filter. This causes two issues:

1. **RP-initiated logout with `id_token_hint`**: `issueLogoutVerifier` at line 942 calls `GetRememberedLoginSession(hintSid)`, gets `ErrNotFound`, and silently redirects to `post_logout_redirect_uri` without any front-/back-channel logout — even though the ID token hint contains a valid `sid` that identifies the session.

2. **Admin headless logout**: `HandleHeadlessLogout` at line 1099 calls `GetRememberedLoginSession(sid)`, gets `ErrNotFound`, and returns a silent 204 no-op — even though the session row exists.

## Solution

Add a new `GetLoginSession` method to the `LoginManager` interface and its SQL persistence implementation — identical to `GetRememberedLoginSession` but without the `WHERE remember = TRUE` filter. Use it at the two logout call sites above.

The filtered variant (`GetRememberedLoginSession`) is kept for the cookie-based SSO lookup at line 103, where `remember=false` sessions should indeed not enable SSO skip.

## Changes

1. **`consent/manager.go`**: Add `GetLoginSession(ctx, id)` to the `LoginManager` interface
2. **`persistence/sql/persister_consent.go`**: Implement `GetLoginSession` (same as `GetRememberedLoginSession` minus the `WHERE remember = TRUE` filter)
3. **`consent/strategy_default.go`**: 
   - `issueLogoutVerifier` (line 942): use `GetLoginSession` instead of `GetRememberedLoginSession`
   - `HandleHeadlessLogout` (line 1099): use `GetLoginSession` instead of `GetRememberedLoginSession`
   - Line 103 (cookie SSO): unchanged, still uses `GetRememberedLoginSession`

## Root cause analysis credit

Detailed analysis by @fkammer in the issue comments confirmed the fix is minimal — no schema changes, no API changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RP-initiated and headless logout now work for sessions that were not remembered.
  * Login sessions can be retrieved reliably by session ID, including appropriate handling when a session is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->