### PR TITLE
fix(oauth2): use UTC timestamp and FOR UPDATE SKIP LOCKED in JTI blacklist cleanup (#4113)

### DIFF
--- a/persistence/sql/persister_oauth2.go
+++ b/persistence/sql/persister_oauth2.go
@@ -461,8 +461,27 @@ func (p *Persister) SetClientAssertionJWT(ctx context.Context, jti string, exp t
 	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.SetClientAssertionJWT")
 	defer otelx.End(span, &err)
 
-	// delete expired; this cleanup spares us the need for a background worker
-	if err := p.QueryWithNetwork(ctx).Where("expires_at < CURRENT_TIMESTAMP").Delete(&oauth2.BlacklistedJTI{}); err != nil {
+	// delete expired; this cleanup spares us the need for a background worker.
+	// Use a bound UTC timestamp (CURRENT_TIMESTAMP is the DB-server-local time and
+	// would prune the replay blacklist against the wrong clock on non-UTC hosts,
+	// see #3740) and bound the delete with LIMIT + FOR UPDATE SKIP LOCKED so
+	// concurrent requests don't all contend for locks on the same expired rows
+	// (see #4113).
+	if err := p.Connection(ctx).RawQuery(
+		`DELETE FROM hydra_oauth2_jti_blacklist
+		 WHERE nid = ? AND expires_at < ?
+		   AND signature IN (
+		       SELECT signature FROM (
+		           SELECT signature FROM hydra_oauth2_jti_blacklist
+		           WHERE nid = ? AND expires_at < ?
+		           LIMIT 100 FOR UPDATE SKIP LOCKED
+		       ) AS sub
+		   )`,
+		p.NetworkID(ctx),
+		time.Now().UTC(),
+		p.NetworkID(ctx),
+		time.Now().UTC(),
+	).Exec(); err != nil {
 		return sqlcon.HandleError(err)
 	}
 


### PR DESCRIPTION
## What

Fixes lock contention and a clock-skew bug in the JTI blacklist cleanup path.

## Why

`SetClientAssertionJWT` runs an unbounded inline `DELETE WHERE expires_at < CURRENT_TIMESTAMP` on every `jwt-bearer` token request. Under concurrent load, many goroutines contend for row locks on the same expired rows, causing 100-400ms latency spikes on `/oauth2/token` (#4113). The same statement also causes InnoDB deadlocks on MySQL (#3740).

Two defects in the single statement:

1. **Lock contention / deadlock** — every request deletes all expired rows, and concurrent requests all target the same rows.
2. **Clock skew (security)** — `CURRENT_TIMESTAMP` is the *database server's* local time, while `expires_at` is written in UTC. On any non-UTC database the replay blacklist is pruned against the wrong clock, so JTIs can be deleted before they actually expire, widening the assertion-replay window.

## How

- Bind a UTC timestamp (`time.Now().UTC()`) instead of `CURRENT_TIMESTAMP`.
- Bound the delete with `LIMIT 100 ... FOR UPDATE SKIP LOCKED` so concurrent requests skip rows already locked by another transaction instead of blocking.

## Notes

The derived-table subquery follows the existing batch-delete pattern in this file for MySQL compatibility.

Closes #4113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of expired OAuth2 client assertion entries.
  * Cleanup now uses bounded processing to improve reliability and reduce database contention.
  * Cleanup errors continue to be handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->