### PR TITLE
fix(oauth2): mark device session as rejected when device flow consent is denied

### DIFF
--- a/consent/strategy_default.go
+++ b/consent/strategy_default.go
@@ -637,7 +637,10 @@ func (s *defaultStrategy) verifyConsent(ctx context.Context, _ http.ResponseWrit
 
 	if f.ConsentError.IsError() {
 		f.ConsentError.SetDefaults(flow.ConsentRequestDeniedErrorName)
-		return nil, errors.WithStack(f.ConsentError.ToRFCError())
+		// Return the flow alongside the error so device-flow callers can identify
+		// a denied consent and mark the device code session as rejected.
+		// The auth-code caller discards the flow on error, so this is safe.
+		return f, errors.WithStack(f.ConsentError.ToRFCError())
 	}
 
 	if err := s.r.ConsentManager().CreateConsentSession(ctx, f); errors.Is(err, sqlcon.ErrUniqueViolation()) {
@@ -1343,3 +1346,4 @@ func (s *defaultStrategy) verifyDevice(ctx context.Context, _ http.ResponseWrite
 func (s *defaultStrategy) getDeviceVerificationPath(ctx context.Context) *url.URL {
 	return urlx.AppendPaths(s.r.Config().PublicURL(ctx), deviceVerificationPath)
 }
+

--- a/oauth2/handler.go
+++ b/oauth2/handler.go
@@ -766,6 +766,23 @@ func (h *Handler) performOAuth2DeviceVerificationFlow(w http.ResponseWriter, r *
 		return
 	} else if err != nil {
 		x.LogError(r, err, h.r.Logger())
+
+		// If consent for a device authorization flow was denied, propagate the
+		// rejection to the device session so the polling token client receives
+		// access_denied (RFC 8628 §3.5) instead of authorization_pending until
+		// the device code expires. HandleOAuth2DeviceAuthorizationRequest returns
+		// the flow alongside the error when the denial came from verifyConsent.
+		if f != nil && f.DeviceCodeRequestID.Valid {
+			if rq, sig, err := h.r.OAuth2Storage().GetDeviceCodeSessionByRequestID(ctx, f.DeviceCodeRequestID.String(), &Session{}); err == nil {
+				rq.SetUserCodeState(fosite.UserCodeRejected)
+				if err := h.r.OAuth2Storage().UpdateDeviceCodeSessionBySignature(ctx, sig, rq); err != nil {
+					x.LogError(r, err, h.r.Logger())
+				}
+			} else {
+				x.LogError(r, err, h.r.Logger())
+			}
+		}
+
 		h.r.Writer().WriteError(w, r, err)
 		return
 	}
@@ -1628,3 +1645,4 @@ func (h *Handler) createVerifiableCredential(w http.ResponseWriter, r *http.Requ
 	response.Credential = rawToken
 	h.r.Writer().Write(w, r, &response)
 }
+


### PR DESCRIPTION
## Summary

Fixes #4110 — when a user denies the consent prompt during the OAuth 2.0 Device Authorization Grant (RFC 8628) flow, the device-code token poll keeps returning `authorization_pending` until the `device_code` expires. The expected `access_denied` is never returned, so the polling client (e.g. a CLI) appears to hang for the full `device_code` lifetime instead of failing fast.

## Root Cause

`fosite/handler/rfc8628/token_handler.go` already handles the `UserCodeRejected` state and returns `access_denied`:

```go
if state == fosite.UserCodeRejected {
    return nil, fosite.ErrAccessDenied
}
```

However, **nothing in Hydra ever transitions a device session into `UserCodeRejected`.** The only writer of the state is the accept path in `oauth2/handler.go` (`performOAuth2DeviceVerificationFlow`):

```go
req.SetUserCodeState(fosite.UserCodeAccepted)
```

On the deny path, `consent/strategy_default.go::verifyConsent` detects the denied consent, returns the RFC error, and the flow is discarded — the device session is left at `UserCodeUnused`, so the token poll keeps returning `authorization_pending`.

## Changes

### 1. `consent/strategy_default.go` — `verifyConsent`

When `f.ConsentError.IsError()` (the consent was denied), return the flow alongside the error so that callers can identify the device code session and propagate the rejection. The auth-code caller (`HandleOAuth2AuthorizationRequest`) discards the flow on error, so this is safe.

### 2. `oauth2/handler.go` — `performOAuth2DeviceVerificationFlow`

On the error path, check if the flow is a device authorization flow (`f.DeviceCodeRequestID.Valid`). If so, transition the device code session to `UserCodeRejected` — mirroring the existing `UserCodeAccepted` transition on the accept path.

This ensures that the polling token client receives `access_denied` (RFC 8628 §3.5) on its next poll instead of hanging until the device code expires.

## Testing

- Existing tests for the device code grant should continue to pass (the change only affects the consent-denial path)
- Manual verification: deny consent → polling token endpoint returns `access_denied` instead of `authorization_pending`

## Related

- RFC 8628 §3.5: Device Access Token Response
- PR #3851: Original device authorization grant implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of denied consent during device authorization flows.
  * Applications polling a rejected device code now receive the expected `access_denied` response instead of continuing to wait.
  * Consent errors are preserved and returned consistently, providing clearer feedback when authorization is declined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->